### PR TITLE
merge: (#139) Refresh Token 만료시간 추가

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/dto/ReissueResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/dto/ReissueResponse.kt
@@ -4,8 +4,9 @@ import java.time.LocalDateTime
 
 data class ReissueResponse(
     val accessToken: String,
-    val expiredAt: LocalDateTime,
+    val accessTokenExpiredAt: LocalDateTime,
     val refreshToken: String,
+    val refreshTokenExpiredAt: LocalDateTime,
     val features: Features
 ) {
     data class Features(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/dto/SignInResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/dto/SignInResponse.kt
@@ -4,8 +4,9 @@ import java.time.LocalDateTime
 
 data class SignInResponse(
     val accessToken: String,
-    val expiredAt: LocalDateTime,
+    val accessTokenExpiredAt: LocalDateTime,
     val refreshToken: String,
+    val refreshTokenExpiredAt: LocalDateTime,
     val features: Features
 ) {
     data class Features(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/dto/TokenResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/dto/TokenResponse.kt
@@ -4,6 +4,7 @@ import java.time.LocalDateTime
 
 data class TokenResponse(
     val accessToken: String,
-    val expiredAt: LocalDateTime,
-    val refreshToken: String
+    val accessTokenExpiredAt: LocalDateTime,
+    val refreshToken: String,
+    val refreshTokenExpiredAt: LocalDateTime,
 )

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCase.kt
@@ -15,12 +15,13 @@ class ReissueTokenUseCase(
     fun execute(token: String): ReissueResponse {
         val queryToken = queryRefreshTokenPort.queryRefreshTokenByToken(token) ?: throw RefreshTokenNotFoundException
 
-        val (accessToken, expiredAt, refreshToken) = jwtPort.receiveToken(queryToken.userId, queryToken.authority)
+        val (accessToken, accessTokenExpiredAt, refreshToken, refreshTokenExpiredAt) = jwtPort.receiveToken(queryToken.userId, queryToken.authority)
 
         return ReissueResponse(
             accessToken = accessToken,
-            expiredAt = expiredAt,
+            accessTokenExpiredAt = accessTokenExpiredAt,
             refreshToken = refreshToken,
+            refreshTokenExpiredAt = refreshTokenExpiredAt,
             features = ReissueResponse.Features(
                 // TODO 서비스 관리 테이블 필요
                 mealService = true,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCase.kt
@@ -23,12 +23,13 @@ class SignInUseCase(
             throw PasswordMismatchException
         }
 
-        val (accessToken, expiredAt, refreshToken) = jwtPort.receiveToken(user.id, user.authority)
+        val (accessToken, accessTokenExpiredAt, refreshToken, refreshTokenExpiredAt) = jwtPort.receiveToken(user.id, user.authority)
 
         return SignInResponse(
             accessToken = accessToken,
-            expiredAt = expiredAt,
+            accessTokenExpiredAt = accessTokenExpiredAt,
             refreshToken = refreshToken,
+            refreshTokenExpiredAt = refreshTokenExpiredAt,
             features = SignInResponse.Features(
                 // TODO 서비스 관리 테이블 필요
                 mealService = true,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/dto/SignUpResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/dto/SignUpResponse.kt
@@ -4,8 +4,9 @@ import java.time.LocalDateTime
 
 data class SignUpResponse(
     val accessToken: String,
-    val expiredAt: LocalDateTime,
+    val accessTokenExpiredAt: LocalDateTime,
     val refreshToken: String,
+    val refreshTokenExpiredAt: LocalDateTime,
     val features: Features
 ) {
     data class Features(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCase.kt
@@ -103,12 +103,13 @@ class SignUpUseCase(
         )
         commandStudentPort.saveStudent(student)
 
-        val (accessToken, expiredAt, refreshToken) = jwtPort.receiveToken(user.id, Authority.STUDENT)
+        val (accessToken, accessTokenExpiredAt, refreshToken, refreshTokenExpiredAt) = jwtPort.receiveToken(user.id, Authority.STUDENT)
 
         return SignUpResponse(
             accessToken = accessToken,
-            expiredAt = expiredAt,
+            accessTokenExpiredAt = accessTokenExpiredAt,
             refreshToken = refreshToken,
+            refreshTokenExpiredAt = refreshTokenExpiredAt,
             features = SignUpResponse.Features(
                 // TODO 서비스 관리 테이블 필요
                 mealService = true,

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCaseTests.kt
@@ -50,8 +50,9 @@ class ReissueTokenUseCaseTests {
     private val tokenResponseStub by lazy {
         TokenResponse(
             accessToken = "Bearer dalkmas",
-            expiredAt = LocalDateTime.now(),
-            refreshToken = "Bearer akldsgmaslkdgmadk"
+            accessTokenExpiredAt = LocalDateTime.now(),
+            refreshToken = "Bearer akldsgmaslkdgmadk",
+            refreshTokenExpiredAt = LocalDateTime.now()
         )
     }
 

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCaseTests.kt
@@ -17,7 +17,6 @@ import team.aliens.dms.domain.auth.spi.AuthSecurityPort
 import team.aliens.dms.domain.auth.spi.JwtPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import team.aliens.dms.domain.user.model.User
-import team.aliens.dms.domain.user.service.CheckUserAuthority
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -67,8 +66,9 @@ class SignInUseCaseTests {
 
     private val tokenResponse = TokenResponse(
         accessToken = "Bearer dga",
-        expiredAt = LocalDateTime.now(),
-        refreshToken = "Bearer sdalkgmsalkgmsa"
+        accessTokenExpiredAt = LocalDateTime.now(),
+        refreshToken = "Bearer sdalkgmsalkgmsa",
+        refreshTokenExpiredAt = LocalDateTime.now()
     )
 
     @Test

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
@@ -174,16 +174,18 @@ class SignUpUseCaseTests {
     private val tokenResponseStub by lazy {
         TokenResponse(
             accessToken = "test access token",
-            expiredAt = LocalDateTime.now(),
-            refreshToken = "test refresh token"
+            accessTokenExpiredAt = LocalDateTime.now(),
+            refreshToken = "test refresh token",
+            refreshTokenExpiredAt = LocalDateTime.now()
         )
     }
 
     private val signUpResponseStub by lazy {
         SignUpResponse(
             accessToken = tokenResponseStub.accessToken,
-            expiredAt = tokenResponseStub.expiredAt,
+            accessTokenExpiredAt = tokenResponseStub.accessTokenExpiredAt,
             refreshToken = tokenResponseStub.refreshToken,
+            refreshTokenExpiredAt = tokenResponseStub.refreshTokenExpiredAt,
             features = SignUpResponse.Features(
                 mealService = true,
                 noticeService = true,

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityProperties.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityProperties.kt
@@ -8,10 +8,8 @@ import java.util.Base64
 @ConstructorBinding
 class SecurityProperties(
     secretKey: String,
-    accessExp: Int,
-    refreshExp: Int
+    val accessExp: Int,
+    val refreshExp: Int
 ) {
     val secretKey: String = Base64.getEncoder().encodeToString(secretKey.toByteArray())
-    val accessExp: Int = accessExp * 1000
-    val refreshExp: Int = refreshExp * 1000
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
@@ -22,9 +22,9 @@ class GenerateJwtAdapter(
 
     override fun receiveToken(userId: UUID, authority: Authority) = TokenResponse(
         accessToken = generateAccessToken(userId, authority),
-        accessTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.accessExp.toLong() / 1000),
+        accessTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.accessExp.toLong()),
         refreshToken = generateRefreshToken(userId, authority),
-        refreshTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.refreshExp.toLong() / 1000)
+        refreshTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.refreshExp.toLong())
     )
 
     private fun generateAccessToken(userId: UUID, authority: Authority) =

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
@@ -34,7 +34,7 @@ class GenerateJwtAdapter(
             .setId(userId.toString())
             .claim(JwtProperties.AUTHORITY, authority.name)
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis() + securityProperties.accessExp))
+            .setExpiration(Date(System.currentTimeMillis() + securityProperties.accessExp * 1000))
             .compact()
 
     private fun generateRefreshToken(userId: UUID, authority: Authority): String {
@@ -42,7 +42,7 @@ class GenerateJwtAdapter(
             .signWith(SignatureAlgorithm.HS512, securityProperties.secretKey)
             .setHeaderParam(Header.JWT_TYPE, JwtProperties.REFRESH)
             .setIssuedAt(Date())
-            .setExpiration(Date(System.currentTimeMillis() + securityProperties.refreshExp))
+            .setExpiration(Date(System.currentTimeMillis() + securityProperties.refreshExp * 1000))
             .compact()
 
         val refreshToken = RefreshTokenEntity(

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
@@ -22,8 +22,9 @@ class GenerateJwtAdapter(
 
     override fun receiveToken(userId: UUID, authority: Authority) = TokenResponse(
         accessToken = generateAccessToken(userId, authority),
-        expiredAt = LocalDateTime.now().plusSeconds(securityProperties.accessExp.toLong()),
-        refreshToken = generateRefreshToken(userId, authority)
+        accessTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.accessExp.toLong() / 1000),
+        refreshToken = generateRefreshToken(userId, authority),
+        refreshTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.refreshExp.toLong() / 1000)
     )
 
     private fun generateAccessToken(userId: UUID, authority: Authority) =


### PR DESCRIPTION
## 작업 내용 설명
- [x] Token Expired millisecond 제외
- [x] 모든 Token Response 사용하는 Usecase  & Test 변경
- [x] Token Exp / 1000

## 주요 변경 사항
- GenerateJwtAdapter
- ReissueResponse 
- SignInResponse
- 모든 Token Response 사용하는 Usecase  & Test

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #139 