### PR TITLE
merge: (#141) 급식 조회 API 변경

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/common/extension/LocalDateExtension.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/common/extension/LocalDateExtension.kt
@@ -6,7 +6,8 @@ operator fun ClosedRange<LocalDate>.iterator(): Iterator<LocalDate> {
     return object : Iterator<LocalDate> {
         private var next = this@iterator.start
         private val finalElement = this@iterator.endInclusive
-        private var hasNext = !next.isAfter(this@iterator.endInclusive)
+        private var hasNext = !next.isAfter(finalElement)
+
         override fun hasNext(): Boolean = hasNext
         override fun next(): LocalDate {
             val value = next

--- a/dms-application/src/main/kotlin/team/aliens/dms/common/extension/LocalDateExtension.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/common/extension/LocalDateExtension.kt
@@ -1,0 +1,21 @@
+package team.aliens.dms.common
+
+import java.time.LocalDate
+
+operator fun ClosedRange<LocalDate>.iterator(): Iterator<LocalDate> {
+    return object : Iterator<LocalDate> {
+        private var next = this@iterator.start
+        private val finalElement = this@iterator.endInclusive
+        private var hasNext = !next.isAfter(this@iterator.endInclusive)
+        override fun hasNext(): Boolean = hasNext
+        override fun next(): LocalDate {
+            val value = next
+            if (value == finalElement) {
+                hasNext = false
+            } else {
+                next = next.plusDays(1)
+            }
+            return value
+        }
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/common/extension/LocalDateExtension.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/common/extension/LocalDateExtension.kt
@@ -1,4 +1,4 @@
-package team.aliens.dms.common
+package team.aliens.dms.common.extension
 
 import java.time.LocalDate
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/dto/QueryMealsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/dto/QueryMealsResponse.kt
@@ -4,7 +4,7 @@ import team.aliens.dms.domain.meal.model.Meal
 import java.time.LocalDate
 
 data class QueryMealsResponse(
-    val meals: List<MealDetails?>
+    val meals: List<MealDetails>
 ) {
     data class MealDetails(
         val date: LocalDate,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/dto/QueryMealsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/dto/QueryMealsResponse.kt
@@ -1,14 +1,34 @@
 package team.aliens.dms.domain.meal.dto
 
+import team.aliens.dms.domain.meal.model.Meal
 import java.time.LocalDate
 
 data class QueryMealsResponse(
-    val meals: List<MealDetails>
+    val meals: List<MealDetails?>
 ) {
     data class MealDetails(
         val date: LocalDate,
         val breakfast: List<String?>,
         val lunch: List<String?>,
         val dinner: List<String?>
-    )
+    ) {
+        companion object {
+            private const val emptyMeal = "급식이 없습니다."
+            fun emptyOf(date: LocalDate) = MealDetails(
+                date = date,
+                breakfast = listOf(emptyMeal),
+                lunch = listOf(emptyMeal),
+                dinner = listOf(emptyMeal)
+            )
+
+            fun of(meal: Meal) = meal.run {
+                MealDetails(
+                    date = mealDate,
+                    breakfast = toSplit(breakfast),
+                    lunch = toSplit(lunch),
+                    dinner = toSplit(dinner)
+                )
+            }
+        }
+    }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/spi/QueryMealPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/spi/QueryMealPort.kt
@@ -6,6 +6,6 @@ import java.util.UUID
 
 interface QueryMealPort {
 
-    fun queryAllMealsByMealDateAndSchoolId(mealDate: LocalDate, schoolId: UUID): List<Meal>
+    fun queryAllMealsByMonthAndSchoolId(firstDay: LocalDate, lastDay: LocalDate, schoolId: UUID): List<Meal>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/usecase/QueryMealsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/usecase/QueryMealsUseCase.kt
@@ -30,7 +30,7 @@ class QueryMealsUseCase(
             firstDay, lastDay, student.schoolId
         ).groupBy { it.mealDate }
 
-        val mealDetails = mutableListOf<MealDetails?>()
+        val mealDetails = mutableListOf<MealDetails>()
         for (date in firstDay..lastDay) {
             val meals = mealMap[date]
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/usecase/QueryMealsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/usecase/QueryMealsUseCase.kt
@@ -1,7 +1,7 @@
 package team.aliens.dms.domain.meal.usecase
 
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
-import team.aliens.dms.common.iterator
+import team.aliens.dms.common.extension.iterator
 import team.aliens.dms.domain.meal.dto.QueryMealsResponse
 import team.aliens.dms.domain.meal.dto.QueryMealsResponse.MealDetails
 import team.aliens.dms.domain.meal.spi.MealQueryStudentPort

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/usecase/QueryMealsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/meal/usecase/QueryMealsUseCase.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.meal.usecase
 
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.common.iterator
 import team.aliens.dms.domain.meal.dto.QueryMealsResponse
 import team.aliens.dms.domain.meal.dto.QueryMealsResponse.MealDetails
 import team.aliens.dms.domain.meal.spi.MealQueryStudentPort
@@ -8,6 +9,7 @@ import team.aliens.dms.domain.meal.spi.MealSecurityPort
 import team.aliens.dms.domain.meal.spi.QueryMealPort
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import java.time.LocalDate
+import java.time.YearMonth
 
 @ReadOnlyUseCase
 class QueryMealsUseCase(
@@ -19,15 +21,26 @@ class QueryMealsUseCase(
     fun execute(mealDate: LocalDate): QueryMealsResponse {
         val currentUserId = securityPort.getCurrentUserId()
         val student = queryStudentPort.queryStudentById(currentUserId) ?: throw StudentNotFoundException
-        val meals = queryMealPort.queryAllMealsByMealDateAndSchoolId(mealDate, student.schoolId)
 
-        val mealDetails = meals.map {
-            MealDetails(
-                date = it.mealDate,
-                breakfast = it.toSplit(it.breakfast),
-                lunch = it.toSplit(it.lunch),
-                dinner = it.toSplit(it.dinner)
-            )
+        val month = YearMonth.from(mealDate)
+        val firstDay = month.atDay(1)
+        val lastDay = month.atEndOfMonth()
+
+        val mealMap = queryMealPort.queryAllMealsByMonthAndSchoolId(
+            firstDay, lastDay, student.schoolId
+        ).groupBy { it.mealDate }
+
+        val mealDetails = mutableListOf<MealDetails?>()
+        for (date in firstDay..lastDay) {
+            val meals = mealMap[date]
+
+            if (meals == null) {
+                mealDetails.add(MealDetails.emptyOf(date))
+            } else {
+                meals[0].apply {
+                    mealDetails.add(MealDetails.of(this))
+                }
+            }
         }
 
         return QueryMealsResponse(mealDetails)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/meal/MealPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/meal/MealPersistenceAdapter.kt
@@ -6,7 +6,6 @@ import team.aliens.dms.domain.meal.spi.MealPort
 import team.aliens.dms.persistence.meal.mapper.MealMapper
 import team.aliens.dms.persistence.meal.repository.MealJpaRepository
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 @Component
@@ -15,12 +14,11 @@ class MealPersistenceAdapter(
     private val mealRepository: MealJpaRepository
 ) : MealPort {
 
-    override fun queryAllMealsByMealDateAndSchoolId(mealDate: LocalDate, schoolId: UUID): List<Meal> {
-        val month = YearMonth.from(mealDate)
-
-        val firstDay = month.atDay(1)
-        val lastDay = month.atEndOfMonth()
-
+    override fun queryAllMealsByMonthAndSchoolId(
+        firstDay: LocalDate,
+        lastDay: LocalDate,
+        schoolId: UUID
+    ): List<Meal> {
         return mealRepository.findBySchoolIdAndIdMealDateBetween(schoolId, firstDay, lastDay).map {
             mealMapper.toDomain(it)!!
         }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/meal/MealPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/meal/MealPersistenceAdapter.kt
@@ -3,10 +3,10 @@ package team.aliens.dms.persistence.meal
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.meal.model.Meal
 import team.aliens.dms.domain.meal.spi.MealPort
-import team.aliens.dms.persistence.meal.entity.MealJpaEntityId
 import team.aliens.dms.persistence.meal.mapper.MealMapper
 import team.aliens.dms.persistence.meal.repository.MealJpaRepository
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.UUID
 
 @Component
@@ -16,9 +16,12 @@ class MealPersistenceAdapter(
 ) : MealPort {
 
     override fun queryAllMealsByMealDateAndSchoolId(mealDate: LocalDate, schoolId: UUID): List<Meal> {
-        val mealId = MealJpaEntityId(mealDate, schoolId)
+        val month = YearMonth.from(mealDate)
 
-        return mealRepository.findAllById(mealId).map {
+        val firstDay = month.atDay(1)
+        val lastDay = month.atEndOfMonth()
+
+        return mealRepository.findBySchoolIdAndIdMealDateBetween(schoolId, firstDay, lastDay).map {
             mealMapper.toDomain(it)!!
         }
     }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/meal/repository/MealJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/meal/repository/MealJpaRepository.kt
@@ -4,10 +4,12 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import team.aliens.dms.persistence.meal.entity.MealJpaEntity
 import team.aliens.dms.persistence.meal.entity.MealJpaEntityId
+import java.time.LocalDate
+import java.util.UUID
 
 @Repository
 interface MealJpaRepository : CrudRepository<MealJpaEntity, MealJpaEntityId> {
 
-    fun findAllById(id: MealJpaEntityId): List<MealJpaEntity>
+    fun findBySchoolIdAndIdMealDateBetween(schoolId: UUID, startAt: LocalDate, endAt: LocalDate): List<MealJpaEntity>
 
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] LocalDateExtension
- [x] 해당 달의 시작 날짜와 마지막 날짜를 기준으로 해당하는 모든 급식 조회

## 주요 변경 사항
- 해당 날짜의 급식이 존재하지 않는 경우 아침, 점심, 저녁에 각각 "급식이 없습니다." 문구 출력
- QueryMealsResponse에 팩터리 메서드 패턴 적용

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #141 