### PR TITLE
merge: 커스텀 타입의 @NotNull 필드 nullable 필드로 변경

### DIFF
--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/auth/dto/request/CertifyEmailCodeWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/auth/dto/request/CertifyEmailCodeWebRequest.kt
@@ -18,6 +18,6 @@ data class CertifyEmailCodeWebRequest(
     val authCode: String,
 
     @field:NotNull
-    val type: EmailType
+    val type: EmailType?
 
 )

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
@@ -71,7 +71,7 @@ class ManagerWebAdapter(
     fun getStudents(@ModelAttribute @Valid request: GetStudentListWebRequest): QueryStudentsResponse {
         return queryStudentsUseCase.execute(
             name = request.name,
-            sort = request.sort
+            sort = request.sort!!
         )
     }
     

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/dto/request/GetStudentListWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/dto/request/GetStudentListWebRequest.kt
@@ -8,6 +8,6 @@ data class GetStudentListWebRequest(
     val name: String?,
 
     @field:NotNull
-    val sort: Sort
+    val sort: Sort?
 
 )


### PR DESCRIPTION
## 작업 내용 설명
- [x] Enum Type에 @NotNull을 적용하기 위해 ``?`` 추가
- [x] 직접 만든 타입의 필드에 @NotNull이 붙어있을 경우 ``?`` 키워드가 없으면 validation이 되기 전 NPE가 발생함

## 주요 변경 사항
- ``?`` 처리에 따른 request 변환 과정에 ``!`` 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved # <!-- 이슈번호 -->