### PR TITLE
merge: (#167) AuthCodeLimit 매번 새로운 UUID 저장됨

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/exception/AuthCodeLimitNotFoundException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/exception/AuthCodeLimitNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.auth.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.auth.error.AuthErrorCode
+
+object AuthCodeLimitNotFoundException : DmsException(
+    AuthErrorCode.AUTH_CODE_LIMIT_NOT_FOUND
+)

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/auth/error/AuthErrorCode.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/auth/error/AuthErrorCode.kt
@@ -13,6 +13,7 @@ enum class AuthErrorCode(
 
     REFRESH_TOKEN_NOT_FOUND(404, "Refresh Token Not Found"),
     AUTH_CODE_NOT_FOUND(404, "Auth Code Not Found"),
+    AUTH_CODE_LIMIT_NOT_FOUND(404, "Auth Code Limit Not Found"),
 
     EMAIL_ALREADY_CERTIFIED(409, "Email Already Certified"),
 

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/auth/model/AuthCodeLimit.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/auth/model/AuthCodeLimit.kt
@@ -33,17 +33,17 @@ data class AuthCodeLimit(
         const val MAX_ATTEMPT_COUNT = 5
         const val EXPIRED = 1800
         private const val VERIFIED_EXPIRED = 2700
+    }
 
-        fun certified(email: String, type: EmailType): AuthCodeLimit {
-            return AuthCodeLimit(
-                id = UUID.randomUUID(),
-                email = email,
-                type = type,
-                attemptCount = MAX_ATTEMPT_COUNT,
-                isVerified = true,
-                expirationTime = VERIFIED_EXPIRED
-            )
-        }
+    fun certified(): AuthCodeLimit {
+        return this.copy(
+            id = id,
+            email = email,
+            type = type,
+            attemptCount = MAX_ATTEMPT_COUNT,
+            isVerified = true,
+            expirationTime = VERIFIED_EXPIRED
+        )
     }
 
     fun increaseCount(): AuthCodeLimit {


### PR DESCRIPTION
## 작업 내용 설명
- [x] AuthCodeLimitNotFoundException

## 주요 변경 사항
- CertifyEmailCodeUseCase 로직 변경 (새로운 uuid 생성 방지, 이미 인증된 경우 예외 처리)
- AuthCodeLimit.certified() 메서드 변경 (새로운 uuid 생성 방지)

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #167 