### PR TITLE
merge: (#204) 자습실 목록 보기 학생 API

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/StudentQueryStudyRoomsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/StudentQueryStudyRoomsResponse.kt
@@ -1,0 +1,20 @@
+package team.aliens.dms.domain.studyroom.dto
+
+import java.util.UUID
+import team.aliens.dms.domain.student.model.Sex
+
+data class StudentQueryStudyRoomsResponse(
+    val studyRooms: List<StudyRoomElement>
+) {
+
+    data class StudyRoomElement(
+        val id: UUID,
+        val floor: Int,
+        val name: String,
+        val availableGrade: Int,
+        val availableSex: Sex,
+        val inUseHeadcount: Int,
+        val totalAvailableSeat: Int,
+        val isMine: Boolean
+    )
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
@@ -4,6 +4,7 @@ import java.util.UUID
 import team.aliens.dms.domain.studyroom.spi.vo.SeatVO
 import team.aliens.dms.domain.studyroom.model.Seat
 import team.aliens.dms.domain.studyroom.model.StudyRoom
+import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
 
 interface QueryStudyRoomPort {
 
@@ -17,7 +18,7 @@ interface QueryStudyRoomPort {
 
     fun queryAllSeatByStudyRoomId(studyRoomId: UUID): List<SeatVO>
 
-    fun queryAllStudyRoomsBySchoolId(schoolId: UUID): List<StudyRoom>
+    fun queryAllStudyRoomsBySchoolId(schoolId: UUID): List<StudyRoomVO>
 
     fun countSeatByStudyRoomId(studyRoomId: UUID): Int
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
@@ -17,4 +17,10 @@ interface QueryStudyRoomPort {
 
     fun queryAllSeatByStudyRoomId(studyRoomId: UUID): List<SeatVO>
 
+    fun queryAllStudyRoomsBySchoolId(schoolId: UUID): List<StudyRoom>
+
+    fun countSeatByStudyRoomId(studyRoomId: UUID): Int
+
+    fun querySeatByStudyRoomId(studyRoomId: UUID): Seat?
+
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
@@ -20,8 +20,6 @@ interface QueryStudyRoomPort {
 
     fun queryAllStudyRoomsBySchoolId(schoolId: UUID): List<StudyRoomVO>
 
-    fun countSeatByStudyRoomId(studyRoomId: UUID): Int
-
     fun querySeatByStudyRoomId(studyRoomId: UUID): Seat?
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/vo/StudyRoomVO.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/vo/StudyRoomVO.kt
@@ -1,0 +1,14 @@
+package team.aliens.dms.domain.studyroom.spi.vo
+
+import java.util.UUID
+import team.aliens.dms.domain.student.model.Sex
+
+open class StudyRoomVO(
+    val id: UUID,
+    val floor: Int,
+    val name: String,
+    val availableGrade: Int,
+    val availableSex: Sex,
+    val inUseHeadcount: Int,
+    val totalAvailableSeat: Int
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
@@ -1,0 +1,49 @@
+package team.aliens.dms.domain.studyroom.usecase
+
+import java.util.UUID
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
+import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse.StudyRoomElement
+import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+
+@ReadOnlyUseCase
+class StudentQueryStudyRoomsUseCase(
+    private val securityPort: StudyRoomSecurityPort,
+    private val queryUserPort: StudyRoomQueryUserPort,
+    private val queryStudyRoomPort: QueryStudyRoomPort
+) {
+
+    fun execute(): StudentQueryStudyRoomsResponse {
+        val currentUserId = securityPort.getCurrentUserId()
+        val user = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val studyRoom = queryStudyRoomPort.queryAllStudyRoomsBySchoolId(user.schoolId).map {
+            StudyRoomElement(
+                id = it.id,
+                floor = it.floor,
+                name = it.name,
+                availableGrade = it.availableGrade,
+                availableSex = it.availableSex,
+                inUseHeadcount = it.inUseHeadcount!!,
+                totalAvailableSeat = queryStudyRoomPort.countSeatByStudyRoomId(it.id),
+                isMine = isMine(
+                    studyRoomId = it.id,
+                    currentUserId = currentUserId
+                )
+            )
+        }
+
+        return StudentQueryStudyRoomsResponse(
+            studyRooms = studyRoom
+        )
+    }
+
+    private fun isMine(studyRoomId: UUID, currentUserId: UUID) : Boolean {
+        val studentId = queryStudyRoomPort.querySeatByStudyRoomId(studyRoomId)?.studentId
+
+        return studentId == currentUserId
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.domain.studyroom.usecase
 
+import java.util.UUID
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse.StudyRoomElement
@@ -19,6 +20,8 @@ class StudentQueryStudyRoomsUseCase(
         val currentUserId = securityPort.getCurrentUserId()
         val user = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 
+        val userStudyRoomId = queryStudyRoomPort.querySeatByStudentId(currentUserId)?.studyRoomId
+
         val studyRoom = queryStudyRoomPort.queryAllStudyRoomsBySchoolId(user.schoolId).map {
             StudyRoomElement(
                 id = it.id,
@@ -28,12 +31,18 @@ class StudentQueryStudyRoomsUseCase(
                 availableSex = it.availableSex,
                 inUseHeadcount = it.inUseHeadcount,
                 totalAvailableSeat = it.totalAvailableSeat,
-                isMine = true // 보류
+                isMine = isMine(userStudyRoomId, it.id)
             )
         }
 
         return StudentQueryStudyRoomsResponse(
             studyRooms = studyRoom
         )
+    }
+
+    private fun isMine(userStudyRoomId: UUID?, studyRoomId: UUID) = userStudyRoomId?.run {
+        this == studyRoomId
+    } ?: run {
+        false
     }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.domain.studyroom.usecase
 
-import java.util.UUID
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse.StudyRoomElement
@@ -27,23 +26,14 @@ class StudentQueryStudyRoomsUseCase(
                 name = it.name,
                 availableGrade = it.availableGrade,
                 availableSex = it.availableSex,
-                inUseHeadcount = it.inUseHeadcount!!,
-                totalAvailableSeat = queryStudyRoomPort.countSeatByStudyRoomId(it.id),
-                isMine = isMine(
-                    studyRoomId = it.id,
-                    currentUserId = currentUserId
-                )
+                inUseHeadcount = it.inUseHeadcount,
+                totalAvailableSeat = it.totalAvailableSeat,
+                isMine = true // 보류
             )
         }
 
         return StudentQueryStudyRoomsResponse(
             studyRooms = studyRoom
         )
-    }
-
-    private fun isMine(studyRoomId: UUID, currentUserId: UUID) : Boolean {
-        val studentId = queryStudyRoomPort.querySeatByStudyRoomId(studyRoomId)?.studentId
-
-        return studentId == currentUserId
     }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
@@ -31,7 +31,10 @@ class StudentQueryStudyRoomsUseCase(
                 availableSex = it.availableSex,
                 inUseHeadcount = it.inUseHeadcount,
                 totalAvailableSeat = it.totalAvailableSeat,
-                isMine = isMine(userStudyRoomId, it.id)
+                isMine = isMine(
+                    userStudyRoomId = userStudyRoomId,
+                    studyRoomId = it.id
+                )
             )
         }
 

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
@@ -136,7 +136,7 @@ class StudentQueryStudyRoomsUseCaseTests {
             .willReturn(userStub)
 
         given(queryStudyRoomPort.querySeatByStudentId(currentUserId))
-            .willReturn(seatStub.copy(studentId = null))
+            .willReturn(null)
 
         given(queryStudyRoomPort.queryAllStudyRoomsBySchoolId(userStub.schoolId))
             .willReturn(listOf(studyRoomVOStub))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
@@ -1,0 +1,164 @@
+package team.aliens.dms.domain.studyroom.usecase
+
+import java.time.LocalDateTime
+import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.studyroom.model.Seat
+import team.aliens.dms.domain.studyroom.model.SeatStatus
+import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
+import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+
+@ExtendWith(SpringExtension::class)
+class StudentQueryStudyRoomsUseCaseTests {
+
+    @MockBean
+    private lateinit var securityPort: StudyRoomSecurityPort
+
+    @MockBean
+    private lateinit var queryUserPort: StudyRoomQueryUserPort
+
+    @MockBean
+    private lateinit var queryStudyRoomPort: QueryStudyRoomPort
+
+    private lateinit var studentQueryStudyRoomsUseCase: StudentQueryStudyRoomsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        studentQueryStudyRoomsUseCase = StudentQueryStudyRoomsUseCase(
+            securityPort, queryUserPort, queryStudyRoomPort
+        )
+    }
+
+    private val currentUserId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+    private val studyRoomId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = currentUserId,
+            schoolId = schoolId,
+            accountId = "계정 아이디",
+            password = "비밀번호",
+            email = "이메일",
+            authority = Authority.STUDENT,
+            createdAt = LocalDateTime.now(),
+            deletedAt = null
+        )
+    }
+
+    private val seatStub by lazy {
+        Seat(
+            id = UUID.randomUUID(),
+            studyRoomId = studyRoomId,
+            studentId = currentUserId,
+            typeId = UUID.randomUUID(),
+            widthLocation = 1,
+            heightLocation = 1,
+            number = 1,
+            status = SeatStatus.AVAILABLE
+        )
+    }
+
+    private val studyRoomVOStub by lazy {
+        StudyRoomVO(
+            id = UUID.randomUUID(),
+            floor = 1,
+            name = "다온실",
+            availableGrade = 1,
+            availableSex = Sex.MALE,
+            inUseHeadcount = 1,
+            totalAvailableSeat = 1
+        )
+    }
+
+    @Test
+    fun `학생 자습실 조회 성공 isMine true`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(currentUserId)
+
+        given(queryUserPort.queryUserById(currentUserId))
+            .willReturn(userStub)
+
+        given(queryStudyRoomPort.querySeatByStudentId(currentUserId))
+            .willReturn(seatStub)
+
+        given(queryStudyRoomPort.queryAllStudyRoomsBySchoolId(userStub.schoolId))
+            .willReturn(listOf(studyRoomVOStub))
+
+        // when & then
+        assertDoesNotThrow {
+            studentQueryStudyRoomsUseCase.execute()
+        }
+    }
+
+    @Test
+    fun `학생 자습실 조회 성공 isMine false`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(currentUserId)
+
+        given(queryUserPort.queryUserById(currentUserId))
+            .willReturn(userStub)
+
+        given(queryStudyRoomPort.querySeatByStudentId(currentUserId))
+            .willReturn(seatStub.copy(studentId = UUID.randomUUID()))
+
+        given(queryStudyRoomPort.queryAllStudyRoomsBySchoolId(userStub.schoolId))
+            .willReturn(listOf(studyRoomVOStub))
+
+        // when & then
+        assertDoesNotThrow {
+            studentQueryStudyRoomsUseCase.execute()
+        }
+    }
+
+    @Test
+    fun `학생 자습실 조회 성공 isMine false NULL`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(currentUserId)
+
+        given(queryUserPort.queryUserById(currentUserId))
+            .willReturn(userStub)
+
+        given(queryStudyRoomPort.querySeatByStudentId(currentUserId))
+            .willReturn(seatStub.copy(studentId = null))
+
+        given(queryStudyRoomPort.queryAllStudyRoomsBySchoolId(userStub.schoolId))
+            .willReturn(listOf(studyRoomVOStub))
+
+        // when & then
+        assertDoesNotThrow {
+            studentQueryStudyRoomsUseCase.execute()
+        }
+    }
+
+    @Test
+    fun `사용자 미존재`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(currentUserId)
+
+        given(queryUserPort.queryUserById(currentUserId))
+            .willReturn(null)
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            studentQueryStudyRoomsUseCase.execute()
+        }
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -110,6 +110,7 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.PATCH, "/study-rooms/{study-room-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/study-rooms/{study-room-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/study-rooms/{study-room-id}/students").hasAuthority(STUDENT.name)
+            .antMatchers(HttpMethod.GET, "/study-rooms/list/students").hasAuthority(STUDENT.name)
 
             .anyRequest().denyAll()
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -89,23 +89,18 @@ class StudyRoomPersistenceAdapter(
                     studyRoomJpaEntity.availableGrade,
                     studyRoomJpaEntity.availableSex,
                     studyRoomJpaEntity.inUseHeadcount,
-                    getTotalAvailableSeatCount(studyRoomJpaEntity.id)
+                    seatJpaEntity.count().intValue()
                 )
             )
             .from(studyRoomJpaEntity)
+            .leftJoin(seatJpaEntity)
+            .on(
+                studyRoomJpaEntity.id.eq(seatJpaEntity.studyRoom.id),
+                seatJpaEntity.status.eq(SeatStatus.AVAILABLE)
+            )
             .where(studyRoomJpaEntity.school.id.eq(schoolId))
+            .groupBy(studyRoomJpaEntity.id)
             .fetch()
-    }
-
-    private fun getTotalAvailableSeatCount(studyRoomId: ComparablePath<UUID>): NumberExpression<Int> {
-        return Expressions.asNumber(
-            JPAExpressions.select(seatJpaEntity.count())
-                .from(seatJpaEntity)
-                .where(
-                    seatJpaEntity.studyRoom.id.eq(studyRoomId),
-                    seatJpaEntity.status.eq(SeatStatus.AVAILABLE)
-                )
-        ).intValue()
     }
 
     override fun querySeatByStudyRoomId(studyRoomId: UUID) = seatMapper.toDomain(

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import team.aliens.dms.domain.studyroom.spi.vo.SeatVO
 import team.aliens.dms.domain.studyroom.model.Seat
-import team.aliens.dms.domain.studyroom.model.SeatStatus
 import team.aliens.dms.domain.studyroom.model.StudyRoom
 import team.aliens.dms.domain.studyroom.spi.StudyRoomPort
 import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
@@ -85,17 +84,11 @@ class StudyRoomPersistenceAdapter(
                     studyRoomJpaEntity.availableGrade,
                     studyRoomJpaEntity.availableSex,
                     studyRoomJpaEntity.inUseHeadcount,
-                    seatJpaEntity.count().intValue()
+                    studyRoomJpaEntity.availableHeadcount
                 )
             )
             .from(studyRoomJpaEntity)
-            .leftJoin(seatJpaEntity)
-            .on(
-                studyRoomJpaEntity.id.eq(seatJpaEntity.studyRoom.id),
-                seatJpaEntity.status.eq(SeatStatus.AVAILABLE)
-            )
             .where(studyRoomJpaEntity.school.id.eq(schoolId))
-            .groupBy(studyRoomJpaEntity.id)
             .fetch()
     }
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -1,9 +1,5 @@
 package team.aliens.dms.persistence.studyroom
 
-import com.querydsl.core.types.dsl.ComparablePath
-import com.querydsl.core.types.dsl.Expressions
-import com.querydsl.core.types.dsl.NumberExpression
-import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import java.util.UUID
 import org.springframework.data.repository.findByIdOrNull

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -108,8 +108,6 @@ class StudyRoomPersistenceAdapter(
         ).intValue()
     }
 
-    override fun countSeatByStudyRoomId(studyRoomId: UUID) = seatRepository.countByStudyRoomId(studyRoomId)
-
     override fun querySeatByStudyRoomId(studyRoomId: UUID) = seatMapper.toDomain(
         seatRepository.findByStudyRoomId(studyRoomId)
     )

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -67,6 +67,17 @@ class StudyRoomPersistenceAdapter(
             .fetch()
     }
 
+    override fun queryAllStudyRoomsBySchoolId(schoolId: UUID) = studyRoomRepository
+        .findAllBySchoolId(schoolId).map {
+            studyRoomMapper.toDomain(it)!!
+        }
+
+    override fun countSeatByStudyRoomId(studyRoomId: UUID) = seatRepository.countByStudyRoomId(studyRoomId)
+
+    override fun querySeatByStudyRoomId(studyRoomId: UUID) = seatMapper.toDomain(
+        seatRepository.findByStudyRoomId(studyRoomId)
+    )
+
     override fun saveSeat(seat: Seat) = seatMapper.toDomain(
         seatRepository.save(
             seatMapper.toEntity(seat)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/SeatJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/SeatJpaRepository.kt
@@ -12,4 +12,8 @@ interface SeatJpaRepository : CrudRepository<SeatJpaEntity, UUID> {
 
     fun deleteAllByStudyRoomId(studyRoomId: UUID)
 
+    fun countByStudyRoomId(studyRoomId: UUID): Int
+
+    fun findByStudyRoomId(studyRoomId: UUID): SeatJpaEntity?
+
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/SeatJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/SeatJpaRepository.kt
@@ -12,8 +12,6 @@ interface SeatJpaRepository : CrudRepository<SeatJpaEntity, UUID> {
 
     fun deleteAllByStudyRoomId(studyRoomId: UUID)
 
-    fun countByStudyRoomId(studyRoomId: UUID): Int
-
     fun findByStudyRoomId(studyRoomId: UUID): SeatJpaEntity?
 
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/StudyRoomJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/StudyRoomJpaRepository.kt
@@ -10,4 +10,6 @@ interface StudyRoomJpaRepository : CrudRepository<StudyRoomJpaEntity, UUID> {
 
     fun existsByNameAndFloorAndSchoolId(name: String, floor: Int, schoolId: UUID): Boolean
 
+    fun findAllBySchoolId(schoolId: UUID): List<StudyRoomJpaEntity>
+
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/StudyRoomJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/StudyRoomJpaRepository.kt
@@ -10,6 +10,4 @@ interface StudyRoomJpaRepository : CrudRepository<StudyRoomJpaEntity, UUID> {
 
     fun existsByNameAndFloorAndSchoolId(name: String, floor: Int, schoolId: UUID): Boolean
 
-    fun findAllBySchoolId(schoolId: UUID): List<StudyRoomJpaEntity>
-
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/vo/QueryStudyRoomVO.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/vo/QueryStudyRoomVO.kt
@@ -1,0 +1,24 @@
+package team.aliens.dms.persistence.studyroom.repository.vo
+
+import com.querydsl.core.annotations.QueryProjection
+import java.util.UUID
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
+
+class QueryStudyRoomVO @QueryProjection constructor(
+    id: UUID,
+    floor: Int,
+    name: String,
+    availableGrade: Int,
+    availableSex: Sex,
+    inUseHeadcount: Int,
+    totalAvailableSeat: Int
+) : StudyRoomVO(
+    id = id,
+    floor = floor,
+    name = name,
+    availableGrade = availableGrade,
+    availableSex = availableSex,
+    inUseHeadcount = inUseHeadcount,
+    totalAvailableSeat = totalAvailableSeat
+)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
@@ -27,7 +27,6 @@ import team.aliens.dms.domain.studyroom.dto.ManagerQueryStudyRoomResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse
 import team.aliens.dms.domain.studyroom.dto.UpdateStudyRoomRequest
 import team.aliens.dms.domain.studyroom.dto.UpdateStudyRoomWebRequest
-import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.usecase.ApplySeatUseCase
 import team.aliens.dms.domain.studyroom.usecase.CreateSeatTypeUseCase

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
@@ -26,12 +26,14 @@ import team.aliens.dms.domain.studyroom.dto.CreateStudyRoomWebRequest
 import team.aliens.dms.domain.studyroom.dto.UpdateStudyRoomRequest
 import team.aliens.dms.domain.studyroom.dto.UpdateStudyRoomWebRequest
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse
+import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.usecase.ApplySeatUseCase
 import team.aliens.dms.domain.studyroom.usecase.CreateSeatTypeUseCase
 import team.aliens.dms.domain.studyroom.usecase.CreateStudyRoomUseCase
 import team.aliens.dms.domain.studyroom.usecase.UnApplySeatUseCase
 import team.aliens.dms.domain.studyroom.usecase.QueryAvailableTimeUseCase
 import team.aliens.dms.domain.studyroom.usecase.StudentQueryStudyRoomUseCase
+import team.aliens.dms.domain.studyroom.usecase.StudentQueryStudyRoomsUseCase
 import team.aliens.dms.domain.studyroom.usecase.UpdateAvailableTimeUseCase
 import team.aliens.dms.domain.studyroom.usecase.UpdateStudyRoomUseCase
 
@@ -47,7 +49,8 @@ class StudyRoomWebAdapter(
     private val unApplySeatUseCase: UnApplySeatUseCase,
     private val createStudyRoomUseCase: CreateStudyRoomUseCase,
     private val updateStudyRoomUseCase: UpdateStudyRoomUseCase,
-    private val studentQueryStudyRoomUseCase: StudentQueryStudyRoomUseCase
+    private val studentQueryStudyRoomUseCase: StudentQueryStudyRoomUseCase,
+    private val studentQueryStudyRoomsUseCase: StudentQueryStudyRoomsUseCase
 ) {
 
     @GetMapping("/available-time")
@@ -159,5 +162,10 @@ class StudyRoomWebAdapter(
     @GetMapping("/{study-room-id}/students")
     fun studentGetStudyRoom(@PathVariable("study-room-id") @NotNull studyRoomId: UUID): StudentQueryStudyRoomResponse {
         return studentQueryStudyRoomUseCase.execute(studyRoomId)
+    }
+
+    @GetMapping("/list/students")
+    fun studentGetStudyRooms(): StudentQueryStudyRoomsResponse {
+        return studentQueryStudyRoomsUseCase.execute()
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] GET /study-rooms/list/students
- [x] StudentQueryStudyRoomsUseCase

## 주요 변경 사항
- Security Configuration GET /study-rooms/list/students
- StudyRoomPersistenceAdapter queryAllStudyRoomsBySchoolId 메소드 추가

## 실행 결과
<img width="400" alt="스크린샷 2022-12-26 오후 4 36 56" src="https://user-images.githubusercontent.com/81298238/209519169-8790516a-7ee9-4654-a712-6e4eab818921.png">


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #204 