### PR TITLE
merge: (#210) 자습실 신청, 취소 비즈니스 로직 수정

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ApplySeatUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ApplySeatUseCase.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.domain.studyroom.usecase
 
-import java.util.UUID
 import team.aliens.dms.common.annotation.UseCase
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
 import team.aliens.dms.domain.studyroom.exception.SeatAlreadyAppliedException
@@ -13,6 +12,7 @@ import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.util.UUID
 
 @UseCase
 class ApplySeatUseCase(
@@ -40,11 +40,12 @@ class ApplySeatUseCase(
         val saveSeat = seat.studentId?.run {
             throw SeatAlreadyAppliedException
         } ?: run {
-            seat.copy(studentId = currentUserId)
+            seat.use(currentUserId)
         }
         commandStudyRoomPort.saveSeat(saveSeat)
+
         commandStudyRoomPort.saveStudyRoom(
-            studyRoom.plusInUseHeadcount()
+            studyRoom.apply()
         )
     }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/UnApplySeatUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/UnApplySeatUseCase.kt
@@ -2,7 +2,6 @@ package team.aliens.dms.domain.studyroom.usecase
 
 import team.aliens.dms.common.annotation.UseCase
 import team.aliens.dms.domain.studyroom.exception.AppliedSeatNotFound
-import team.aliens.dms.domain.studyroom.exception.SeatNotFoundException
 import team.aliens.dms.domain.studyroom.exception.StudyRoomNotFoundException
 import team.aliens.dms.domain.studyroom.spi.CommandStudyRoomPort
 import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
@@ -22,10 +21,10 @@ class UnApplySeatUseCase(
         val studyRoom = queryStudyRoomPort.queryStudyRoomById(seat.studyRoomId) ?: throw StudyRoomNotFoundException
 
         commandStudyRoomPort.saveSeat(
-            seat.copy(studentId = null)
+            seat.unUse()
         )
         commandStudyRoomPort.saveStudyRoom(
-            studyRoom.minusInUseHeadcount()
+            studyRoom.unApply()
         )
     }
 }

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/studyroom/model/Seat.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/studyroom/model/Seat.kt
@@ -20,4 +20,15 @@ data class Seat(
 
     val status: SeatStatus
 
-)
+) {
+
+    fun use(studentId: UUID) = this.copy(
+        studentId = studentId,
+        status = SeatStatus.IN_USE
+    )
+
+    fun unUse() = this.copy(
+        studentId = null,
+        status = SeatStatus.AVAILABLE
+    )
+}

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/studyroom/model/StudyRoom.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/studyroom/model/StudyRoom.kt
@@ -38,11 +38,13 @@ data class StudyRoom(
 
 ) {
 
-    fun plusInUseHeadcount() = this.copy(
-        inUseHeadcount = inUseHeadcount!!.inc()
+    fun apply() = this.copy(
+        inUseHeadcount = inUseHeadcount!!.inc(),
+        availableHeadcount = availableHeadcount.dec()
     )
 
-    fun minusInUseHeadcount() = this.copy(
-        inUseHeadcount = inUseHeadcount!!.dec()
+    fun unApply() = this.copy(
+        inUseHeadcount = inUseHeadcount!!.dec(),
+        availableHeadcount = availableHeadcount.inc()
     )
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] 자습실 신청시 IN_USE 상태로 변경, availableHeadCount 증가
- [x] 자습실 신청 취소시 AVAILABLE 상태로 변경, availableHeadCount 감소

## 주요 변경 사항
- seat.use(), seat.unUse() 메서드로 변경
- studyRoom.apply(), studyRoom.unApply() 메서드로 변경

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #210 