### PR TITLE
merge: (#176) 검증된 학생 엑셀 파일 DB 저장 API

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -47,4 +47,8 @@ object Dependencies {
 
     // time based uuid
     const val UUID_TIME = "com.fasterxml.uuid:java-uuid-generator:${DependencyVersions.UUID_TIME_VERSION}"
+
+    // excel
+    const val APACHE_POI = "org.apache.poi:poi:${DependencyVersions.APACHE_POI_VERSION}"
+    const val APACHE_POI_OOXML = "org.apache.poi:poi-ooxml:${DependencyVersions.APACHE_POI_VERSION}"
 }

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -8,4 +8,5 @@ object DependencyVersions {
     const val UUID_TIME_VERSION = "3.1.4"
     const val SPRING_TRANSACTION = "5.3.22"
     const val QUERYDSL = "5.0.0"
+    const val APACHE_POI_VERSION = "3.7"
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/file/spi/ParseFilePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/file/spi/ParseFilePort.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.file.spi
+
+import java.io.File
+import team.aliens.dms.domain.student.model.VerifiedStudent
+
+interface ParseFilePort {
+
+    fun transferToVerifiedStudent(file: File): List<VerifiedStudent>
+
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/file/usecase/ImportVerifiedStudentUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/file/usecase/ImportVerifiedStudentUseCase.kt
@@ -1,0 +1,19 @@
+package team.aliens.dms.domain.file.usecase
+
+import java.io.File
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.student.spi.CommandStudentPort
+import team.aliens.dms.domain.file.spi.ParseFilePort
+
+@UseCase
+class ImportVerifiedStudentUseCase(
+    private val parseFilePort: ParseFilePort,
+    private val commandStudentPort: CommandStudentPort
+) {
+
+    fun execute(file: File) {
+        val verifiedStudents = parseFilePort.transferToVerifiedStudent(file)
+
+        commandStudentPort.saveAllVerifiedStudent(verifiedStudents)
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/CommandStudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/CommandStudentPort.kt
@@ -1,9 +1,12 @@
 package team.aliens.dms.domain.student.spi
 
 import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.model.VerifiedStudent
 
 interface CommandStudentPort {
 
     fun saveStudent(student: Student): Student
+
+    fun saveAllVerifiedStudent(verifiedStudents: List<VerifiedStudent>)
 
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.domain.student.usecase
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -17,7 +16,6 @@ import team.aliens.dms.domain.auth.model.EmailType
 import team.aliens.dms.domain.room.exception.RoomNotFoundException
 import team.aliens.dms.domain.room.model.Room
 import team.aliens.dms.domain.school.exception.AnswerMismatchException
-import team.aliens.dms.domain.school.exception.FeatureNotFoundException
 import team.aliens.dms.domain.school.exception.SchoolCodeMismatchException
 import team.aliens.dms.domain.school.model.AvailableFeature
 import team.aliens.dms.domain.school.model.School
@@ -124,6 +122,7 @@ class SignUpUseCaseTests {
 
     private val verifiedStudentStub by lazy {
         VerifiedStudent(
+            id = UUID.randomUUID(),
             schoolName = schoolStub.name,
             name = name,
             roomNumber = 318,

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/UpdateStudentProfileUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/UpdateStudentProfileUseCaseTests.kt
@@ -14,7 +14,6 @@ import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.student.spi.CommandStudentPort
 import team.aliens.dms.domain.student.spi.QueryStudentPort
 import team.aliens.dms.domain.student.spi.StudentSecurityPort
-import team.aliens.dms.domain.user.exception.UserNotFoundException
 import java.util.UUID
 
 @ExtendWith(SpringExtension::class)

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/Sex.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/Sex.kt
@@ -4,4 +4,10 @@ enum class Sex {
     MALE,
     FEMALE,
     ALL
+    ;
+
+    companion object {
+        const val MALE_KOREAN = "남"
+        const val FEMALE_KOREAN = "여"
+    }
 }

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/VerifiedStudent.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/VerifiedStudent.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 @Aggregate
 data class VerifiedStudent(
 
-    val id: UUID = UUID(0, 0),
+    val id: UUID,
 
     val schoolName: String,
 

--- a/dms-infrastructure/build.gradle.kts
+++ b/dms-infrastructure/build.gradle.kts
@@ -43,6 +43,10 @@ dependencies {
     // configuration
     kapt(Dependencies.CONFIGURATION_PROCESSOR)
 
+    // excel
+    implementation(Dependencies.APACHE_POI)
+    implementation(Dependencies.APACHE_POI_OOXML)
+
 }
 
 kapt {

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/error/GlobalErrorCode.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/error/GlobalErrorCode.kt
@@ -13,7 +13,7 @@ enum class GlobalErrorCode(
     INVALID_FILE(400, "Invalid File"),
 
     SEX_MISMATCH(401, "Sex Mismatch"),
-    EXTENSION_MISMATCH(401, "Excel Extension Mismatch"),
+    EXTENSION_MISMATCH(401, "File Extension Mismatch"),
 
     INTERNAL_SERVER_ERROR(500, "Internal Server Error")
     ;

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/error/GlobalErrorCode.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/error/GlobalErrorCode.kt
@@ -10,6 +10,10 @@ enum class GlobalErrorCode(
     SEND_EMAIL_REJECTED(400, "Send Email Rejected"),
     SIMPLE_EMAIL_SERVICE(400, "Simple Email Service"),
     BAD_REQUEST(400, "Bad Request"),
+    INVALID_FILE(400, "Invalid File"),
+
+    SEX_MISMATCH(401, "Sex Mismatch"),
+    EXTENSION_MISMATCH(401, "Excel Extension Mismatch"),
 
     INTERNAL_SERVER_ERROR(500, "Internal Server Error")
     ;

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -86,6 +86,7 @@ class SecurityConfiguration(
 
             // /files
             .antMatchers(HttpMethod.POST, "/files").permitAll()
+            .antMatchers(HttpMethod.POST, "/files/verified-student").permitAll()
 
             // /meals
             .antMatchers(HttpMethod.GET, "/meals/{date}").hasAuthority(STUDENT.name)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -13,11 +13,16 @@ import team.aliens.dms.persistence.student.mapper.StudentMapper
 import team.aliens.dms.persistence.student.repository.StudentJpaRepository
 import team.aliens.dms.persistence.user.entity.QUserJpaEntity.userJpaEntity
 import java.util.UUID
+import team.aliens.dms.domain.student.model.VerifiedStudent
+import team.aliens.dms.persistence.student.mapper.VerifiedStudentMapper
+import team.aliens.dms.persistence.student.repository.VerifiedStudentJpaRepository
 
 @Component
 class StudentPersistenceAdapter(
     private val studentMapper: StudentMapper,
     private val studentRepository: StudentJpaRepository,
+    private val verifiedStudentRepository: VerifiedStudentJpaRepository,
+    private val verifiedStudentMapper: VerifiedStudentMapper,
     private val queryFactory: JPAQueryFactory
 ) : StudentPort {
 
@@ -39,6 +44,14 @@ class StudentPersistenceAdapter(
             studentMapper.toEntity(student)
         )
     )!!
+
+    override fun saveAllVerifiedStudent(verifiedStudents: List<VerifiedStudent>) {
+        verifiedStudentRepository.saveAll(
+            verifiedStudents.map {
+                verifiedStudentMapper.toEntity(it)
+            }
+        )
+    }
 
     override fun queryStudentsByNameAndSort(name: String?, sort: Sort, schoolId: UUID): List<Student> {
         return queryFactory

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
@@ -17,9 +17,7 @@ import team.aliens.dms.thirdparty.parser.exception.ExcelInvalidFileException
 import team.aliens.dms.thirdparty.parser.exception.ExcelSexMismatchException
 
 @Component
-class ExcelAdapter(
-
-) : ParseFilePort {
+class ExcelAdapter : ParseFilePort {
 
     override fun transferToVerifiedStudent(file: File): List<VerifiedStudent> {
         val workbook = transferToExcel(file)
@@ -49,7 +47,6 @@ class ExcelAdapter(
             e.printStackTrace()
         }
 
-
         return verifiedStudents
     }
 
@@ -63,8 +60,9 @@ class ExcelAdapter(
                 else -> throw ExcelExtensionMismatchException
             }
         }.also {
-            inputStream.close()
-            file.delete()
+            inputStream.use {
+                file.delete()
+            }
         }.onFailure {
             throw ExcelInvalidFileException
         }.getOrThrow()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
@@ -1,0 +1,78 @@
+package team.aliens.dms.thirdparty.parser
+
+import com.fasterxml.uuid.Generators
+import java.io.File
+import org.apache.poi.hssf.usermodel.HSSFWorkbook
+import org.apache.poi.ss.usermodel.Row.CREATE_NULL_AS_BLANK
+import org.apache.poi.ss.usermodel.Workbook
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.file.FileExtension.XLS
+import team.aliens.dms.domain.file.FileExtension.XLSX
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.model.VerifiedStudent
+import team.aliens.dms.domain.file.spi.ParseFilePort
+import team.aliens.dms.thirdparty.parser.exception.ExcelExtensionMismatchException
+import team.aliens.dms.thirdparty.parser.exception.ExcelInvalidFileException
+import team.aliens.dms.thirdparty.parser.exception.ExcelSexMismatchException
+
+@Component
+class ExcelAdapter(
+
+) : ParseFilePort {
+
+    override fun transferToVerifiedStudent(file: File): List<VerifiedStudent> {
+        val workbook = transferToExcel(file)
+
+        val verifiedStudents = mutableListOf<VerifiedStudent>()
+
+        try {
+            val worksheet = workbook.getSheetAt(0)
+
+            for (i in 1..worksheet.lastRowNum) {
+                val excelData = worksheet.getRow(i).run {
+                    VerifiedStudent(
+                        id = Generators.timeBasedGenerator().generate(),
+                        schoolName = getCell(0, CREATE_NULL_AS_BLANK).stringCellValue,
+                        name = getCell(1, CREATE_NULL_AS_BLANK).stringCellValue,
+                        gcn = getCell(2, CREATE_NULL_AS_BLANK).numericCellValue.toInt().toString(),
+                        roomNumber = getCell(3, CREATE_NULL_AS_BLANK).numericCellValue.toInt(),
+                        sex = transferToSex(
+                            getCell(4, CREATE_NULL_AS_BLANK).stringCellValue
+                        )
+                    )
+                }
+
+                verifiedStudents.add(excelData)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+
+        return verifiedStudents
+    }
+
+    private fun transferToExcel(file: File): Workbook {
+        val inputStream = file.inputStream()
+
+        return runCatching {
+            when (file.extension.lowercase()) {
+                XLS -> HSSFWorkbook(inputStream)
+                XLSX -> XSSFWorkbook(inputStream)
+                else -> throw ExcelExtensionMismatchException
+            }
+        }.also {
+            inputStream.close()
+            file.delete()
+        }.onFailure {
+            throw ExcelInvalidFileException
+        }.getOrThrow()
+    }
+
+    private fun transferToSex(sex: String) = when (sex) {
+        Sex.MALE_KOREAN -> Sex.MALE
+        Sex.FEMALE_KOREAN -> Sex.FEMALE
+        else -> throw ExcelSexMismatchException
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
@@ -53,19 +53,19 @@ class ExcelAdapter : ParseFilePort {
     private fun transferToExcel(file: File): Workbook {
         val inputStream = file.inputStream()
 
-        return runCatching {
-            when (file.extension.lowercase()) {
-                XLS -> HSSFWorkbook(inputStream)
-                XLSX -> XSSFWorkbook(inputStream)
-                else -> throw ExcelExtensionMismatchException
-            }
-        }.also {
-            inputStream.use {
+        return inputStream.use {
+            runCatching {
+                when (file.extension.lowercase()) {
+                    XLS -> HSSFWorkbook(inputStream)
+                    XLSX -> XSSFWorkbook(inputStream)
+                    else -> throw ExcelExtensionMismatchException
+                }
+            }.also {
                 file.delete()
-            }
-        }.onFailure {
-            throw ExcelInvalidFileException
-        }.getOrThrow()
+            }.onFailure {
+                throw ExcelInvalidFileException
+            }.getOrThrow()
+        }
     }
 
     private fun transferToSex(sex: String) = when (sex) {

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/exception/ExcelExtensionMismatchException.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/exception/ExcelExtensionMismatchException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.thirdparty.parser.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.global.error.GlobalErrorCode
+
+object ExcelExtensionMismatchException : DmsException(
+    GlobalErrorCode.EXTENSION_MISMATCH
+)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/exception/ExcelInvalidFileException.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/exception/ExcelInvalidFileException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.thirdparty.parser.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.global.error.GlobalErrorCode
+
+object ExcelInvalidFileException : DmsException(
+    GlobalErrorCode.INVALID_FILE
+)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/exception/ExcelSexMismatchException.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/exception/ExcelSexMismatchException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.thirdparty.parser.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.global.error.GlobalErrorCode
+
+object ExcelSexMismatchException : DmsException(
+    GlobalErrorCode.SEX_MISMATCH
+)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/file/FileExtension.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/file/FileExtension.kt
@@ -1,0 +1,13 @@
+package team.aliens.dms.domain.file
+
+object FileExtension {
+    // image
+    const val JPG = "jpg"
+    const val JPEG = "jpeg"
+    const val PNG = "png"
+    const val HEIC = "heic"
+
+    // excel
+    const val XLS = "xls"
+    const val XLSX = "xlsx"
+}

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/file/FileWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/file/FileWebAdapter.kt
@@ -11,13 +11,17 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
 import javax.validation.constraints.NotNull
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.ResponseStatus
+import team.aliens.dms.domain.file.usecase.ImportVerifiedStudentUseCase
 
 @Validated
 @RequestMapping("/files")
 @RestController
 class FileWebAdapter(
-    private val uploadFileUseCase: UploadFileUseCase
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val importVerifiedStudentUseCase: ImportVerifiedStudentUseCase
 ) {
 
     @PostMapping
@@ -27,6 +31,14 @@ class FileWebAdapter(
         )
 
         return UploadFileResponse(result)
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/verified-student")
+    fun importVerifiedStudentFromExcel(@RequestPart @NotNull file: MultipartFile?) {
+        importVerifiedStudentUseCase.execute(
+            file!!.let(transferFile)
+        )
     }
 
     private val transferFile = { multipartFile: MultipartFile ->


### PR DESCRIPTION
## 작업 내용 설명
- [x] 엑셀 파일 인증된 학생으로 변환
- [x] ImportVerifiedStudentUseCase

## 주요 변경 사항
- ExcelAdapter
- VerifiedStudentPersistenceAdapter

## 실행 결과
<img width="400" alt="스크린샷 2023-01-06 오후 6 38 38" src="https://user-images.githubusercontent.com/81298238/210973940-34994ece-e22f-4e3c-9f01-5b2226384473.png">

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #176