### PR TITLE
merge: (#222) PointHistory 비정규화

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryPointPort.kt
@@ -1,11 +1,9 @@
 package team.aliens.dms.domain.manager.spi
 
-import java.util.UUID
+import team.aliens.dms.domain.student.model.Student
 
 interface ManagerQueryPointPort {
 
-    fun queryTotalBonusPoint(studentId: UUID): Int
-
-    fun queryTotalMinusPoint(studentId: UUID): Int
+    fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryPointPort.kt
@@ -1,9 +1,7 @@
 package team.aliens.dms.domain.manager.spi
 
-import team.aliens.dms.domain.student.model.Student
-
 interface ManagerQueryPointPort {
 
-    fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int>
+    fun queryBonusAndMinusTotalPointByGcnAndStudentName(gcn: String, studentName: String): Pair<Int, Int>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryPointPort.kt
@@ -2,6 +2,6 @@ package team.aliens.dms.domain.manager.spi
 
 interface ManagerQueryPointPort {
 
-    fun queryBonusAndMinusTotalPointByGcnAndStudentName(gcn: String, studentName: String): Pair<Int, Int>
+    fun queryBonusAndMinusTotalPointByStudentGcnAndName(gcn: String, studentName: String): Pair<Int, Int>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -30,7 +30,7 @@ class QueryStudentDetailsUseCase(
         }
 
         val (bonusPoint, minusPoint) =
-            queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(student.gcn, student.name)
+            queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(student.gcn, student.name)
 
         val roomMates = queryStudentPort.queryUserByRoomNumberAndSchoolId(
             roomNumber = student.roomNumber,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -29,10 +29,8 @@ class QueryStudentDetailsUseCase(
             throw SchoolMismatchException
         }
 
-        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(
-            gcn = student.gcn,
-            name = student.name
-        )
+        val (bonusPoint, minusPoint) =
+            queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(student.gcn, student.name)
 
         val roomMates = queryStudentPort.queryUserByRoomNumberAndSchoolId(
             roomNumber = student.roomNumber,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -2,14 +2,14 @@ package team.aliens.dms.domain.manager.usecase
 
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.manager.dto.GetStudentDetailsResponse
+import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
 import team.aliens.dms.domain.manager.spi.ManagerQueryPointPort
 import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
-import team.aliens.dms.domain.student.exception.StudentNotFoundException
-import java.util.UUID
-import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
 import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.manager.spi.QueryManagerPort
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import java.util.UUID
 
 @ReadOnlyUseCase
 class QueryStudentDetailsUseCase(
@@ -29,8 +29,7 @@ class QueryStudentDetailsUseCase(
             throw SchoolMismatchException
         }
 
-        val bonusPoint = queryPointPort.queryTotalBonusPoint(studentId)
-        val minusPoint = queryPointPort.queryTotalMinusPoint(studentId)
+        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByStudent(student)
 
         val roomMates = queryStudentPort.queryUserByRoomNumberAndSchoolId(
             roomNumber = student.roomNumber,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -29,7 +29,10 @@ class QueryStudentDetailsUseCase(
             throw SchoolMismatchException
         }
 
-        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByStudent(student)
+        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(
+            gcn = student.gcn,
+            name = student.name
+        )
 
         val roomMates = queryStudentPort.queryUserByRoomNumberAndSchoolId(
             roomNumber = student.roomNumber,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
@@ -9,7 +9,7 @@ data class QueryPointHistoryResponse(
     val points: List<Point>
 ) {
     data class Point(
-        val pointId: UUID,
+        val pointHistoryId: UUID,
         val date: LocalDate,
         val type: PointType,
         val name: String,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
@@ -2,14 +2,12 @@ package team.aliens.dms.domain.point.dto
 
 import team.aliens.dms.domain.point.model.PointType
 import java.time.LocalDate
-import java.util.UUID
 
 data class QueryPointHistoryResponse(
     val totalPoint: Int,
     val points: List<Point>
 ) {
     data class Point(
-        val pointHistoryId: UUID,
         val date: LocalDate,
         val type: PointType,
         val name: String,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/PointQueryStudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/PointQueryStudentPort.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.point.spi
+
+import team.aliens.dms.domain.student.model.Student
+import java.util.UUID
+
+interface PointQueryStudentPort {
+
+    fun queryStudentById(studentId: UUID): Student?
+
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -2,14 +2,25 @@ package team.aliens.dms.domain.point.spi
 
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
-import team.aliens.dms.domain.student.model.Student
 
 interface QueryPointPort {
 
-    fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int>
+    fun queryBonusAndMinusTotalPointByGcnAndStudentName(
+        gcn: String,
+        studentName: String,
+    ): Pair<Int, Int>
 
-    fun queryGrantedPointHistoryByStudentAndType(student: Student, type: PointType): List<QueryPointHistoryResponse.Point>
+    fun queryPointHistoryByGcnAndStudentNameAndType(
+        gcn: String,
+        studentName: String,
+        type: PointType,
+        isCancel: Boolean? = null
+    ): List<QueryPointHistoryResponse.Point>
 
-    fun queryGrantedPointHistoryByStudent(student: Student): List<QueryPointHistoryResponse.Point>
+    fun queryPointHistoryByGcnAndStudentName(
+        gcn: String,
+        studentName: String,
+        isCancel: Boolean? = null
+    ): List<QueryPointHistoryResponse.Point>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -1,10 +1,8 @@
 package team.aliens.dms.domain.point.spi
 
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
-import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.student.model.Student
-import java.util.UUID
 
 interface QueryPointPort {
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -1,7 +1,5 @@
 package team.aliens.dms.domain.point.spi
 
-import team.aliens.dms.common.dto.PageData
-import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -13,13 +13,7 @@ interface QueryPointPort {
     fun queryPointHistoryByStudentGcnAndNameAndType(
         gcn: String,
         studentName: String,
-        type: PointType,
-        isCancel: Boolean? = null
-    ): List<QueryPointHistoryResponse.Point>
-
-    fun queryPointHistoryByStudentGcnAndName(
-        gcn: String,
-        studentName: String,
+        type: PointType?,
         isCancel: Boolean? = null
     ): List<QueryPointHistoryResponse.Point>
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -1,13 +1,19 @@
 package team.aliens.dms.domain.point.spi
 
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
+import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.student.model.Student
 import java.util.UUID
 
 interface QueryPointPort {
 
-    fun queryPointHistoryByStudentIdAndType(studentId: UUID, type: PointType): List<QueryPointHistoryResponse.Point>
+    fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int>
 
-    fun queryAllPointHistoryByStudentId(studentId: UUID): List<QueryPointHistoryResponse.Point>
+    fun queryGrantedPointHistoryByStudentAndType(student: Student, type: PointType): List<QueryPointHistoryResponse.Point>
+
+    fun queryGrantedPointHistoryByStudent(student: Student): List<QueryPointHistoryResponse.Point>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -7,7 +7,7 @@ interface QueryPointPort {
 
     fun queryBonusAndMinusTotalPointByStudentGcnAndName(
         gcn: String,
-        studentName: String,
+        studentName: String
     ): Pair<Int, Int>
 
     fun queryPointHistoryByStudentGcnAndNameAndType(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointPort.kt
@@ -5,19 +5,19 @@ import team.aliens.dms.domain.point.model.PointType
 
 interface QueryPointPort {
 
-    fun queryBonusAndMinusTotalPointByGcnAndStudentName(
+    fun queryBonusAndMinusTotalPointByStudentGcnAndName(
         gcn: String,
         studentName: String,
     ): Pair<Int, Int>
 
-    fun queryPointHistoryByGcnAndStudentNameAndType(
+    fun queryPointHistoryByStudentGcnAndNameAndType(
         gcn: String,
         studentName: String,
         type: PointType,
         isCancel: Boolean? = null
     ): List<QueryPointHistoryResponse.Point>
 
-    fun queryPointHistoryByGcnAndStudentName(
+    fun queryPointHistoryByStudentGcnAndName(
         gcn: String,
         studentName: String,
         isCancel: Boolean? = null

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
@@ -24,14 +24,14 @@ class QueryPointHistoryUseCase(
         val pointType = PointRequestType.toPointType(type)
 
         val pointHistories = if (pointType != null) {
-            queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(
+            queryPointPort.queryPointHistoryByStudentGcnAndNameAndType(
                 gcn = gcn,
                 studentName = name,
                 type = pointType,
                 isCancel = false
             )
         } else {
-            queryPointPort.queryPointHistoryByGcnAndStudentName(
+            queryPointPort.queryPointHistoryByStudentGcnAndName(
                 gcn = gcn,
                 studentName = name,
                 isCancel = false
@@ -39,7 +39,7 @@ class QueryPointHistoryUseCase(
         }
 
         val (bonusTotal, minusTotal) =
-            queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name)
+            queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name)
 
         return QueryPointHistoryResponse(
             totalPoint = getTotalPoint(type, bonusTotal, minusTotal),

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
@@ -24,9 +24,18 @@ class QueryPointHistoryUseCase(
         val pointType = PointRequestType.toPointType(type)
 
         val pointHistories = if (pointType != null) {
-            queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, pointType)
+            queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(
+                gcn = gcn,
+                studentName = name,
+                type = pointType,
+                isCancel = false
+            )
         } else {
-            queryPointPort.queryPointHistoryByGcnAndStudentName(gcn, name)
+            queryPointPort.queryPointHistoryByGcnAndStudentName(
+                gcn = gcn,
+                studentName = name,
+                isCancel = false
+            )
         }
 
         val (bonusTotal, minusTotal) =

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
@@ -3,42 +3,48 @@ package team.aliens.dms.domain.point.usecase
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
-import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointPort
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
 
 @ReadOnlyUseCase
 class QueryPointHistoryUseCase(
     private val securityPort: PointSecurityPort,
+    private val queryStudentPort: PointQueryStudentPort,
     private val queryPointPort: QueryPointPort
 ) {
 
     fun execute(type: PointRequestType): QueryPointHistoryResponse {
-        val pointType = PointRequestType.toPointType(type)
         val currentStudentId = securityPort.getCurrentUserId()
+        val currentStudent = queryStudentPort.queryStudentById(currentStudentId) ?: throw StudentNotFoundException
 
-        val pointHistory = if (pointType != null) {
-            queryPointPort.queryPointHistoryByStudentIdAndType(currentStudentId, pointType)
+        val pointType = PointRequestType.toPointType(type)
+        val pointHistories = if (pointType != null) {
+            queryPointPort.queryGrantedPointHistoryByStudentAndType(currentStudent, pointType)
         } else {
-            queryPointPort.queryAllPointHistoryByStudentId(currentStudentId)
+            queryPointPort.queryGrantedPointHistoryByStudent(currentStudent)
         }
 
-        val totalPoint = pointHistory.sumOf {
-            if (type == PointRequestType.ALL && it.type == PointType.MINUS) {
-                it.score * -1
-            } else {
-                it.score
-            }
-        }
+        val (bonusTotal, minusTotal) =
+            queryPointPort.queryBonusAndMinusTotalPointByStudent(currentStudent)
 
         return QueryPointHistoryResponse(
-            /**
-             * BONUS -> 상점의 총합 ex) 상점 3점 = 3
-             * MINUS -> 벌점의 총합 ex) 벌점 4점 = 4
-             * ALL -> 상점 + 벌점의 총합 상점 3점, 벌점 4점 = -1
-             **/
-            totalPoint = totalPoint,
-            points = pointHistory
+            totalPoint = getTotalPoint(type, bonusTotal, minusTotal),
+            points = pointHistories
         )
+    }
+
+    private fun getTotalPoint(
+        type: PointRequestType,
+        bonusTotal: Int,
+        minusTotal: Int
+    ): Int {
+        val totalPoint = when (type) {
+            PointRequestType.BONUS -> bonusTotal
+            PointRequestType.MINUS -> minusTotal
+            PointRequestType.ALL -> bonusTotal - minusTotal
+        }
+        return totalPoint
     }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
@@ -23,20 +23,13 @@ class QueryPointHistoryUseCase(
         val name = currentStudent.name
         val pointType = PointRequestType.toPointType(type)
 
-        val pointHistories = if (pointType != null) {
+        val pointHistories =
             queryPointPort.queryPointHistoryByStudentGcnAndNameAndType(
                 gcn = gcn,
                 studentName = name,
                 type = pointType,
                 isCancel = false
             )
-        } else {
-            queryPointPort.queryPointHistoryByStudentGcnAndName(
-                gcn = gcn,
-                studentName = name,
-                isCancel = false
-            )
-        }
 
         val (bonusTotal, minusTotal) =
             queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
@@ -19,15 +19,18 @@ class QueryPointHistoryUseCase(
         val currentStudentId = securityPort.getCurrentUserId()
         val currentStudent = queryStudentPort.queryStudentById(currentStudentId) ?: throw StudentNotFoundException
 
+        val gcn = currentStudent.gcn
+        val name = currentStudent.name
         val pointType = PointRequestType.toPointType(type)
+
         val pointHistories = if (pointType != null) {
-            queryPointPort.queryGrantedPointHistoryByStudentAndType(currentStudent, pointType)
+            queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, pointType)
         } else {
-            queryPointPort.queryGrantedPointHistoryByStudent(currentStudent)
+            queryPointPort.queryPointHistoryByGcnAndStudentName(gcn, name)
         }
 
         val (bonusTotal, minusTotal) =
-            queryPointPort.queryBonusAndMinusTotalPointByStudent(currentStudent)
+            queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name)
 
         return QueryPointHistoryResponse(
             totalPoint = getTotalPoint(type, bonusTotal, minusTotal),

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentPort.kt
@@ -4,6 +4,7 @@ import team.aliens.dms.domain.auth.spi.AuthQueryStudentPort
 import team.aliens.dms.domain.manager.spi.ManagerCommandStudentPort
 import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
 import team.aliens.dms.domain.meal.spi.MealQueryStudentPort
+import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryStudentPort
 import team.aliens.dms.domain.user.spi.UserQueryStudentPort
 
@@ -15,5 +16,6 @@ interface StudentPort :
     UserQueryStudentPort,
     ManagerQueryStudentPort,
     ManagerCommandStudentPort,
-    StudyRoomQueryStudentPort {
+    StudyRoomQueryStudentPort,
+    PointQueryStudentPort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryPointPort.kt
@@ -1,11 +1,9 @@
 package team.aliens.dms.domain.student.spi
 
-import java.util.UUID
+import team.aliens.dms.domain.student.model.Student
 
 interface StudentQueryPointPort {
 
-    fun queryTotalBonusPoint(studentId: UUID): Int
-
-    fun queryTotalMinusPoint(studentId: UUID): Int
+    fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryPointPort.kt
@@ -1,9 +1,7 @@
 package team.aliens.dms.domain.student.spi
 
-import team.aliens.dms.domain.student.model.Student
-
 interface StudentQueryPointPort {
 
-    fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int>
+    fun queryBonusAndMinusTotalPointByGcnAndStudentName(gcn: String, studentName: String): Pair<Int, Int>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryPointPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryPointPort.kt
@@ -2,6 +2,6 @@ package team.aliens.dms.domain.student.spi
 
 interface StudentQueryPointPort {
 
-    fun queryBonusAndMinusTotalPointByGcnAndStudentName(gcn: String, studentName: String): Pair<Int, Int>
+    fun queryBonusAndMinusTotalPointByStudentGcnAndName(gcn: String, studentName: String): Pair<Int, Int>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
@@ -27,10 +27,8 @@ class StudentMyPageUseCase(
         val student = queryStudentPort.queryStudentById(currentUserId) ?: throw StudentNotFoundException
         val school = querySchoolPort.querySchoolById(student.schoolId) ?: throw SchoolNotFoundException
 
-        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(
-            gcn = student.gcn,
-            name = student.name
-        )
+        val (bonusPoint, minusPoint) =
+            queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(student.gcn, student.name)
 
         val phrase = randomPhrase(bonusPoint, minusPoint)
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.domain.student.usecase
 
-import java.security.SecureRandom
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.point.model.Phrase
 import team.aliens.dms.domain.point.model.PointType
@@ -12,6 +11,7 @@ import team.aliens.dms.domain.student.spi.QueryStudentPort
 import team.aliens.dms.domain.student.spi.StudentQueryPointPort
 import team.aliens.dms.domain.student.spi.StudentQuerySchoolPort
 import team.aliens.dms.domain.student.spi.StudentSecurityPort
+import java.security.SecureRandom
 
 @ReadOnlyUseCase
 class StudentMyPageUseCase(
@@ -27,8 +27,7 @@ class StudentMyPageUseCase(
         val student = queryStudentPort.queryStudentById(currentUserId) ?: throw StudentNotFoundException
         val school = querySchoolPort.querySchoolById(student.schoolId) ?: throw SchoolNotFoundException
 
-        val bonusPoint = queryPointPort.queryTotalBonusPoint(student.id)
-        val minusPoint = queryPointPort.queryTotalMinusPoint(student.id)
+        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByStudent(student)
 
         val phrase = randomPhrase(bonusPoint, minusPoint)
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
@@ -28,7 +28,7 @@ class StudentMyPageUseCase(
         val school = querySchoolPort.querySchoolById(student.schoolId) ?: throw SchoolNotFoundException
 
         val (bonusPoint, minusPoint) =
-            queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(student.gcn, student.name)
+            queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(student.gcn, student.name)
 
         val phrase = randomPhrase(bonusPoint, minusPoint)
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCase.kt
@@ -27,7 +27,10 @@ class StudentMyPageUseCase(
         val student = queryStudentPort.queryStudentById(currentUserId) ?: throw StudentNotFoundException
         val school = querySchoolPort.querySchoolById(student.schoolId) ?: throw SchoolNotFoundException
 
-        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByStudent(student)
+        val (bonusPoint, minusPoint) = queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(
+            gcn = student.gcn,
+            name = student.name
+        )
 
         val phrase = randomPhrase(bonusPoint, minusPoint)
 

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
@@ -75,6 +75,9 @@ class QueryStudentDetailsUseCaseTests {
         )
     }
 
+    private val gcn = studentStub.gcn
+    private val name = studentStub.name
+
     private val responseStub by lazy {
         GetStudentDetailsResponse(
             name = studentStub.name,
@@ -105,7 +108,7 @@ class QueryStudentDetailsUseCaseTests {
         given(queryStudentPort.queryStudentById(studentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
             .willReturn(Pair(bonusPoint, minusPoint))
 
         given(queryStudentPort.queryUserByRoomNumberAndSchoolId(studentStub.roomNumber, studentStub.schoolId))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
@@ -1,8 +1,10 @@
 package team.aliens.dms.domain.manager.usecase
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
@@ -78,6 +80,21 @@ class QueryStudentDetailsUseCaseTests {
     private val gcn = studentStub.gcn
     private val name = studentStub.name
 
+    private val roomMateStub by lazy {
+        Student(
+            id = UUID.randomUUID(),
+            roomId = UUID.randomUUID(),
+            roomNumber = 216,
+            schoolId = schoolId,
+            grade = 2,
+            classRoom = 1,
+            number = 21,
+            name = "김철수",
+            profileImageUrl = "profile image url",
+            sex = Sex.FEMALE
+        )
+    }
+
     private val responseStub by lazy {
         GetStudentDetailsResponse(
             name = studentStub.name,
@@ -112,14 +129,19 @@ class QueryStudentDetailsUseCaseTests {
             .willReturn(Pair(bonusPoint, minusPoint))
 
         given(queryStudentPort.queryUserByRoomNumberAndSchoolId(studentStub.roomNumber, studentStub.schoolId))
-            .willReturn(listOf(studentStub))
+            .willReturn(listOf(studentStub, roomMateStub))
 
         // when
         val response = queryStudentDetailsUseCase.execute(studentId)
 
         // then
-        assertThat(response).isNotNull
-        assertThat(response.roomMates.isEmpty())
+        assertAll(
+            { assertThat(response).isNotNull },
+            { assertThat(response.roomMates.isNotEmpty()) },
+            { assertEquals(response.roomMates[0].id, roomMateStub.id) },
+            { assertEquals(response.roomMates[0].name, roomMateStub.name) },
+            { assertEquals(response.roomMates[0].profileImageUrl, roomMateStub.profileImageUrl) }
+        )
     }
 
     @Test

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
@@ -125,7 +125,7 @@ class QueryStudentDetailsUseCaseTests {
         given(queryStudentPort.queryStudentById(studentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(bonusPoint, minusPoint))
 
         given(queryStudentPort.queryUserByRoomNumberAndSchoolId(studentStub.roomNumber, studentStub.schoolId))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
@@ -119,6 +119,7 @@ class QueryStudentDetailsUseCaseTests {
 
         // then
         assertThat(response).isNotNull
+        assertThat(response.roomMates.isEmpty())
     }
 
     @Test

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
@@ -9,17 +9,17 @@ import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.manager.dto.GetStudentDetailsResponse
-import team.aliens.dms.domain.manager.spi.ManagerQueryPointPort
-import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
-import team.aliens.dms.domain.student.exception.StudentNotFoundException
-import team.aliens.dms.domain.student.model.Student
-import java.util.UUID
 import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
 import team.aliens.dms.domain.manager.model.Manager
+import team.aliens.dms.domain.manager.spi.ManagerQueryPointPort
+import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
 import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.manager.spi.QueryManagerPort
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.model.Student
+import java.util.UUID
 
 @ExtendWith(SpringExtension::class)
 class QueryStudentDetailsUseCaseTests {
@@ -105,11 +105,8 @@ class QueryStudentDetailsUseCaseTests {
         given(queryStudentPort.queryStudentById(studentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryTotalBonusPoint(studentStub.id))
-            .willReturn(bonusPoint)
-
-        given(queryPointPort.queryTotalMinusPoint(studentStub.id))
-            .willReturn(minusPoint)
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+            .willReturn(Pair(bonusPoint, minusPoint))
 
         given(queryStudentPort.queryUserByRoomNumberAndSchoolId(studentStub.roomNumber, studentStub.schoolId))
             .willReturn(listOf(studentStub))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -86,7 +86,7 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.BONUS))
+        given(queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.BONUS, false))
             .willReturn(pointStubs)
 
         given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
@@ -94,6 +94,8 @@ class QueryPointHistoryUseCaseTests {
 
         // when
         val response = queryPointHistoryUseCase.execute(PointRequestType.BONUS)
+
+        println(response)
 
         // then
         assertAll(
@@ -128,7 +130,8 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(/* methodCall = */ queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.MINUS)).willReturn(pointStubs)
+        given(queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.MINUS, false))
+            .willReturn(pointStubs)
 
         given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
             .willReturn(Pair(15, 10))
@@ -169,7 +172,7 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryPointHistoryByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryPointHistoryByGcnAndStudentName(gcn, name, false))
             .willReturn(pointStubs)
 
         given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -57,6 +57,9 @@ class QueryPointHistoryUseCaseTests {
         )
     }
 
+    private val gcn = studentStub.gcn
+    private val name = studentStub.name
+
     @Test
     fun `상벌점 내역 조회 성공(BONUS)`() {
         // given
@@ -83,10 +86,10 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryGrantedPointHistoryByStudentAndType(studentStub, PointType.BONUS))
+        given(queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.BONUS))
             .willReturn(pointStubs)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
             .willReturn(Pair(15, 0))
 
         // when
@@ -125,10 +128,9 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryGrantedPointHistoryByStudentAndType(studentStub, PointType.MINUS))
-            .willReturn(pointStubs)
+        given(/* methodCall = */ queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.MINUS)).willReturn(pointStubs)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
             .willReturn(Pair(15, 10))
 
         // when
@@ -167,10 +169,10 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryGrantedPointHistoryByStudent(studentStub))
+        given(queryPointPort.queryPointHistoryByGcnAndStudentName(gcn, name))
             .willReturn(pointStubs)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
             .willReturn(Pair(10, 5))
 
         // when

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -168,7 +168,7 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryPointHistoryByStudentGcnAndName(gcn, name, false))
+        given(queryPointPort.queryPointHistoryByStudentGcnAndNameAndType(gcn, name, null, false))
             .willReturn(pointStubs)
 
         given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -14,6 +15,7 @@ import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointPort
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.Student
 import java.time.LocalDate
@@ -65,14 +67,12 @@ class QueryPointHistoryUseCaseTests {
         // given
         val pointStubs = listOf(
             QueryPointHistoryResponse.Point(
-                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
             QueryPointHistoryResponse.Point(
-                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name2",
@@ -109,14 +109,12 @@ class QueryPointHistoryUseCaseTests {
         // given
         val pointStubs = listOf(
             QueryPointHistoryResponse.Point(
-                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name",
                 score = 5
             ),
             QueryPointHistoryResponse.Point(
-                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",
@@ -151,14 +149,12 @@ class QueryPointHistoryUseCaseTests {
         // given
         val pointStubs = listOf(
             QueryPointHistoryResponse.Point(
-                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
             QueryPointHistoryResponse.Point(
-                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",
@@ -186,5 +182,20 @@ class QueryPointHistoryUseCaseTests {
             { assert(response.totalPoint == 5) },
             { assertThat(response.points).isNotEmpty }
         )
+    }
+
+    @Test
+    fun `학생이 존재하지 않음`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(currentStudentId)
+
+        given(queryStudentPort.queryStudentById(currentStudentId))
+            .willReturn(null)
+
+        // when & then
+        assertThrows<StudentNotFoundException> {
+            queryPointHistoryUseCase.execute(PointRequestType.ALL)
+        }
     }
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -86,10 +86,10 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.BONUS, false))
+        given(queryPointPort.queryPointHistoryByStudentGcnAndNameAndType(gcn, name, PointType.BONUS, false))
             .willReturn(pointStubs)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(15, 0))
 
         // when
@@ -128,10 +128,10 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryPointHistoryByGcnAndStudentNameAndType(gcn, name, PointType.MINUS, false))
+        given(queryPointPort.queryPointHistoryByStudentGcnAndNameAndType(gcn, name, PointType.MINUS, false))
             .willReturn(pointStubs)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(15, 10))
 
         // when
@@ -168,10 +168,10 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointPort.queryPointHistoryByGcnAndStudentName(gcn, name, false))
+        given(queryPointPort.queryPointHistoryByStudentGcnAndName(gcn, name, false))
             .willReturn(pointStubs)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(10, 5))
 
         // when

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -11,8 +11,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointPort
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.model.Student
 import java.time.LocalDate
 import java.util.UUID
 
@@ -23,6 +26,9 @@ class QueryPointHistoryUseCaseTests {
     private lateinit var securityPort: PointSecurityPort
 
     @MockBean
+    private lateinit var queryStudentPort: PointQueryStudentPort
+
+    @MockBean
     private lateinit var queryPointPort: QueryPointPort
 
     private lateinit var queryPointHistoryUseCase: QueryPointHistoryUseCase
@@ -30,25 +36,40 @@ class QueryPointHistoryUseCaseTests {
     @BeforeEach
     fun setUp() {
         queryPointHistoryUseCase = QueryPointHistoryUseCase(
-            securityPort, queryPointPort
+            securityPort, queryStudentPort, queryPointPort
         )
     }
 
     private val currentStudentId = UUID.randomUUID()
+
+    private val studentStub by lazy {
+        Student(
+            id = currentStudentId,
+            roomId = UUID.randomUUID(),
+            roomNumber = 123,
+            schoolId = UUID.randomUUID(),
+            grade = 2,
+            classRoom = 1,
+            number = 6,
+            name = "이름",
+            profileImageUrl = "https://~",
+            sex = Sex.FEMALE
+        )
+    }
 
     @Test
     fun `상벌점 내역 조회 성공(BONUS)`() {
         // given
         val pointStubs = listOf(
             QueryPointHistoryResponse.Point(
-                pointId = UUID.randomUUID(),
+                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
             QueryPointHistoryResponse.Point(
-                pointId = UUID.randomUUID(),
+                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name2",
@@ -59,8 +80,14 @@ class QueryPointHistoryUseCaseTests {
         given(securityPort.getCurrentUserId())
             .willReturn(currentStudentId)
 
-        given(queryPointPort.queryPointHistoryByStudentIdAndType(currentStudentId, PointType.BONUS))
+        given(queryStudentPort.queryStudentById(currentStudentId))
+            .willReturn(studentStub)
+
+        given(queryPointPort.queryGrantedPointHistoryByStudentAndType(studentStub, PointType.BONUS))
             .willReturn(pointStubs)
+
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+            .willReturn(Pair(15, 0))
 
         // when
         val response = queryPointHistoryUseCase.execute(PointRequestType.BONUS)
@@ -77,14 +104,14 @@ class QueryPointHistoryUseCaseTests {
         // given
         val pointStubs = listOf(
             QueryPointHistoryResponse.Point(
-                pointId = UUID.randomUUID(),
+                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name",
                 score = 5
             ),
             QueryPointHistoryResponse.Point(
-                pointId = UUID.randomUUID(),
+                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",
@@ -95,8 +122,14 @@ class QueryPointHistoryUseCaseTests {
         given(securityPort.getCurrentUserId())
             .willReturn(currentStudentId)
 
-        given(queryPointPort.queryPointHistoryByStudentIdAndType(currentStudentId, PointType.MINUS))
+        given(queryStudentPort.queryStudentById(currentStudentId))
+            .willReturn(studentStub)
+
+        given(queryPointPort.queryGrantedPointHistoryByStudentAndType(studentStub, PointType.MINUS))
             .willReturn(pointStubs)
+
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+            .willReturn(Pair(15, 10))
 
         // when
         val response = queryPointHistoryUseCase.execute(PointRequestType.MINUS)
@@ -113,14 +146,14 @@ class QueryPointHistoryUseCaseTests {
         // given
         val pointStubs = listOf(
             QueryPointHistoryResponse.Point(
-                pointId = UUID.randomUUID(),
+                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
             QueryPointHistoryResponse.Point(
-                pointId = UUID.randomUUID(),
+                pointHistoryId = UUID.randomUUID(),
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",
@@ -131,8 +164,14 @@ class QueryPointHistoryUseCaseTests {
         given(securityPort.getCurrentUserId())
             .willReturn(currentStudentId)
 
-        given(queryPointPort.queryAllPointHistoryByStudentId(currentStudentId))
+        given(queryStudentPort.queryStudentById(currentStudentId))
+            .willReturn(studentStub)
+
+        given(queryPointPort.queryGrantedPointHistoryByStudent(studentStub))
             .willReturn(pointStubs)
+
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+            .willReturn(Pair(10, 5))
 
         // when
         val response = queryPointHistoryUseCase.execute(PointRequestType.ALL)

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
@@ -109,7 +109,7 @@ class StudentMyPageUseCaseTests {
         given(querySchoolPort.querySchoolById(studentStub.schoolId))
             .willReturn(schoolStub)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(1, 1))
 
         given(queryPhrasePort.queryPhraseAllByPointTypeAndStandardPoint(type = PointType.BONUS, point = 1))
@@ -140,7 +140,7 @@ class StudentMyPageUseCaseTests {
         given(querySchoolPort.querySchoolById(studentStub.schoolId))
             .willReturn(schoolStub)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(1, 1))
 
         given(queryPhrasePort.queryPhraseAllByPointTypeAndStandardPoint(type = PointType.BONUS, point = 1))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
@@ -1,14 +1,20 @@
 package team.aliens.dms.domain.student.usecase
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.point.model.Phrase
+import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.StudentQueryPhrasePort
 import team.aliens.dms.domain.school.exception.SchoolNotFoundException
 import team.aliens.dms.domain.school.model.School
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.student.spi.QueryStudentPort
 import team.aliens.dms.domain.student.spi.StudentQueryPointPort
@@ -16,12 +22,6 @@ import team.aliens.dms.domain.student.spi.StudentQuerySchoolPort
 import team.aliens.dms.domain.student.spi.StudentSecurityPort
 import java.time.LocalDate
 import java.util.UUID
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.assertThrows
-import team.aliens.dms.domain.point.model.Phrase
-import team.aliens.dms.domain.point.model.PointType
-import team.aliens.dms.domain.point.spi.StudentQueryPhrasePort
-import team.aliens.dms.domain.student.model.Sex
 
 @ExtendWith(SpringExtension::class)
 class StudentMyPageUseCaseTests {
@@ -105,11 +105,8 @@ class StudentMyPageUseCaseTests {
         given(querySchoolPort.querySchoolById(studentStub.schoolId))
             .willReturn(schoolStub)
 
-        given(queryPointPort.queryTotalBonusPoint(studentStub.id))
-            .willReturn(1)
-
-        given(queryPointPort.queryTotalMinusPoint(studentStub.id))
-            .willReturn(1)
+        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+            .willReturn(Pair(1, 1))
 
         given(queryPhrasePort.queryPhraseAllByPointTypeAndStandardPoint(type = PointType.BONUS, point = 1))
             .willReturn(listOf(phraseStub))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
@@ -68,6 +68,9 @@ class StudentMyPageUseCaseTests {
         )
     }
 
+    private val gcn = studentStub.gcn
+    private val name = studentStub.name
+
     private val schoolStub by lazy {
         School(
             id = schoolId,
@@ -105,7 +108,7 @@ class StudentMyPageUseCaseTests {
         given(querySchoolPort.querySchoolById(studentStub.schoolId))
             .willReturn(schoolStub)
 
-        given(queryPointPort.queryBonusAndMinusTotalPointByStudent(studentStub))
+        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
             .willReturn(Pair(1, 1))
 
         given(queryPhrasePort.queryPhraseAllByPointTypeAndStandardPoint(type = PointType.BONUS, point = 1))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentMyPageUseCaseTests.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.student.usecase
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -122,6 +123,38 @@ class StudentMyPageUseCaseTests {
 
         // then
         assertThat(response).isNotNull
+    }
+
+    @Test
+    fun `문구 없는 경우`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(currentUserId)
+
+        given(queryStudentPort.queryStudentById(currentUserId))
+            .willReturn(studentStub)
+
+        given(queryStudentPort.queryStudentById(currentUserId))
+            .willReturn(studentStub)
+
+        given(querySchoolPort.querySchoolById(studentStub.schoolId))
+            .willReturn(schoolStub)
+
+        given(queryPointPort.queryBonusAndMinusTotalPointByGcnAndStudentName(gcn, name))
+            .willReturn(Pair(1, 1))
+
+        given(queryPhrasePort.queryPhraseAllByPointTypeAndStandardPoint(type = PointType.BONUS, point = 1))
+            .willReturn(listOf())
+
+        given(queryPhrasePort.queryPhraseAllByPointTypeAndStandardPoint(type = PointType.MINUS, point = 1))
+            .willReturn(listOf())
+
+        // when
+        val response = studentMyPageUseCase.execute()
+
+        // then
+        assertThat(response).isNotNull
+        assertEquals(response.phrase, Phrase.NO_PHRASE)
     }
 
     @Test

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -9,10 +9,24 @@ data class PointHistory(
 
     val id: UUID = UUID(0, 0),
 
-    val pointOptionId: UUID,
+    val studentName: String,
 
-    val studentId: UUID,
+    val gcn: String,
 
-    val createdAt: LocalDateTime?
+    val bonusTotal: Int,
+
+    val minusTotal: Int,
+
+    val isCancel: Boolean,
+
+    val name: String,
+
+    val score: Int,
+
+    val type: PointType,
+
+    val createdAt: LocalDateTime,
+
+    val schoolId: UUID,
 
 )

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -27,6 +27,6 @@ data class PointHistory(
 
     val createdAt: LocalDateTime,
 
-    val schoolId: UUID,
+    val schoolId: UUID
 
 )

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -11,7 +11,7 @@ data class PointHistory(
 
     val studentName: String,
 
-    val gcn: String,
+    val studentGcn: String,
 
     val bonusTotal: Int,
 
@@ -19,11 +19,11 @@ data class PointHistory(
 
     val isCancel: Boolean,
 
-    val name: String,
+    val pointName: String,
 
-    val score: Int,
+    val pointScore: Int,
 
-    val type: PointType,
+    val pointType: PointType,
 
     val createdAt: LocalDateTime,
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -1,7 +1,6 @@
 package team.aliens.dms.persistence.point
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
@@ -12,7 +11,7 @@ import team.aliens.dms.persistence.point.entity.QPointOptionJpaEntity.pointOptio
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
 import team.aliens.dms.persistence.point.repository.vo.QQueryPointHistoryVO
-import java.util.UUID
+import team.aliens.dms.persistence.point.repository.vo.QueryAllPointHistoryVO
 
 @Component
 class PointPersistenceAdapter(

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -39,7 +39,7 @@ class PointPersistenceAdapter(
     override fun queryPointHistoryByStudentGcnAndNameAndType(
         gcn: String,
         studentName: String,
-        type: PointType,
+        type: PointType?,
         isCancel: Boolean?
     ): List<QueryPointHistoryResponse.Point> {
         return queryFactory
@@ -55,39 +55,7 @@ class PointPersistenceAdapter(
             .where(
                 pointHistoryJpaEntity.studentGcn.eq(gcn),
                 pointHistoryJpaEntity.studentName.eq(studentName),
-                pointHistoryJpaEntity.pointType.eq(type),
-                isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
-            )
-            .orderBy(pointHistoryJpaEntity.createdAt.desc())
-            .fetch()
-            .map {
-                QueryPointHistoryResponse.Point(
-                    date = it.date.toLocalDate(),
-                    type = it.pointType,
-                    name = it.pointName,
-                    score = it.pointScore
-                )
-            }
-    }
-
-    override fun queryPointHistoryByStudentGcnAndName(
-        gcn: String,
-        studentName: String,
-        isCancel: Boolean?
-    ): List<QueryPointHistoryResponse.Point> {
-        return queryFactory
-            .select(
-                QQueryPointHistoryVO(
-                    pointHistoryJpaEntity.createdAt!!,
-                    pointHistoryJpaEntity.pointType,
-                    pointHistoryJpaEntity.pointName,
-                    pointHistoryJpaEntity.pointScore
-                )
-            )
-            .from(pointHistoryJpaEntity)
-            .where(
-                pointHistoryJpaEntity.studentGcn.eq(gcn),
-                pointHistoryJpaEntity.studentName.eq(studentName),
+                type?.let {pointHistoryJpaEntity.pointType.eq(it) },
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
             )
             .orderBy(pointHistoryJpaEntity.createdAt.desc())

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -9,7 +9,6 @@ import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHist
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
 import team.aliens.dms.persistence.point.repository.vo.QQueryPointHistoryVO
-import team.aliens.dms.persistence.point.repository.vo.QueryAllPointHistoryVO
 
 @Component
 class PointPersistenceAdapter(
@@ -17,10 +16,6 @@ class PointPersistenceAdapter(
     private val pointHistoryRepository: PointHistoryJpaRepository,
     private val queryFactory: JPAQueryFactory
 ) : PointPort {
-
-    override fun queryPointHistoryById(pointHistoryId: UUID) = pointHistoryMapper.toDomain(
-        pointHistoryRepository.findByIdOrNull(pointHistoryId)
-    )
 
     override fun queryBonusAndMinusTotalPointByGcnAndStudentName(
         gcn: String,

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -19,7 +19,7 @@ class PointPersistenceAdapter(
 
     override fun queryBonusAndMinusTotalPointByStudentGcnAndName(
         gcn: String,
-        studentName: String,
+        studentName: String
     ): Pair<Int, Int> {
         val lastHistory = queryFactory
             .selectFrom(pointHistoryJpaEntity)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -46,7 +46,6 @@ class PointPersistenceAdapter(
         return queryFactory
             .select(
                 QQueryPointHistoryVO(
-                    pointHistoryJpaEntity.id,
                     pointHistoryJpaEntity.createdAt!!,
                     pointHistoryJpaEntity.type,
                     pointHistoryJpaEntity.name,
@@ -65,7 +64,6 @@ class PointPersistenceAdapter(
             .fetch()
             .map {
                 QueryPointHistoryResponse.Point(
-                    pointHistoryId = it.pointId,
                     date = it.date.toLocalDate(),
                     type = it.type,
                     name = it.name,
@@ -82,7 +80,6 @@ class PointPersistenceAdapter(
         return queryFactory
             .select(
                 QQueryPointHistoryVO(
-                    pointHistoryJpaEntity.id,
                     pointHistoryJpaEntity.createdAt!!,
                     pointHistoryJpaEntity.type,
                     pointHistoryJpaEntity.name,
@@ -100,7 +97,6 @@ class PointPersistenceAdapter(
             .fetch()
             .map {
                 QueryPointHistoryResponse.Point(
-                    pointHistoryId = it.pointId,
                     date = it.date.toLocalDate(),
                     type = it.type,
                     name = it.name,

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -17,7 +17,7 @@ class PointPersistenceAdapter(
     private val queryFactory: JPAQueryFactory
 ) : PointPort {
 
-    override fun queryBonusAndMinusTotalPointByGcnAndStudentName(
+    override fun queryBonusAndMinusTotalPointByStudentGcnAndName(
         gcn: String,
         studentName: String,
     ): Pair<Int, Int> {
@@ -25,8 +25,8 @@ class PointPersistenceAdapter(
             .selectFrom(pointHistoryJpaEntity)
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .where(
-                pointHistoryJpaEntity.gcn.eq(gcn),
-                pointHistoryJpaEntity.name.eq(studentName)
+                pointHistoryJpaEntity.studentGcn.eq(gcn),
+                pointHistoryJpaEntity.studentName.eq(studentName)
             )
             .limit(1)
             .fetchOne()
@@ -37,7 +37,7 @@ class PointPersistenceAdapter(
         return Pair(bonusTotal, minusTotal)
     }
 
-    override fun queryPointHistoryByGcnAndStudentNameAndType(
+    override fun queryPointHistoryByStudentGcnAndNameAndType(
         gcn: String,
         studentName: String,
         type: PointType,
@@ -47,16 +47,16 @@ class PointPersistenceAdapter(
             .select(
                 QQueryPointHistoryVO(
                     pointHistoryJpaEntity.createdAt!!,
-                    pointHistoryJpaEntity.type,
-                    pointHistoryJpaEntity.name,
-                    pointHistoryJpaEntity.score
+                    pointHistoryJpaEntity.pointType,
+                    pointHistoryJpaEntity.pointName,
+                    pointHistoryJpaEntity.pointScore
                 )
             )
             .from(pointHistoryJpaEntity)
             .where(
-                pointHistoryJpaEntity.gcn.eq(gcn),
-                pointHistoryJpaEntity.name.eq(studentName),
-                pointHistoryJpaEntity.type.eq(type),
+                pointHistoryJpaEntity.studentGcn.eq(gcn),
+                pointHistoryJpaEntity.studentName.eq(studentName),
+                pointHistoryJpaEntity.pointType.eq(type),
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
             )
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
@@ -64,14 +64,14 @@ class PointPersistenceAdapter(
             .map {
                 QueryPointHistoryResponse.Point(
                     date = it.date.toLocalDate(),
-                    type = it.type,
-                    name = it.name,
-                    score = it.score
+                    type = it.pointType,
+                    name = it.pointName,
+                    score = it.pointScore
                 )
             }
     }
 
-    override fun queryPointHistoryByGcnAndStudentName(
+    override fun queryPointHistoryByStudentGcnAndName(
         gcn: String,
         studentName: String,
         isCancel: Boolean?
@@ -80,15 +80,15 @@ class PointPersistenceAdapter(
             .select(
                 QQueryPointHistoryVO(
                     pointHistoryJpaEntity.createdAt!!,
-                    pointHistoryJpaEntity.type,
-                    pointHistoryJpaEntity.name,
-                    pointHistoryJpaEntity.score
+                    pointHistoryJpaEntity.pointType,
+                    pointHistoryJpaEntity.pointName,
+                    pointHistoryJpaEntity.pointScore
                 )
             )
             .from(pointHistoryJpaEntity)
             .where(
-                pointHistoryJpaEntity.gcn.eq(gcn),
-                pointHistoryJpaEntity.name.eq(studentName),
+                pointHistoryJpaEntity.studentGcn.eq(gcn),
+                pointHistoryJpaEntity.studentName.eq(studentName),
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
             )
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
@@ -96,9 +96,9 @@ class PointPersistenceAdapter(
             .map {
                 QueryPointHistoryResponse.Point(
                     date = it.date.toLocalDate(),
-                    type = it.type,
-                    name = it.name,
-                    score = it.score
+                    type = it.pointType,
+                    name = it.pointName,
+                    score = it.pointScore
                 )
             }
     }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -54,7 +54,6 @@ class PointPersistenceAdapter(
             )
             .from(pointHistoryJpaEntity)
             .where(
-                pointHistoryJpaEntity.isCancel.eq(false),
                 pointHistoryJpaEntity.gcn.eq(gcn),
                 pointHistoryJpaEntity.name.eq(studentName),
                 pointHistoryJpaEntity.type.eq(type),
@@ -88,7 +87,6 @@ class PointPersistenceAdapter(
             )
             .from(pointHistoryJpaEntity)
             .where(
-                pointHistoryJpaEntity.isCancel.eq(false),
                 pointHistoryJpaEntity.gcn.eq(gcn),
                 pointHistoryJpaEntity.name.eq(studentName),
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -1,15 +1,22 @@
 package team.aliens.dms.persistence.point
 
+import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointPort
+import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
 import team.aliens.dms.persistence.point.entity.QPointOptionJpaEntity.pointOptionJpaEntity
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
+import team.aliens.dms.persistence.point.repository.vo.QQueryAllPointHistoryVO
 import team.aliens.dms.persistence.point.repository.vo.QQueryPointHistoryVO
+import team.aliens.dms.persistence.point.repository.vo.QueryAllPointHistoryVO
 import java.util.UUID
 
 @Component
@@ -19,8 +26,21 @@ class PointPersistenceAdapter(
     private val queryFactory: JPAQueryFactory
 ) : PointPort {
 
-    override fun queryPointHistoryByStudentIdAndType(
-        studentId: UUID,
+    override fun queryBonusAndMinusTotalPointByStudent(student: Student): Pair<Int, Int> {
+        val lastHistory = queryFactory
+            .selectFrom(pointHistoryJpaEntity)
+            .orderBy(pointHistoryJpaEntity.createdAt.desc())
+            .limit(1)
+            .fetchOne()
+
+        val bonusTotal = lastHistory?.bonusTotal ?: 0
+        val minusTotal = lastHistory?.bonusTotal ?: 0
+
+        return Pair(bonusTotal, minusTotal)
+    }
+
+    override fun queryGrantedPointHistoryByStudentAndType(
+        student: Student,
         type: PointType
     ): List<QueryPointHistoryResponse.Point> {
         return queryFactory
@@ -34,16 +54,17 @@ class PointPersistenceAdapter(
                 )
             )
             .from(pointHistoryJpaEntity)
-            .join(pointHistoryJpaEntity.pointOption, pointOptionJpaEntity)
             .where(
-                pointHistoryJpaEntity.student.id.eq(studentId),
+                pointHistoryJpaEntity.isCancel.eq(false),
+                pointHistoryJpaEntity.gcn.eq(student.gcn),
+                pointHistoryJpaEntity.name.eq(student.name),
                 pointOptionJpaEntity.type.eq(type)
             )
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .fetch()
             .map {
                 QueryPointHistoryResponse.Point(
-                    pointId = it.pointId,
+                    pointHistoryId = it.pointId,
                     date = it.date.toLocalDate(),
                     type = it.type,
                     name = it.name,
@@ -52,7 +73,7 @@ class PointPersistenceAdapter(
             }
     }
 
-    override fun queryAllPointHistoryByStudentId(studentId: UUID): List<QueryPointHistoryResponse.Point> {
+    override fun queryGrantedPointHistoryByStudent(student: Student): List<QueryPointHistoryResponse.Point> {
         return queryFactory
             .select(
                 QQueryPointHistoryVO(
@@ -64,42 +85,21 @@ class PointPersistenceAdapter(
                 )
             )
             .from(pointHistoryJpaEntity)
-            .join(pointHistoryJpaEntity.pointOption, pointOptionJpaEntity)
-            .where(pointHistoryJpaEntity.student.id.eq(studentId))
+            .where(
+                pointHistoryJpaEntity.isCancel.eq(false),
+                pointHistoryJpaEntity.gcn.eq(student.gcn),
+                pointHistoryJpaEntity.name.eq(student.name)
+            )
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .fetch()
             .map {
                 QueryPointHistoryResponse.Point(
-                    pointId = it.pointId,
+                    pointHistoryId = it.pointId,
                     date = it.date.toLocalDate(),
                     type = it.type,
                     name = it.name,
                     score = it.score
                 )
             }
-    }
-
-    override fun queryTotalBonusPoint(studentId: UUID): Int {
-        return queryFactory
-            .select(pointOptionJpaEntity.score.sum())
-            .from(pointHistoryJpaEntity)
-            .join(pointHistoryJpaEntity.pointOption, pointOptionJpaEntity)
-            .where(
-                pointHistoryJpaEntity.student.id.eq(studentId),
-                pointOptionJpaEntity.type.eq(PointType.BONUS)
-            )
-            .fetchOne() ?: 0
-    }
-
-    override fun queryTotalMinusPoint(studentId: UUID): Int {
-        return queryFactory
-            .select(pointOptionJpaEntity.score.sum())
-            .from(pointHistoryJpaEntity)
-            .join(pointHistoryJpaEntity.pointOption, pointOptionJpaEntity)
-            .where(
-                pointHistoryJpaEntity.student.id.eq(studentId),
-                pointOptionJpaEntity.type.eq(PointType.MINUS)
-            )
-            .fetchOne() ?: 0
     }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -1,11 +1,8 @@
 package team.aliens.dms.persistence.point
 
-import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
-import team.aliens.dms.common.dto.PageData
-import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointPort
@@ -14,9 +11,7 @@ import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHist
 import team.aliens.dms.persistence.point.entity.QPointOptionJpaEntity.pointOptionJpaEntity
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
-import team.aliens.dms.persistence.point.repository.vo.QQueryAllPointHistoryVO
 import team.aliens.dms.persistence.point.repository.vo.QQueryPointHistoryVO
-import team.aliens.dms.persistence.point.repository.vo.QueryAllPointHistoryVO
 import java.util.UUID
 
 @Component

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointPersistenceAdapter.kt
@@ -23,13 +23,12 @@ class PointPersistenceAdapter(
     ): Pair<Int, Int> {
         val lastHistory = queryFactory
             .selectFrom(pointHistoryJpaEntity)
-            .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .where(
                 pointHistoryJpaEntity.studentGcn.eq(gcn),
                 pointHistoryJpaEntity.studentName.eq(studentName)
             )
-            .limit(1)
-            .fetchOne()
+            .orderBy(pointHistoryJpaEntity.createdAt.desc())
+            .fetchFirst()
 
         val bonusTotal = lastHistory?.bonusTotal ?: 0
         val minusTotal = lastHistory?.bonusTotal ?: 0

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
@@ -1,10 +1,14 @@
 package team.aliens.dms.persistence.point.entity
 
+import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.persistence.BaseEntity
-import team.aliens.dms.persistence.student.entity.StudentJpaEntity
+import team.aliens.dms.persistence.school.entity.SchoolJpaEntity
 import java.time.LocalDateTime
 import java.util.UUID
+import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -16,13 +20,34 @@ class PointHistoryJpaEntity(
 
     override val id: UUID?,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "point_option_id", columnDefinition = "BINARY(16)", nullable = false)
-    val pointOption: PointOptionJpaEntity?,
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    val studentName: String,
+
+    @Column(columnDefinition = "VARCHAR(5)", nullable = false)
+    val gcn: String,
+
+    @Column(columnDefinition = "INT", nullable = false)
+    val score: Int,
+
+    @Column(columnDefinition = "INT", nullable = false)
+    val bonusTotal: Int,
+
+    @Column(columnDefinition = "INT", nullable = false)
+    val minusTotal: Int,
+
+    @Column(columnDefinition = "BIT(1)", nullable = false)
+    val isCancel: Boolean,
+
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
+    val name: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(5)", nullable = false)
+    val type: PointType,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)", nullable = false)
-    val student: StudentJpaEntity?,
+    @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)
+    val school: SchoolJpaEntity?,
 
     override val createdAt: LocalDateTime
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
@@ -24,10 +24,7 @@ class PointHistoryJpaEntity(
     val studentName: String,
 
     @Column(columnDefinition = "VARCHAR(5)", nullable = false)
-    val gcn: String,
-
-    @Column(columnDefinition = "INT", nullable = false)
-    val score: Int,
+    val studentGcn: String,
 
     @Column(columnDefinition = "INT", nullable = false)
     val bonusTotal: Int,
@@ -39,11 +36,14 @@ class PointHistoryJpaEntity(
     val isCancel: Boolean,
 
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
-    val name: String,
+    val pointName: String,
+
+    @Column(columnDefinition = "INT", nullable = false)
+    val pointScore: Int,
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(5)", nullable = false)
-    val type: PointType,
+    val pointType: PointType,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PointHistoryMapper.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PointHistoryMapper.kt
@@ -17,13 +17,13 @@ class PointHistoryMapper(
             PointHistory(
                 id = it.id!!,
                 studentName = it.studentName,
-                gcn = it.gcn,
+                studentGcn = it.studentGcn,
                 bonusTotal = it.bonusTotal,
                 minusTotal = it.minusTotal,
                 isCancel = it.isCancel,
-                name = it.name,
-                score = it.score,
-                type = it.type,
+                pointName = it.pointName,
+                pointScore = it.pointScore,
+                pointType = it.pointType,
                 schoolId = it.school!!.id!!,
                 createdAt = it.createdAt
             )
@@ -36,13 +36,13 @@ class PointHistoryMapper(
         return PointHistoryJpaEntity(
             id = domain.id,
             studentName = domain.studentName,
-            gcn = domain.gcn,
+            studentGcn = domain.studentGcn,
             bonusTotal = domain.bonusTotal,
             minusTotal = domain.minusTotal,
             isCancel = domain.isCancel,
-            name = domain.name,
-            score = domain.score,
-            type = domain.type,
+            pointName = domain.pointName,
+            pointScore = domain.pointScore,
+            pointType = domain.pointType,
             school = school,
             createdAt = domain.createdAt
         )

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PointHistoryMapper.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PointHistoryMapper.kt
@@ -5,35 +5,46 @@ import org.springframework.stereotype.Component
 import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.persistence.GenericMapper
 import team.aliens.dms.persistence.point.entity.PointHistoryJpaEntity
-import team.aliens.dms.persistence.point.repository.PointOptionJpaRepository
-import team.aliens.dms.persistence.student.repository.StudentJpaRepository
+import team.aliens.dms.persistence.school.repository.SchoolJpaRepository
 
 @Component
 class PointHistoryMapper(
-    private val pointOptionRepository: PointOptionJpaRepository,
-    private val studentRepository: StudentJpaRepository
+    private val schoolRepository: SchoolJpaRepository
 ) : GenericMapper<PointHistory, PointHistoryJpaEntity> {
 
     override fun toDomain(entity: PointHistoryJpaEntity?): PointHistory? {
         return entity?.let {
             PointHistory(
                 id = it.id!!,
-                pointOptionId = it.pointOption!!.id!!,
-                studentId = it.student!!.id,
+                studentName = it.studentName,
+                gcn = it.gcn,
+                bonusTotal = it.bonusTotal,
+                minusTotal = it.minusTotal,
+                isCancel = it.isCancel,
+                name = it.name,
+                score = it.score,
+                type = it.type,
+                schoolId = it.school!!.id!!,
                 createdAt = it.createdAt
             )
         }
     }
 
     override fun toEntity(domain: PointHistory): PointHistoryJpaEntity {
-        val pointOption = pointOptionRepository.findByIdOrNull(domain.pointOptionId)
-        val student = studentRepository.findByIdOrNull(domain.studentId)
+        val school = schoolRepository.findByIdOrNull(domain.schoolId)
 
         return PointHistoryJpaEntity(
             id = domain.id,
-            pointOption = pointOption,
-            student = student,
-            createdAt = domain.createdAt!!
+            studentName = domain.studentName,
+            gcn = domain.gcn,
+            bonusTotal = domain.bonusTotal,
+            minusTotal = domain.minusTotal,
+            isCancel = domain.isCancel,
+            name = domain.name,
+            score = domain.score,
+            type = domain.type,
+            school = school,
+            createdAt = domain.createdAt
         )
     }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryPointHistoryVO.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryPointHistoryVO.kt
@@ -3,10 +3,8 @@ package team.aliens.dms.persistence.point.repository.vo
 import com.querydsl.core.annotations.QueryProjection
 import team.aliens.dms.domain.point.model.PointType
 import java.time.LocalDateTime
-import java.util.UUID
 
 data class QueryPointHistoryVO @QueryProjection constructor(
-    val pointId: UUID,
     val date: LocalDateTime,
     val type: PointType,
     val name: String,

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryPointHistoryVO.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryPointHistoryVO.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 data class QueryPointHistoryVO @QueryProjection constructor(
     val date: LocalDateTime,
-    val type: PointType,
-    val name: String,
-    val score: Int
+    val pointType: PointType,
+    val pointName: String,
+    val pointScore: Int
 )


### PR DESCRIPTION
## 작업 내용 설명
- [x] PointHistory 테이블에서 학생, 상벌점 항목을 참조하는 FK를 삭제하고, 필요한 정보를 비정규화하여 삽입하였습니다.
- [x] 영향받는 코드를 수정했습니다.

## 주요 변경 사항
- entity 컬럼을 수정헀습니다.
- 상벌점 total을 불러오는 로직을, 최근 History을 조회하여 가져오는 방식으로 변경했습니다.

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #222