### PR TITLE
merge: (#229) 잔류 항목 생성 api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ subprojects {
 
         // test
         implementation(Dependencies.SPRING_TEST)
+        implementation(Dependencies.MOCKK)
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -44,6 +44,7 @@ object Dependencies {
 
     // test
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test:${PluginVersions.SPRING_BOOT_VERSION}"
+    const val MOCKK = "io.mockk:mockk:${PluginVersions.MOCKK_VERSION}"
 
     // time based uuid
     const val UUID_TIME = "com.fasterxml.uuid:java-uuid-generator:${DependencyVersions.UUID_TIME_VERSION}"

--- a/buildSrc/src/main/kotlin/PluginVersions.kt
+++ b/buildSrc/src/main/kotlin/PluginVersions.kt
@@ -6,4 +6,5 @@ object PluginVersions {
     const val JPA_PLUGIN_VERSION = "1.6.21"
     const val KAPT_VERSION = "1.7.10"
     const val ALLOPEN_VERSION = "1.6.21"
+    const val MOCKK_VERSION = "1.13.2"
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/common/spi/SecurityPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/common/spi/SecurityPort.kt
@@ -5,6 +5,7 @@ import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.meal.spi.MealSecurityPort
 import team.aliens.dms.domain.notice.spi.NoticeSecurityPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
 import team.aliens.dms.domain.school.spi.SchoolSecurityPort
 import team.aliens.dms.domain.student.spi.StudentSecurityPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
@@ -19,5 +20,6 @@ interface SecurityPort :
     NoticeSecurityPort,
     SchoolSecurityPort,
     PointSecurityPort,
-    StudyRoomSecurityPort {
+    StudyRoomSecurityPort,
+    RemainSecurityPort{
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainOptionPort.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.remain.model.RemainOption
+
+interface CommandRemainOptionPort {
+
+    fun saveRemainOption(remainOption: RemainOption): RemainOption
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainOptionPort.kt
@@ -1,0 +1,4 @@
+package team.aliens.dms.domain.remain.spi
+
+interface RemainOptionPort: CommandRemainOptionPort {
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryUserPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryUserPort.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.user.model.User
+import java.util.UUID
+
+interface RemainQueryUserPort {
+
+    fun queryUserById(userId: UUID): User?
+
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainSecurityPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainSecurityPort.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.spi
+
+import java.util.UUID
+
+interface RemainSecurityPort {
+
+    fun getCurrentUserId(): UUID
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/CreateRemainOptionUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/CreateRemainOptionUseCase.kt
@@ -1,0 +1,33 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.spi.CommandRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.spi.QueryUserPort
+import java.util.UUID
+
+@UseCase
+class CreateRemainOptionUseCase (
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: QueryUserPort,
+    private val commentRemainOptionPort: CommandRemainOptionPort
+) {
+
+    fun execute(title: String, description: String): UUID {
+
+        val currentUserId = securityPort.getCurrentUserId()
+        val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val savedRemainOption = commentRemainOptionPort.saveRemainOption(
+            RemainOption(
+                schoolId = currentUser.schoolId,
+                title = title,
+                description = description
+            )
+        )
+
+        return savedRemainOption.id
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/user/spi/UserPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/user/spi/UserPort.kt
@@ -5,6 +5,7 @@ import team.aliens.dms.domain.manager.spi.ManagerCommandUserPort
 import team.aliens.dms.domain.manager.spi.ManagerQueryUserPort
 import team.aliens.dms.domain.notice.spi.NoticeQueryUserPort
 import team.aliens.dms.domain.point.spi.PointQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.school.spi.SchoolQueryUserPort
 import team.aliens.dms.domain.student.spi.StudentCommandUserPort
 import team.aliens.dms.domain.student.spi.StudentQueryUserPort
@@ -21,5 +22,6 @@ interface UserPort :
     NoticeQueryUserPort,
     SchoolQueryUserPort,
     PointQueryUserPort,
-    StudyRoomQueryUserPort {
+    StudyRoomQueryUserPort,
+    RemainQueryUserPort {
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/CreateRemainUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/CreateRemainUseCaseTests.kt
@@ -1,0 +1,83 @@
+package team.aliens.dms.domain.remain.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.spi.CommandRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import team.aliens.dms.domain.user.spi.QueryUserPort
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class CreateRemainUseCaseTests {
+
+    private val securityPort: RemainSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: QueryUserPort = mockk(relaxed = true)
+    private val commentRemainOptionPort: CommandRemainOptionPort = mockk(relaxed = true)
+
+    private val createRemainOptionUseCase = CreateRemainOptionUseCase(securityPort, queryUserPort, commentRemainOptionPort)
+
+    private val managerId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = managerId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val remainOptionId = UUID.randomUUID()
+    private val title = "title"
+    private val description = "description"
+
+    private val remainOptionStub by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = schoolId,
+            title = title,
+            description = description
+        )
+    }
+
+    @Test
+    fun `잔류항목 생성 성공`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+        every { commentRemainOptionPort.saveRemainOption(any()) } returns remainOptionStub
+
+        // when
+        val response = createRemainOptionUseCase.execute(title, description)
+
+        // then
+        assertEquals(response, remainOptionStub.id)
+    }
+
+    @Test
+    fun `유저 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+        every { queryUserPort.queryUserById(managerId) } returns null
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            createRemainOptionUseCase.execute(title, description)
+        }
+    }
+
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -115,8 +115,10 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.GET, "/study-rooms/list/students").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.GET, "/study-rooms/list/managers").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/study-rooms/types/{type-id}").hasAuthority(MANAGER.name)
-            .anyRequest().denyAll()
 
+            // /remains
+            .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
+            .anyRequest().denyAll()
 
         http
             .apply(FilterConfig(jwtParser, objectMapper))

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
@@ -1,0 +1,20 @@
+package team.aliens.dms.persistence.remain
+
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.spi.RemainOptionPort
+import team.aliens.dms.persistence.remain.mapper.RemainOptionMapper
+import team.aliens.dms.persistence.remain.repository.RemainOptionJpaRepository
+
+@Component
+class RemainOptionPersistenceAdapter(
+    private val remainOptionRepository: RemainOptionJpaRepository,
+    private val remainOptionMapper: RemainOptionMapper
+) : RemainOptionPort {
+
+    override fun saveRemainOption(remainOption: RemainOption) = remainOptionMapper.toDomain(
+        remainOptionRepository.save(
+            remainOptionMapper.toEntity(remainOption)
+        )
+    )!!
+}

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -1,0 +1,31 @@
+package team.aliens.dms.domain.remain
+
+import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
+import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
+import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
+import javax.validation.Valid
+
+@Validated
+@RequestMapping("/remains")
+@RestController
+class RemainWebAdapter(
+    private val createRemainOptionUseCase: CreateRemainOptionUseCase,
+) {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/options")
+    fun createRemainOption(@RequestBody @Valid request: CreateRemainOptionWebRequest): CreateRemainOptionResponse {
+        val remainOptionId = createRemainOptionUseCase.execute(
+            title = request.title!!,
+            description = request.description!!
+        )
+        return CreateRemainOptionResponse(remainOptionId)
+    }
+}

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/request/CreateRemainOptionWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/request/CreateRemainOptionWebRequest.kt
@@ -1,0 +1,16 @@
+package team.aliens.dms.domain.remain.dto.request
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class CreateRemainOptionWebRequest(
+
+    @field:NotBlank
+    @field:Size(max = 100)
+    val title: String?,
+
+    @field:NotBlank
+    @field:Size(max = 255)
+    val description: String?
+
+)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/response/CreateRemainOptionResponse.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/response/CreateRemainOptionResponse.kt
@@ -1,0 +1,7 @@
+package team.aliens.dms.domain.remain.dto.response
+
+import java.util.UUID
+
+data class CreateRemainOptionResponse(
+    val remainOptionId: UUID
+)


### PR DESCRIPTION
## 작업 내용 설명
- [x]  CreateRemainOptionUseCase
- [x]  POST remains/options

## 주요 변경 사항
- CreateRemainOptionUseCase

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #229 

## 결과물

<img src="https://user-images.githubusercontent.com/81006587/219547496-03255838-bde6-4d26-9dee-0f4d94542101.png" height=300px>
