### PR TITLE
merge: (#240) 전체 상벌점 내역 보기 api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ subprojects {
 
         // test
         implementation(Dependencies.SPRING_TEST)
+        implementation(Dependencies.MOCKK)
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -44,6 +44,7 @@ object Dependencies {
 
     // test
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test:${PluginVersions.SPRING_BOOT_VERSION}"
+    const val MOCKK = "io.mockk:mockk:${DependencyVersions.MOCKK_VERSION}"
 
     // time based uuid
     const val UUID_TIME = "com.fasterxml.uuid:java-uuid-generator:${DependencyVersions.UUID_TIME_VERSION}"

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -9,4 +9,5 @@ object DependencyVersions {
     const val SPRING_TRANSACTION = "5.3.22"
     const val QUERYDSL = "5.0.0"
     const val APACHE_POI_VERSION = "3.7"
+    const val MOCKK_VERSION = "1.13.2"
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/common/dto/PageData.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/common/dto/PageData.kt
@@ -1,0 +1,13 @@
+package team.aliens.dms.common.dto
+
+data class PageData(
+    val page: Long = 0,
+    val size: Long = 10000
+) {
+    val offset: Long
+        get() = page * size
+
+    companion object {
+        val DEFAULT = PageData()
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/common/dto/PageData.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/common/dto/PageData.kt
@@ -1,13 +1,17 @@
 package team.aliens.dms.common.dto
 
-data class PageData(
-    val page: Long = 0,
-    val size: Long = 10000
+class PageData(
+    page: Long?,
+    size: Long?
 ) {
+
+    val page: Long = page ?: 0
+    val size: Long = size ?: 500
+
     val offset: Long
         get() = page * size
 
     companion object {
-        val DEFAULT = PageData()
+        val DEFAULT = PageData(null, null)
     }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryAllPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryAllPointHistoryResponse.kt
@@ -1,0 +1,19 @@
+package team.aliens.dms.domain.point.dto
+
+import team.aliens.dms.domain.point.model.PointType
+import java.time.LocalDate
+import java.util.UUID
+
+data class QueryAllPointHistoryResponse(
+    val pointHistories: List<PointHistory>
+) {
+    data class PointHistory(
+        val pointHistoryId: UUID,
+        val studentName: String,
+        val studentGcn: String,
+        val date: LocalDate,
+        val pointName: String,
+        val pointType: PointType,
+        val pointScore: Int
+    )
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -1,7 +1,10 @@
 package team.aliens.dms.domain.point.spi
 
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
+import java.util.UUID
 
 interface QueryPointHistoryPort {
 
@@ -17,4 +20,10 @@ interface QueryPointHistoryPort {
         isCancel: Boolean? = null
     ): List<QueryPointHistoryResponse.Point>
 
+    fun queryPointHistoryBySchoolIdAndType(
+        schoolId: UUID,
+        type: PointType?,
+        isCancel: Boolean? = null,
+        pageData: PageData = PageData.DEFAULT
+    ): List<QueryAllPointHistoryResponse.PointHistory>
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryAllPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryAllPointHistoryUseCase.kt
@@ -1,0 +1,36 @@
+package team.aliens.dms.domain.point.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.PointRequestType
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
+import team.aliens.dms.domain.point.spi.PointQueryUserPort
+import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+
+@ReadOnlyUseCase
+class QueryAllPointHistoryUseCase(
+    private val securityPort: PointSecurityPort,
+    private val queryUserPort: PointQueryUserPort,
+    private val queryPointHistoryPort: QueryPointHistoryPort
+) {
+
+    fun execute(type: PointRequestType, pageData: PageData): QueryAllPointHistoryResponse {
+
+        val currentUserId = securityPort.getCurrentUserId()
+        val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+        val schoolId = manager.schoolId
+
+        val pointType = PointRequestType.toPointType(type)
+
+        val pointHistories = queryPointHistoryPort.queryPointHistoryBySchoolIdAndType(
+            schoolId = schoolId,
+            type = pointType,
+            isCancel = false,
+            pageData = pageData
+        )
+
+        return QueryAllPointHistoryResponse(pointHistories)
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryAllPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryAllPointHistoryUseCase.kt
@@ -20,13 +20,10 @@ class QueryAllPointHistoryUseCase(
 
         val currentUserId = securityPort.getCurrentUserId()
         val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
-        val schoolId = manager.schoolId
-
-        val pointType = PointRequestType.toPointType(type)
 
         val pointHistories = queryPointHistoryPort.queryPointHistoryBySchoolIdAndType(
-            schoolId = schoolId,
-            type = pointType,
+            schoolId = manager.schoolId,
+            type = PointRequestType.toPointType(type),
             isCancel = false,
             pageData = pageData
         )

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryAllPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryAllPointHistoryUseCaseTests.kt
@@ -103,7 +103,7 @@ class QueryAllPointHistoryUseCaseTests {
         every { queryUserPort.queryUserById(managerId) } returns null
 
         // when & then
-        assertThrows<UserNotFountException> {
+        assertThrows<UserNotFoundException> {
             queryAllPointHistoryUseCase.execute(pointRequestType, pageData)
         }
     }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryAllPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryAllPointHistoryUseCaseTests.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -16,6 +17,7 @@ import team.aliens.dms.domain.point.spi.PointQueryUserPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
 import team.aliens.dms.domain.user.model.User
+import team.aliens.dms.domain.user.exception.UserNotFoundException
 import java.time.LocalDate
 import java.util.UUID
 
@@ -70,7 +72,6 @@ class QueryAllPointHistoryUseCaseTests {
     @Test
     fun `상벌점 내역 조회 성공`() {
         // given
-
         every { securityPort.getCurrentUserId() } returns managerId
 
         every { queryUserPort.queryUserById(managerId) } returns userStub
@@ -94,5 +95,16 @@ class QueryAllPointHistoryUseCaseTests {
         )
     }
 
+    @Test
+    fun `유저가 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
 
+        every { queryUserPort.queryUserById(managerId) } returns null
+
+        // when & then
+        assertThrows<UserNotFountException> {
+            queryAllPointHistoryUseCase.execute(pointRequestType, pageData)
+        }
+    }
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryAllPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryAllPointHistoryUseCaseTests.kt
@@ -1,0 +1,98 @@
+package team.aliens.dms.domain.point.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.point.dto.PointRequestType
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
+import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.PointQueryUserPort
+import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.user.model.User
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class QueryAllPointHistoryUseCaseTests {
+
+    private val securityPort: PointSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: PointQueryUserPort = mockk(relaxed = true)
+    private val queryPointHistoryPort: QueryPointHistoryPort = mockk(relaxed = true)
+
+    private val queryAllPointHistoryUseCase = QueryAllPointHistoryUseCase(
+        securityPort, queryUserPort, queryPointHistoryPort
+    )
+
+    private val managerId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = managerId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val responseStub by lazy {
+        QueryAllPointHistoryResponse.PointHistory(
+            pointHistoryId = UUID.randomUUID(),
+            studentName = "김은빈",
+            studentGcn = "2106",
+            date = LocalDate.now(),
+            pointName = "타호실 출입",
+            pointType = PointType.MINUS,
+            pointScore = 3
+        )
+    }
+
+    private val pointRequestType = PointRequestType.ALL
+
+    private val pageData by lazy {
+        PageData(
+            page = 0,
+            size = 10
+        )
+    }
+
+    @Test
+    fun `상벌점 내역 조회 성공`() {
+        // given
+
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+
+        every {
+            queryPointHistoryPort.queryPointHistoryBySchoolIdAndType(
+                schoolId = schoolId,
+                type = null,
+                isCancel = false,
+                pageData = pageData
+            )
+        } returns listOf(responseStub)
+
+        // when
+        val response = queryAllPointHistoryUseCase.execute(pointRequestType, pageData)
+
+        // then
+        assertAll(
+            { assertEquals(response.pointHistories.size, 1) },
+            { assertEquals(response.pointHistories[0], responseStub) }
+        )
+    }
+
+
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -93,6 +93,7 @@ class SecurityConfiguration(
 
             // /points
             .antMatchers(HttpMethod.GET, "/points").hasAuthority(STUDENT.name)
+            .antMatchers(HttpMethod.GET, "/points/history").hasAuthority(MANAGER.name)
 
             // /templates
             .antMatchers(HttpMethod.GET, "/templates").permitAll()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -98,6 +98,8 @@ class PointHistoryPersistenceAdapter(
                 type?.let { pointHistoryJpaEntity.pointType.eq(it) },
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
             )
+            .offset(pageData.offset)
+            .limit(pageData.size)
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .fetch()
             .map {

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -2,13 +2,17 @@ package team.aliens.dms.persistence.point
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointHistoryPort
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
+import team.aliens.dms.persistence.point.repository.vo.QQueryAllPointHistoryVO
 import team.aliens.dms.persistence.point.repository.vo.QQueryPointHistoryVO
+import java.util.UUID
 
 @Component
 class PointHistoryPersistenceAdapter(
@@ -55,7 +59,7 @@ class PointHistoryPersistenceAdapter(
             .where(
                 pointHistoryJpaEntity.studentGcn.eq(gcn),
                 pointHistoryJpaEntity.studentName.eq(studentName),
-                type?.let {pointHistoryJpaEntity.pointType.eq(it) },
+                type?.let { pointHistoryJpaEntity.pointType.eq(it) },
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
             )
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
@@ -66,6 +70,45 @@ class PointHistoryPersistenceAdapter(
                     type = it.pointType,
                     name = it.pointName,
                     score = it.pointScore
+                )
+            }
+    }
+
+    override fun queryPointHistoryBySchoolIdAndType(
+        schoolId: UUID,
+        type: PointType?,
+        isCancel: Boolean?,
+        pageData: PageData
+    ): List<QueryAllPointHistoryResponse.PointHistory> {
+        return queryFactory
+            .select(
+                QQueryAllPointHistoryVO(
+                    pointHistoryJpaEntity.id,
+                    pointHistoryJpaEntity.studentName,
+                    pointHistoryJpaEntity.studentGcn,
+                    pointHistoryJpaEntity.createdAt,
+                    pointHistoryJpaEntity.pointName,
+                    pointHistoryJpaEntity.pointType,
+                    pointHistoryJpaEntity.pointScore
+                )
+            )
+            .from(pointHistoryJpaEntity)
+            .where(
+                pointHistoryJpaEntity.school.id.eq(schoolId),
+                type?.let { pointHistoryJpaEntity.pointType.eq(it) },
+                isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
+            )
+            .orderBy(pointHistoryJpaEntity.createdAt.desc())
+            .fetch()
+            .map {
+                QueryAllPointHistoryResponse.PointHistory(
+                    pointHistoryId = it.pointHistoryId,
+                    studentName = it.studentName,
+                    studentGcn = it.studentGcn,
+                    date = it.date.toLocalDate(),
+                    pointName = it.pointName,
+                    pointType = it.pointType,
+                    pointScore = it.pointScore
                 )
             }
     }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryAllPointHistoryVO.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryAllPointHistoryVO.kt
@@ -1,0 +1,16 @@
+package team.aliens.dms.persistence.point.repository.vo
+
+import com.querydsl.core.annotations.QueryProjection
+import team.aliens.dms.domain.point.model.PointType
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class QueryAllPointHistoryVO @QueryProjection constructor(
+    val pointHistoryId: UUID,
+    val studentName: String,
+    val studentGcn: String,
+    val date: LocalDateTime,
+    val pointName: String,
+    val pointType: PointType,
+    val pointScore: Int
+)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/common/dto/PageWebData.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/common/dto/PageWebData.kt
@@ -1,0 +1,6 @@
+package team.aliens.dms.common.dto
+
+data class PageWebData(
+    val page: Long?,
+    val size: Long?
+)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -2,11 +2,15 @@ package team.aliens.dms.domain.point
 
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.PointRequestType
+import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
+import team.aliens.dms.domain.point.usecase.QueryAllPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.QueryPointHistoryUseCase
 import javax.validation.constraints.NotNull
 
@@ -14,11 +18,20 @@ import javax.validation.constraints.NotNull
 @RequestMapping("/points")
 @RestController
 class PointWebAdapter(
-    private val queryPointHistoryUseCase: QueryPointHistoryUseCase
+    private val queryPointHistoryUseCase: QueryPointHistoryUseCase,
+    private val queryAllPointHistoryUseCase: QueryAllPointHistoryUseCase,
 ) {
 
     @GetMapping
     fun getPointHistory(@RequestParam @NotNull type: PointRequestType?): QueryPointHistoryResponse {
         return queryPointHistoryUseCase.execute(type!!)
+    }
+
+    @GetMapping("/history")
+    fun getAllPointHistory(
+        @RequestParam @NotNull type: PointRequestType?,
+        @ModelAttribute pageData: PageData
+    ): QueryAllPointHistoryResponse {
+        return queryAllPointHistoryUseCase.execute(type!!, pageData)
     }
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.common.dto.PageWebData
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
@@ -30,8 +31,11 @@ class PointWebAdapter(
     @GetMapping("/history")
     fun getAllPointHistory(
         @RequestParam @NotNull type: PointRequestType?,
-        @ModelAttribute pageData: PageData
+        @ModelAttribute pageData: PageWebData
     ): QueryAllPointHistoryResponse {
-        return queryAllPointHistoryUseCase.execute(type!!, pageData)
+        return queryAllPointHistoryUseCase.execute(
+            type = type!!,
+            pageData = PageData(pageData.page, pageData.size)
+        )
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] QueryAllPointHistoryUseCase
- [x] GET points/history

## 주요 변경 사항
- 전체 상벌점 내역 보기 api
- PageData는 앞으로 공용으로 사용될 수 있을 것 같아서 application 모듈의 common 패키지에 정의해놓았습니다
- mockk 의존성은 이전 PR이 아직 머지되지 않아서 일단 같이 커밋했습니다
  - 앞으로 테스트를 작성할때도 mockk를 계속 사용할지는 이야기가 더 필요할 것 같아요!

## 결과물

<img src="https://user-images.githubusercontent.com/81006587/219847480-36381b6e-5920-4b70-a16f-8c20d6bd34a0.png" height=300px>


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #240