### PR TITLE
merge: (#243) 잔류 항목 수정 api

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/exception/RemainOptionNotFoundException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/exception/RemainOptionNotFoundException.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.domain.remain.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.remain.error.RemainOptionErrorCode
+import team.aliens.dms.domain.room.error.RoomErrorCode
+
+object RemainOptionNotFoundException : DmsException(
+    RemainOptionErrorCode.REMAIN_OPTION_NOT_FOUND
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainOptionPort.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.remain.model.RemainOption
+import java.util.UUID
+
+interface QueryRemainOptionPort {
+    fun queryRemainOptionById(remainOptionId: UUID): RemainOption?
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainOptionPort.kt
@@ -1,4 +1,4 @@
 package team.aliens.dms.domain.remain.spi
 
-interface RemainOptionPort: CommandRemainOptionPort {
+interface RemainOptionPort: CommandRemainOptionPort, QueryRemainOptionPort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCase.kt
@@ -1,0 +1,37 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
+import team.aliens.dms.domain.remain.spi.CommandRemainOptionPort
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.util.UUID
+
+@UseCase
+class UpdateRemainOptionUseCase(
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: RemainQueryUserPort,
+    private val queryRemainOptionPort: QueryRemainOptionPort,
+    private val commendRemainOptionPort: CommandRemainOptionPort
+) {
+    fun execute(remainOptionId: UUID, title: String, description: String) {
+        val currentUserId = securityPort.getCurrentUserId()
+        val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
+
+        if (remainOption.schoolId != manager.schoolId) {
+            throw SchoolMismatchException
+        }
+
+        commendRemainOptionPort.saveRemainOption(
+            remainOption.copy(
+                title = title,
+                description = description
+            )
+        )
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCase.kt
@@ -17,11 +17,8 @@ class UpdateRemainOptionUseCase(
     private val queryRemainOptionPort: QueryRemainOptionPort,
     private val commendRemainOptionPort: CommandRemainOptionPort
 ) {
-    fun execute(
-        remainOptionId: UUID,
-        title: String,
-        description: String
-    ) {
+
+    fun execute(remainOptionId: UUID, title: String, description: String) {
         val currentUserId = securityPort.getCurrentUserId()
         val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCase.kt
@@ -17,7 +17,11 @@ class UpdateRemainOptionUseCase(
     private val queryRemainOptionPort: QueryRemainOptionPort,
     private val commendRemainOptionPort: CommandRemainOptionPort
 ) {
-    fun execute(remainOptionId: UUID, title: String, description: String) {
+    fun execute(
+        remainOptionId: UUID,
+        title: String,
+        description: String
+    ) {
         val currentUserId = securityPort.getCurrentUserId()
         val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainOptionUseCaseTests.kt
@@ -1,0 +1,136 @@
+package team.aliens.dms.domain.remain.usecase
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.spi.CommandRemainOptionPort
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.user.model.User
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class UpdateRemainOptionUseCaseTests {
+
+    @MockBean
+    private lateinit var securityPort: RemainSecurityPort
+
+    @MockBean
+    private lateinit var queryUserPort: RemainQueryUserPort
+
+    @MockBean
+    private lateinit var queryRemainOptionPort: QueryRemainOptionPort
+
+    @MockBean
+    private lateinit var commandRemainOptionPort: CommandRemainOptionPort
+
+    private lateinit var updateRemainOptionUseCase: UpdateRemainOptionUseCase
+
+    @BeforeEach
+    fun setUp() {
+        updateRemainOptionUseCase = UpdateRemainOptionUseCase(
+            securityPort, queryUserPort, queryRemainOptionPort, commandRemainOptionPort
+        )
+    }
+
+    private val managerId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = managerId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val remainOptionId = UUID.randomUUID()
+    private val title = "title"
+    private val description = "descripton"
+
+    private val remainOptionStub by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = schoolId,
+            title = title,
+            description = description
+        )
+    }
+
+    @Test
+    fun `잔류항목 수정 성공`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(managerId)
+
+        given(queryUserPort.queryUserById(managerId))
+            .willReturn(userStub)
+
+        given(queryRemainOptionPort.queryRemainOptionById(remainOptionId))
+            .willReturn(remainOptionStub)
+
+        //when & then
+        assertDoesNotThrow {
+            updateRemainOptionUseCase.execute(remainOptionId, title, description)
+        }
+    }
+
+    @Test
+    fun `잔류항목 존재하지 않음`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(managerId)
+
+        given(queryUserPort.queryUserById(managerId))
+            .willReturn(userStub)
+
+        given(queryRemainOptionPort.queryRemainOptionById(remainOptionId))
+            .willReturn(null)
+
+        // when & then
+        assertThrows<RemainOptionNotFoundException> {
+            updateRemainOptionUseCase.execute(remainOptionId, title, description)
+        }
+    }
+
+    private val otherRemainOptionStub by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = UUID.randomUUID(),
+            title = title,
+            description = description
+        )
+    }
+
+    @Test
+    fun `같은 학교의 매니저가 아님`() {
+        given(securityPort.getCurrentUserId())
+            .willReturn(managerId)
+
+        given(queryUserPort.queryUserById(managerId))
+            .willReturn(userStub)
+
+        given(queryRemainOptionPort.queryRemainOptionById(remainOptionId))
+            .willReturn(otherRemainOptionStub)
+
+        // when & then
+        assertThrows<SchoolMismatchException> {
+            updateRemainOptionUseCase.execute(remainOptionId, title, description)
+        }
+    }
+}

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/remain/error/RemainOptionErrorCode.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/remain/error/RemainOptionErrorCode.kt
@@ -1,0 +1,15 @@
+package team.aliens.dms.domain.remain.error
+
+import team.aliens.dms.common.error.ErrorProperty
+
+enum class RemainOptionErrorCode(
+    private val status: Int,
+    private val message: String
+) : ErrorProperty {
+
+    REMAIN_OPTION_NOT_FOUND(404, "Remain Option Not Found")
+    ;
+
+    override fun status(): Int = status
+    override fun message(): String = message
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -118,6 +118,7 @@ class SecurityConfiguration(
 
             // /remains
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.PATCH, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
             .anyRequest().denyAll()
 
         http

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
@@ -1,10 +1,12 @@
 package team.aliens.dms.persistence.remain
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.remain.model.RemainOption
 import team.aliens.dms.domain.remain.spi.RemainOptionPort
 import team.aliens.dms.persistence.remain.mapper.RemainOptionMapper
 import team.aliens.dms.persistence.remain.repository.RemainOptionJpaRepository
+import java.util.UUID
 
 @Component
 class RemainOptionPersistenceAdapter(
@@ -17,4 +19,8 @@ class RemainOptionPersistenceAdapter(
             remainOptionMapper.toEntity(remainOption)
         )
     )!!
+
+    override fun queryRemainOptionById(remainOptionId: UUID) = remainOptionMapper.toDomain(
+        remainOptionRepository.findByIdOrNull(remainOptionId)
+    )
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -2,21 +2,28 @@ package team.aliens.dms.domain.remain
 
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
+import team.aliens.dms.domain.remain.dto.request.UpdateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
 import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
+import team.aliens.dms.domain.remain.usecase.UpdateRemainOptionUseCase
+import java.util.UUID
 import javax.validation.Valid
+import javax.validation.constraints.NotNull
 
 @Validated
 @RequestMapping("/remains")
 @RestController
 class RemainWebAdapter(
     private val createRemainOptionUseCase: CreateRemainOptionUseCase,
+    private val updateRemainOptionUseCase: UpdateRemainOptionUseCase,
 ) {
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -27,5 +34,18 @@ class RemainWebAdapter(
             description = request.description!!
         )
         return CreateRemainOptionResponse(remainOptionId)
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/options/{remain-option-id}")
+    fun updateRemainOption(
+        @PathVariable("remain-option-id") @NotNull remainOptionId: UUID?,
+        @RequestBody @Valid request: UpdateRemainOptionWebRequest
+    ) {
+        updateRemainOptionUseCase.execute(
+            remainOptionId = remainOptionId!!,
+            title = request.title!!,
+            description = request.description!!
+        )
     }
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/request/UpdateRemainOptionWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/request/UpdateRemainOptionWebRequest.kt
@@ -1,0 +1,15 @@
+package team.aliens.dms.domain.remain.dto.request
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class UpdateRemainOptionWebRequest(
+
+    @field:NotBlank
+    @field:Size(max = 100)
+    val title: String?,
+
+    @field:NotBlank
+    @field:Size(max = 255)
+    val description: String?
+)


### PR DESCRIPTION
## 작업 내용 설명
- [x] UpdateRemainOptionUseCase
- [x] PATCH remains/options


## 주요 변경 사항
- 잔류 항목 수정 api

## 결과물
<img src="https://user-images.githubusercontent.com/81006587/219987279-ed9746de-2442-45d6-b3db-0d90389df0d1.png" height=250px>

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #243 