### PR TITLE
merge: (#234) 잔류 신청 시간 설정 API

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/UpdateRemainAvailableTimeRequest.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/UpdateRemainAvailableTimeRequest.kt
@@ -1,0 +1,16 @@
+package team.aliens.dms.domain.remain.dto
+
+import java.time.DayOfWeek
+import java.time.LocalTime
+
+data class UpdateRemainAvailableTimeRequest(
+
+    val startDayOfWeek: DayOfWeek,
+
+    val startTime: LocalTime,
+
+    val endDayOfWeek: DayOfWeek,
+
+    val endTime: LocalTime
+
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainAvailableTimePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainAvailableTimePort.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.remain.model.RemainAvailableTime
+
+interface CommandRemainAvailableTimePort {
+
+    fun saveRemainAvailableTime(remainAvailableTime: RemainAvailableTime): RemainAvailableTime
+
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainAvailableTimePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainAvailableTimePort.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.remain.model.RemainAvailableTime
+import java.util.UUID
+
+interface QueryRemainAvailableTimePort {
+
+    fun queryRemainAvailableTimeBySchoolId(schoolId: UUID): RemainAvailableTime?
+
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainAvailableTimePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainAvailableTimePort.kt
@@ -1,0 +1,6 @@
+package team.aliens.dms.domain.remain.spi
+
+interface RemainAvailableTimePort:
+    CommandRemainAvailableTimePort,
+    QueryRemainAvailableTimePort {
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCase.kt
@@ -1,0 +1,46 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.remain.dto.UpdateRemainAvailableTimeRequest
+import team.aliens.dms.domain.remain.model.RemainAvailableTime
+import team.aliens.dms.domain.remain.spi.CommandRemainAvailableTimePort
+import team.aliens.dms.domain.remain.spi.QueryRemainAvailableTimePort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+
+@UseCase
+class UpdateRemainAvailableTimeUseCase(
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: RemainQueryUserPort,
+    private val commandRemainAvailableTimePort: CommandRemainAvailableTimePort,
+    private val queryRemainAvailableTimePort: QueryRemainAvailableTimePort
+) {
+
+    fun execute(request: UpdateRemainAvailableTimeRequest) {
+        val currentUserId = securityPort.getCurrentUserId()
+        val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val remainAvailableTime =
+            queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(currentUser.schoolId)
+
+        remainAvailableTime?.let {
+            commandRemainAvailableTimePort.saveRemainAvailableTime(
+                it.copy(
+                    startDayOfWeek = it.startDayOfWeek,
+                    startTime = it.startTime,
+                    endDayOfWeek = it.endDayOfWeek,
+                    endTime = it.endTime
+                )
+            )
+        } ?: commandRemainAvailableTimePort.saveRemainAvailableTime(
+            RemainAvailableTime(
+                id = currentUser.schoolId,
+                startDayOfWeek = request.startDayOfWeek,
+                startTime = request.startTime,
+                endDayOfWeek = request.endDayOfWeek,
+                endTime = request.endTime
+            )
+        )
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCase.kt
@@ -21,19 +21,7 @@ class UpdateRemainAvailableTimeUseCase(
         val currentUserId = securityPort.getCurrentUserId()
         val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 
-        val remainAvailableTime =
-            queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(currentUser.schoolId)
-
-        remainAvailableTime?.let {
-            commandRemainAvailableTimePort.saveRemainAvailableTime(
-                it.copy(
-                    startDayOfWeek = it.startDayOfWeek,
-                    startTime = it.startTime,
-                    endDayOfWeek = it.endDayOfWeek,
-                    endTime = it.endTime
-                )
-            )
-        } ?: commandRemainAvailableTimePort.saveRemainAvailableTime(
+        commandRemainAvailableTimePort.saveRemainAvailableTime(
             RemainAvailableTime(
                 id = currentUser.schoolId,
                 startDayOfWeek = request.startDayOfWeek,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCase.kt
@@ -4,7 +4,6 @@ import team.aliens.dms.common.annotation.UseCase
 import team.aliens.dms.domain.remain.dto.UpdateRemainAvailableTimeRequest
 import team.aliens.dms.domain.remain.model.RemainAvailableTime
 import team.aliens.dms.domain.remain.spi.CommandRemainAvailableTimePort
-import team.aliens.dms.domain.remain.spi.QueryRemainAvailableTimePort
 import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.remain.spi.RemainSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
@@ -13,8 +12,7 @@ import team.aliens.dms.domain.user.exception.UserNotFoundException
 class UpdateRemainAvailableTimeUseCase(
     private val securityPort: RemainSecurityPort,
     private val queryUserPort: RemainQueryUserPort,
-    private val commandRemainAvailableTimePort: CommandRemainAvailableTimePort,
-    private val queryRemainAvailableTimePort: QueryRemainAvailableTimePort
+    private val commandRemainAvailableTimePort: CommandRemainAvailableTimePort
 ) {
 
     fun execute(request: UpdateRemainAvailableTimeRequest) {

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCaseTests.kt
@@ -1,0 +1,136 @@
+package team.aliens.dms.domain.remain.usecase
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.remain.dto.UpdateRemainAvailableTimeRequest
+import team.aliens.dms.domain.remain.model.RemainAvailableTime
+import team.aliens.dms.domain.remain.spi.CommandRemainAvailableTimePort
+import team.aliens.dms.domain.remain.spi.QueryRemainAvailableTimePort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class UpdateRemainAvailableTimeUseCaseTests {
+
+    @MockBean
+    private lateinit var securityPort: RemainSecurityPort
+
+    @MockBean
+    private lateinit var queryUserPort: RemainQueryUserPort
+
+    @MockBean
+    private lateinit var commandRemainAvailableTimePort: CommandRemainAvailableTimePort
+
+    @MockBean
+    private lateinit var queryRemainAvailableTimePort: QueryRemainAvailableTimePort
+
+    private lateinit var updateRemainAvailableTimeUseCase: UpdateRemainAvailableTimeUseCase
+
+    @BeforeEach
+    fun setUp() {
+        updateRemainAvailableTimeUseCase = UpdateRemainAvailableTimeUseCase(
+                securityPort,
+                queryUserPort,
+                commandRemainAvailableTimePort,
+                queryRemainAvailableTimePort
+            )
+    }
+
+    private val userId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = userId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val remainAvailableTimeStub by lazy {
+        RemainAvailableTime(
+            id = schoolId,
+            startDayOfWeek = requestStub.startDayOfWeek,
+            startTime = requestStub.startTime,
+            endDayOfWeek = requestStub.endDayOfWeek,
+            endTime = requestStub.endTime
+        )
+    }
+
+    private val requestStub by lazy {
+        UpdateRemainAvailableTimeRequest(
+            startDayOfWeek = DayOfWeek.MONDAY,
+            startTime = LocalTime.MIN,
+            endDayOfWeek = DayOfWeek.TUESDAY,
+            endTime = LocalTime.now()
+        )
+    }
+
+    @Test
+    fun `잔류 신청 시간 생성 성공`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(userStub)
+
+        given(queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId))
+            .willReturn(remainAvailableTimeStub)
+
+        // when & then
+        assertDoesNotThrow {
+            updateRemainAvailableTimeUseCase.execute(requestStub)
+        }
+    }
+
+    @Test
+    fun `잔류 신청 시간 변경 성공`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(userStub)
+
+        given(queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId))
+            .willReturn(null)
+
+        // when & then
+        assertDoesNotThrow {
+            updateRemainAvailableTimeUseCase.execute(requestStub)
+        }
+    }
+
+    @Test
+    fun `유저를 찾지 못함`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(null)
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            updateRemainAvailableTimeUseCase.execute(requestStub)
+        }
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/UpdateRemainAvailableTimeUseCaseTests.kt
@@ -10,9 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.auth.model.Authority
 import team.aliens.dms.domain.remain.dto.UpdateRemainAvailableTimeRequest
-import team.aliens.dms.domain.remain.model.RemainAvailableTime
 import team.aliens.dms.domain.remain.spi.CommandRemainAvailableTimePort
-import team.aliens.dms.domain.remain.spi.QueryRemainAvailableTimePort
 import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.remain.spi.RemainSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
@@ -33,9 +31,6 @@ class UpdateRemainAvailableTimeUseCaseTests {
     @MockBean
     private lateinit var commandRemainAvailableTimePort: CommandRemainAvailableTimePort
 
-    @MockBean
-    private lateinit var queryRemainAvailableTimePort: QueryRemainAvailableTimePort
-
     private lateinit var updateRemainAvailableTimeUseCase: UpdateRemainAvailableTimeUseCase
 
     @BeforeEach
@@ -43,8 +38,7 @@ class UpdateRemainAvailableTimeUseCaseTests {
         updateRemainAvailableTimeUseCase = UpdateRemainAvailableTimeUseCase(
                 securityPort,
                 queryUserPort,
-                commandRemainAvailableTimePort,
-                queryRemainAvailableTimePort
+                commandRemainAvailableTimePort
             )
     }
 
@@ -61,16 +55,6 @@ class UpdateRemainAvailableTimeUseCaseTests {
             authority = Authority.MANAGER,
             createdAt = null,
             deletedAt = null
-        )
-    }
-
-    private val remainAvailableTimeStub by lazy {
-        RemainAvailableTime(
-            id = schoolId,
-            startDayOfWeek = requestStub.startDayOfWeek,
-            startTime = requestStub.startTime,
-            endDayOfWeek = requestStub.endDayOfWeek,
-            endTime = requestStub.endTime
         )
     }
 
@@ -91,27 +75,6 @@ class UpdateRemainAvailableTimeUseCaseTests {
 
         given(queryUserPort.queryUserById(userId))
             .willReturn(userStub)
-
-        given(queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId))
-            .willReturn(remainAvailableTimeStub)
-
-        // when & then
-        assertDoesNotThrow {
-            updateRemainAvailableTimeUseCase.execute(requestStub)
-        }
-    }
-
-    @Test
-    fun `잔류 신청 시간 변경 성공`() {
-        // given
-        given(securityPort.getCurrentUserId())
-            .willReturn(userId)
-
-        given(queryUserPort.queryUserById(userId))
-            .willReturn(userStub)
-
-        given(queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId))
-            .willReturn(null)
 
         // when & then
         assertDoesNotThrow {

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/remain/model/RemainAvailableTime.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/remain/model/RemainAvailableTime.kt
@@ -10,12 +10,12 @@ data class RemainAvailableTime(
 
     val id: UUID,
 
-    val startTime: LocalTime,
-
     val startDayOfWeek: DayOfWeek,
 
-    val endTime: LocalTime,
+    val startTime: LocalTime,
 
-    val endDayOfWeek: DayOfWeek
+    val endDayOfWeek: DayOfWeek,
+
+    val endTime: LocalTime,
 
 )

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -118,6 +118,7 @@ class SecurityConfiguration(
 
             // /remains
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.PUT, "/remains/available-time").hasAuthority(MANAGER.name)
             .anyRequest().denyAll()
 
         http

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainAvailableTimePersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainAvailableTimePersistenceAdapter.kt
@@ -6,7 +6,7 @@ import team.aliens.dms.domain.remain.model.RemainAvailableTime
 import team.aliens.dms.domain.remain.spi.RemainAvailableTimePort
 import team.aliens.dms.persistence.remain.mapper.RemainAvailableTimeMapper
 import team.aliens.dms.persistence.remain.repository.RemainAvailableTimeJpaRepository
-import java.util.*
+import java.util.UUID
 
 @Component
 class RemainAvailableTimePersistenceAdapter(

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainAvailableTimePersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainAvailableTimePersistenceAdapter.kt
@@ -1,0 +1,26 @@
+package team.aliens.dms.persistence.remain
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.remain.model.RemainAvailableTime
+import team.aliens.dms.domain.remain.spi.RemainAvailableTimePort
+import team.aliens.dms.persistence.remain.mapper.RemainAvailableTimeMapper
+import team.aliens.dms.persistence.remain.repository.RemainAvailableTimeJpaRepository
+import java.util.*
+
+@Component
+class RemainAvailableTimePersistenceAdapter(
+    private val remainAvailableTimeJpaRepository: RemainAvailableTimeJpaRepository,
+    private val remainAvailableTimeMapper: RemainAvailableTimeMapper
+) : RemainAvailableTimePort {
+
+    override fun saveRemainAvailableTime(remainAvailableTime: RemainAvailableTime) = remainAvailableTimeMapper.toDomain(
+        remainAvailableTimeJpaRepository.save(
+            remainAvailableTimeMapper.toEntity(remainAvailableTime)
+        )
+    )!!
+
+    override fun queryRemainAvailableTimeBySchoolId(schoolId: UUID) = remainAvailableTimeMapper.toDomain(
+        remainAvailableTimeJpaRepository.findByIdOrNull(schoolId)
+    )
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainAvailableTimePersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainAvailableTimePersistenceAdapter.kt
@@ -10,17 +10,17 @@ import java.util.UUID
 
 @Component
 class RemainAvailableTimePersistenceAdapter(
-    private val remainAvailableTimeJpaRepository: RemainAvailableTimeJpaRepository,
+    private val remainAvailableTimeRepository: RemainAvailableTimeJpaRepository,
     private val remainAvailableTimeMapper: RemainAvailableTimeMapper
 ) : RemainAvailableTimePort {
 
     override fun saveRemainAvailableTime(remainAvailableTime: RemainAvailableTime) = remainAvailableTimeMapper.toDomain(
-        remainAvailableTimeJpaRepository.save(
+        remainAvailableTimeRepository.save(
             remainAvailableTimeMapper.toEntity(remainAvailableTime)
         )
     )!!
 
     override fun queryRemainAvailableTimeBySchoolId(schoolId: UUID) = remainAvailableTimeMapper.toDomain(
-        remainAvailableTimeJpaRepository.findByIdOrNull(schoolId)
+        remainAvailableTimeRepository.findByIdOrNull(schoolId)
     )
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -51,7 +51,6 @@ class RemainWebAdapter(
             remainOptionId = remainOptionId!!,
             title = request.title!!,
             description = request.description!!
-
         )
     }
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -3,13 +3,17 @@ package team.aliens.dms.domain.remain
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import team.aliens.dms.domain.remain.dto.UpdateRemainAvailableTimeRequest
 import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
+import team.aliens.dms.domain.remain.dto.request.UpdateRemainAvailableTimeWebRequest
 import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
 import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
+import team.aliens.dms.domain.remain.usecase.UpdateRemainAvailableTimeUseCase
 import javax.validation.Valid
 
 @Validated
@@ -17,6 +21,7 @@ import javax.validation.Valid
 @RestController
 class RemainWebAdapter(
     private val createRemainOptionUseCase: CreateRemainOptionUseCase,
+    private val updateRemainAvailableTimeUseCase: UpdateRemainAvailableTimeUseCase
 ) {
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -27,5 +32,17 @@ class RemainWebAdapter(
             description = request.description!!
         )
         return CreateRemainOptionResponse(remainOptionId)
+    }
+
+    @PutMapping("/available-time")
+    fun updateRemainAvailableTime(@RequestBody @Valid request: UpdateRemainAvailableTimeWebRequest) {
+        updateRemainAvailableTimeUseCase.execute(
+            UpdateRemainAvailableTimeRequest(
+                startDayOfWeek = request.startDayOfWeek!!,
+                startTime = request.startTime!!,
+                endDayOfWeek = request.endDayOfWeek!!,
+                endTime = request.endTime!!
+            )
+        )
     }
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/request/UpdateRemainAvailableTimeWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/dto/request/UpdateRemainAvailableTimeWebRequest.kt
@@ -1,0 +1,21 @@
+package team.aliens.dms.domain.remain.dto.request
+
+import java.time.DayOfWeek
+import java.time.LocalTime
+import javax.validation.constraints.NotNull
+
+data class UpdateRemainAvailableTimeWebRequest(
+
+    @field:NotNull
+    val startDayOfWeek: DayOfWeek?,
+
+    @field:NotNull
+    val startTime: LocalTime?,
+
+    @field:NotNull
+    val endDayOfWeek: DayOfWeek?,
+
+    @field:NotNull
+    val endTime: LocalTime?
+
+)


### PR DESCRIPTION
## 작업 내용 설명
- [X] PUT /remains/available-time
- [X] UpdateRemainAvailableTimeUseCase

## 주요 변경 사항
- 잔류 신청 시간 설정 API

## 결과물
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/103026813/220612989-774de40e-841b-4a35-93f9-9cfead73a332.png">

## 체크리스트
- [X] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [X] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #234 