### PR TITLE
merge: (#249) 상벌점 부여 취소 api 

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/exception/PointHistoryNotFoundException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/exception/PointHistoryNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.point.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.point.error.PointHistoryErrorCode
+
+object PointHistoryNotFoundException : DmsException(
+    PointHistoryErrorCode.POINT_HISTORY_NOT_FOUND
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/CommandPointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/CommandPointHistoryPort.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.point.spi
+
+import team.aliens.dms.domain.point.model.PointHistory
+
+interface CommandPointHistoryPort {
+
+    fun savePointHistory(pointHistory: PointHistory): PointHistory
+
+    fun deletePointHistory(pointHistory: PointHistory)
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/PointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/PointHistoryPort.kt
@@ -4,6 +4,7 @@ import team.aliens.dms.domain.manager.spi.ManagerQueryPointHistoryPort
 import team.aliens.dms.domain.student.spi.StudentQueryPointHistoryPort
 
 interface PointHistoryPort :
+    CommandPointHistoryPort,
     QueryPointHistoryPort,
     ManagerQueryPointHistoryPort,
     StudentQueryPointHistoryPort {

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -3,10 +3,13 @@ package team.aliens.dms.domain.point.spi
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
+import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
 import java.util.UUID
 
 interface QueryPointHistoryPort {
+
+    fun queryPointHistoryById(pointHistoryId: UUID): PointHistory?
 
     fun queryBonusAndMinusTotalPointByStudentGcnAndName(
         gcn: String,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/CancelGrantedPointUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/CancelGrantedPointUseCase.kt
@@ -1,0 +1,34 @@
+package team.aliens.dms.domain.point.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.point.exception.PointHistoryNotFoundException
+import team.aliens.dms.domain.point.spi.CommandPointHistoryPort
+import team.aliens.dms.domain.point.spi.PointQueryUserPort
+import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.util.UUID
+
+@UseCase
+class CancelGrantedPointUseCase(
+    private val commandPointHistoryPort: CommandPointHistoryPort,
+    private val queryPointHistoryPort: QueryPointHistoryPort,
+    private val securityPort: PointSecurityPort,
+    private val queryUserPort: PointQueryUserPort
+) {
+
+    fun execute(pointHistoryId: UUID) {
+        val currentUserId = securityPort.getCurrentUserId()
+        val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val pointHistory = queryPointHistoryPort.queryPointHistoryById(pointHistoryId) ?: throw PointHistoryNotFoundException
+
+        if (manager.schoolId != pointHistory.schoolId) {
+            throw SchoolMismatchException
+        }
+
+        commandPointHistoryPort.savePointHistory(pointHistory.canceledHistory())
+        commandPointHistoryPort.deletePointHistory(pointHistory)
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/CancelGrantedPointUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/CancelGrantedPointUseCase.kt
@@ -28,7 +28,7 @@ class CancelGrantedPointUseCase(
             throw SchoolMismatchException
         }
 
-        commandPointHistoryPort.savePointHistory(pointHistory.canceledHistory())
+        commandPointHistoryPort.savePointHistory(pointHistory.cancelHistory())
         commandPointHistoryPort.deletePointHistory(pointHistory)
     }
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/CancelGrantedPointUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/CancelGrantedPointUseCaseTests.kt
@@ -1,0 +1,139 @@
+package team.aliens.dms.domain.point.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.point.exception.PointHistoryNotFoundException
+import team.aliens.dms.domain.point.model.PointHistory
+import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.CommandPointHistoryPort
+import team.aliens.dms.domain.point.spi.PointQueryUserPort
+import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.time.LocalDateTime
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class CancelGrantedPointUseCaseTests {
+
+    private val commandPointHistoryPort: CommandPointHistoryPort = mockk(relaxed = true)
+    private val queryPointHistoryPort: QueryPointHistoryPort = mockk(relaxed = true)
+    private val securityPort: PointSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: PointQueryUserPort = mockk(relaxed = true)
+
+    private val cancelGrantedPointUseCase = CancelGrantedPointUseCase(
+        commandPointHistoryPort, queryPointHistoryPort, securityPort, queryUserPort
+    )
+
+    private val pointHistoryId = UUID.randomUUID()
+
+    private val managerId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = managerId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val pointHistoryStub by lazy {
+        PointHistory(
+            studentName = "김은빈",
+            studentGcn = "2106",
+            bonusTotal = 3,
+            minusTotal = 0,
+            isCancel = false,
+            pointName = "분리수거",
+            pointScore = 3,
+            pointType = PointType.BONUS,
+            createdAt = LocalDateTime.of(2023, 3, 5, 12, 0),
+            schoolId = schoolId
+        )
+    }
+
+    @Test
+    fun `상벌점 부여 취소 성공`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+
+        every { queryPointHistoryPort.queryPointHistoryById(pointHistoryId) } returns pointHistoryStub
+
+        // when & then
+        assertDoesNotThrow {
+            cancelGrantedPointUseCase.execute(pointHistoryId)
+        }
+    }
+
+    @Test
+    fun `유저가 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns null
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            cancelGrantedPointUseCase.execute(pointHistoryId)
+        }
+    }
+
+    @Test
+    fun `pointHistory 미존재`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+
+        every { queryPointHistoryPort.queryPointHistoryById(pointHistoryId) } returns null
+
+        // when & then
+        assertThrows<PointHistoryNotFoundException> {
+            cancelGrantedPointUseCase.execute(pointHistoryId)
+        }
+    }
+
+    private val otherUserStub by lazy {
+        User(
+            id = managerId,
+            schoolId = UUID.randomUUID(),
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    @Test
+    fun `학교 불일치`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns otherUserStub
+
+        every { queryPointHistoryPort.queryPointHistoryById(pointHistoryId) } returns pointHistoryStub
+
+        // when & then
+        assertThrows<SchoolMismatchException> {
+            cancelGrantedPointUseCase.execute(pointHistoryId)
+        }
+    }
+}

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/error/PointHistoryErrorCode.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/error/PointHistoryErrorCode.kt
@@ -7,7 +7,8 @@ enum class PointHistoryErrorCode(
     private val message: String
 ) : ErrorProperty {
 
-    POINT_HISTORY_NOT_FOUND(404, "Point History Not Found")
+    POINT_HISTORY_NOT_FOUND(404, "Point History Not Found"),
+    POINT_HISTORY_CAN_NOT_CANCEL(400, "Point History Can Not Cancel")
     ;
 
     override fun status(): Int = status

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/exception/PointHistoryCanNotCancelException.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/exception/PointHistoryCanNotCancelException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.point.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.point.error.PointHistoryErrorCode
+
+object PointHistoryCanNotCancelException : DmsException(
+    PointHistoryErrorCode.POINT_HISTORY_CAN_NOT_CANCEL
+)

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.point.model
 
 import team.aliens.dms.common.annotation.Aggregate
+import team.aliens.dms.domain.point.exception.PointHistoryCanNotCancelException
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -29,4 +30,30 @@ data class PointHistory(
 
     val schoolId: UUID
 
-)
+) {
+    fun canceledHistory(): PointHistory {
+
+        if (this.isCancel) {
+            throw PointHistoryCanNotCancelException
+        }
+
+        val bonusTotal = this.bonusTotal -
+                (if (pointType == PointType.BONUS) pointScore else 0)
+
+        val minusTotal = this.minusTotal -
+                (if (pointType == PointType.MINUS) pointScore else 0)
+
+        return PointHistory(
+            isCancel = true,
+            studentName = this.studentName,
+            studentGcn = this.studentGcn,
+            bonusTotal = bonusTotal,
+            minusTotal = minusTotal,
+            pointName = this.pointName,
+            pointScore = this.pointScore,
+            pointType = this.pointType,
+            createdAt = LocalDateTime.now(),
+            schoolId = this.schoolId
+        )
+    }
+}

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -31,17 +31,13 @@ data class PointHistory(
     val schoolId: UUID
 
 ) {
-    fun canceledHistory(): PointHistory {
+    fun cancelHistory(): PointHistory {
 
         if (this.isCancel) {
             throw PointHistoryCanNotCancelException
         }
 
-        val bonusTotal = this.bonusTotal -
-                (if (pointType == PointType.BONUS) pointScore else 0)
-
-        val minusTotal = this.minusTotal -
-                (if (pointType == PointType.MINUS) pointScore else 0)
+        val (bonusTotal, minusTotal) = calculateTotalPoint()
 
         return PointHistory(
             isCancel = true,
@@ -55,5 +51,13 @@ data class PointHistory(
             createdAt = LocalDateTime.now(),
             schoolId = this.schoolId
         )
+    }
+
+    private fun calculateTotalPoint(): Pair<Int, Int> {
+        return if (this.pointType == PointType.BONUS) {
+            Pair(this.bonusTotal + this.pointScore, this.minusTotal)
+        } else {
+            Pair(this.bonusTotal, this.minusTotal + pointScore)
+        }
     }
 }

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -37,7 +37,7 @@ data class PointHistory(
             throw PointHistoryCanNotCancelException
         }
 
-        val (bonusTotal, minusTotal) = calculateTotalPoint()
+        val (bonusTotal, minusTotal) = calculateCanceledPointTotal()
 
         return PointHistory(
             isCancel = true,
@@ -53,7 +53,7 @@ data class PointHistory(
         )
     }
 
-    private fun calculateTotalPoint(): Pair<Int, Int> {
+    private fun calculateCanceledPointTotal(): Pair<Int, Int> {
         return if (this.pointType == PointType.BONUS) {
             Pair(this.bonusTotal - this.pointScore, this.minusTotal)
         } else {

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -55,9 +55,9 @@ data class PointHistory(
 
     private fun calculateTotalPoint(): Pair<Int, Int> {
         return if (this.pointType == PointType.BONUS) {
-            Pair(this.bonusTotal + this.pointScore, this.minusTotal)
+            Pair(this.bonusTotal - this.pointScore, this.minusTotal)
         } else {
-            Pair(this.bonusTotal, this.minusTotal + pointScore)
+            Pair(this.bonusTotal, this.minusTotal - pointScore)
         }
     }
 }

--- a/dms-domain/src/test/kotlin/team/aliens/dms/point/model/PointHistoryTests.kt
+++ b/dms-domain/src/test/kotlin/team/aliens/dms/point/model/PointHistoryTests.kt
@@ -29,7 +29,7 @@ class PointHistoryTests {
         )
 
         // when
-        val canceledHistory = pointHistory.canceledHistory()
+        val canceledHistory = pointHistory.cancelHistory()
 
         // then
         assertAll(
@@ -57,7 +57,7 @@ class PointHistoryTests {
 
         // when & then
         assertThrows<PointHistoryCanNotCancelException> {
-            canceledPointHistory.canceledHistory()
+            canceledPointHistory.cancelHistory()
         }
     }
 }

--- a/dms-domain/src/test/kotlin/team/aliens/dms/point/model/PointHistoryTests.kt
+++ b/dms-domain/src/test/kotlin/team/aliens/dms/point/model/PointHistoryTests.kt
@@ -1,0 +1,63 @@
+package team.aliens.dms.point.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import team.aliens.dms.domain.point.exception.PointHistoryCanNotCancelException
+import team.aliens.dms.domain.point.model.PointHistory
+import team.aliens.dms.domain.point.model.PointType
+import java.time.LocalDateTime
+import java.util.UUID
+
+class PointHistoryTests {
+
+    @Test
+    fun `취소 내역 반환`() {
+        // given
+        val pointHistory = PointHistory(
+            studentName = "김은빈",
+            studentGcn = "2106",
+            bonusTotal = 3,
+            minusTotal = 0,
+            isCancel = false,
+            pointName = "분리수거",
+            pointScore = 3,
+            pointType = PointType.BONUS,
+            createdAt = LocalDateTime.of(2023, 3, 5, 12, 0),
+            schoolId = UUID.randomUUID()
+        )
+
+        // when
+        val canceledHistory = pointHistory.canceledHistory()
+
+        // then
+        assertAll(
+            { assertEquals(canceledHistory.bonusTotal, 0) },
+            { assertEquals(canceledHistory.minusTotal, 0) },
+            { assertEquals(canceledHistory.isCancel, true) }
+        )
+    }
+
+    @Test
+    fun `취소할 수 없는 내역`() {
+        // given
+        val canceledPointHistory = PointHistory(
+            studentName = "김은빈",
+            studentGcn = "2106",
+            bonusTotal = 3,
+            minusTotal = 0,
+            isCancel = true,
+            pointName = "분리수거",
+            pointScore = 3,
+            pointType = PointType.BONUS,
+            createdAt = LocalDateTime.of(2023, 3, 5, 12, 0),
+            schoolId = UUID.randomUUID()
+        )
+
+        // when & then
+        assertThrows<PointHistoryCanNotCancelException> {
+            canceledPointHistory.canceledHistory()
+        }
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -95,7 +95,7 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.GET, "/points").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.POST, "/points/history").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/points/history").hasAuthority(MANAGER.name)
-            .antMatchers(HttpMethod.DELETE, "/points/history/{point-history-id}").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.PUT, "/points/history/{point-history-id}").hasAuthority(MANAGER.name)
 
             // /templates
             .antMatchers(HttpMethod.GET, "/templates").permitAll()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -94,6 +94,7 @@ class SecurityConfiguration(
             // /points
             .antMatchers(HttpMethod.GET, "/points").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.GET, "/points/history").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.DELETE, "/points/history/{point-history-id}").hasAuthority(MANAGER.name)
 
             // /templates
             .antMatchers(HttpMethod.GET, "/templates").permitAll()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -1,10 +1,12 @@
 package team.aliens.dms.persistence.point
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
+import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointHistoryPort
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
@@ -20,6 +22,22 @@ class PointHistoryPersistenceAdapter(
     private val pointHistoryRepository: PointHistoryJpaRepository,
     private val queryFactory: JPAQueryFactory
 ) : PointHistoryPort {
+
+    override fun savePointHistory(pointHistory: PointHistory) = pointHistoryMapper.toDomain(
+        pointHistoryRepository.save(
+            pointHistoryMapper.toEntity(pointHistory)
+        )
+    )!!
+
+    override fun deletePointHistory(pointHistory: PointHistory) {
+        pointHistoryRepository.delete(
+            pointHistoryMapper.toEntity(pointHistory)
+        )
+    }
+
+    override fun queryPointHistoryById(pointHistoryId: UUID) = pointHistoryMapper.toDomain(
+        pointHistoryRepository.findByIdOrNull(pointHistoryId)
+    )
 
     override fun queryBonusAndMinusTotalPointByStudentGcnAndName(
         gcn: String,

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -2,10 +2,10 @@ package team.aliens.dms.domain.point
 
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -47,7 +47,7 @@ class PointWebAdapter(
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/history/{point-history-id}")
+    @PutMapping("/history/{point-history-id}")
     fun cancelGrantedPoint(@PathVariable("point-history-id") pointHistoryId: UUID) {
         cancelGrantedPointUseCase.execute(pointHistoryId)
     }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -1,18 +1,24 @@
 package team.aliens.dms.domain.point
 
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.common.dto.PageWebData
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
+import team.aliens.dms.domain.point.usecase.CancelGrantedPointUseCase
 import team.aliens.dms.domain.point.usecase.QueryAllPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.QueryPointHistoryUseCase
+import java.util.UUID
 import javax.validation.constraints.NotNull
 
 @Validated
@@ -21,6 +27,7 @@ import javax.validation.constraints.NotNull
 class PointWebAdapter(
     private val queryPointHistoryUseCase: QueryPointHistoryUseCase,
     private val queryAllPointHistoryUseCase: QueryAllPointHistoryUseCase,
+    private val cancelGrantedPointUseCase: CancelGrantedPointUseCase,
 ) {
 
     @GetMapping
@@ -37,5 +44,11 @@ class PointWebAdapter(
             type = type!!,
             pageData = PageData(pageData.page, pageData.size)
         )
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/history/{point-history-id}")
+    fun cancelGrantedPoint(@PathVariable("point-history-id") pointHistoryId: UUID) {
+        cancelGrantedPointUseCase.execute(pointHistoryId)
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x]  CancelGrantedPointUseCase
- [x] DELETE /points/history/{point-history-id}

## 주요 변경 사항
- 상벌점 부여 취소 api
- domain 모듈에 있는 PointHistory model에 취소 내역을 반환하는 메서드를 만들었습니다.

## 결과물
<img src="https://user-images.githubusercontent.com/81006587/220226678-2fc2a8fd-ca09-4fba-94ef-730d8050529c.png" height=150px>

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #249