### PR TITLE
merge: (#256) 학생 상벌점 내역 조회api

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/PointHistoryDto.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/PointHistoryDto.kt
@@ -1,9 +1,9 @@
-package team.aliens.dms.domain.point.spi.vo
+package team.aliens.dms.domain.point.dto
 
 import team.aliens.dms.domain.point.model.PointType
 import java.time.LocalDate
 
-data class PointHistoryVO(
+data class PointHistoryDto(
     val date: LocalDate,
     val type: PointType,
     val name: String,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
@@ -1,16 +1,10 @@
 package team.aliens.dms.domain.point.dto
 
 import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 import java.time.LocalDate
 
 data class QueryPointHistoryResponse(
     val totalPoint: Int,
-    val points: List<Point>
-) {
-    data class Point(
-        val date: LocalDate,
-        val type: PointType,
-        val name: String,
-        val score: Int
-    )
-}
+    val points: List<PointHistoryVO>
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
@@ -1,8 +1,6 @@
 package team.aliens.dms.domain.point.dto
 
-import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
-
 data class QueryPointHistoryResponse(
     val totalPoint: Int,
-    val points: List<PointHistoryVO>
+    val points: List<PointHistoryDto>
 )

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryPointHistoryResponse.kt
@@ -1,8 +1,6 @@
 package team.aliens.dms.domain.point.dto
 
-import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
-import java.time.LocalDate
 
 data class QueryPointHistoryResponse(
     val totalPoint: Int,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryStudentPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryStudentPointHistoryResponse.kt
@@ -1,7 +1,5 @@
 package team.aliens.dms.domain.point.dto
 
-import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
-
 data class QueryStudentPointHistoryResponse(
     val pointHistories: List<PointHistoryVO>
 )

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryStudentPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryStudentPointHistoryResponse.kt
@@ -1,5 +1,5 @@
 package team.aliens.dms.domain.point.dto
 
 data class QueryStudentPointHistoryResponse(
-    val pointHistories: List<PointHistoryVO>
+    val pointHistories: List<PointHistoryDto>
 )

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryStudentPointHistoryResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/dto/QueryStudentPointHistoryResponse.kt
@@ -1,0 +1,7 @@
+package team.aliens.dms.domain.point.dto
+
+import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
+
+data class QueryStudentPointHistoryResponse(
+    val pointHistories: List<PointHistoryVO>
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -3,7 +3,6 @@ package team.aliens.dms.domain.point.spi
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.PointHistoryDto
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
-import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
 import java.time.LocalDateTime

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.point.spi
 
 import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.PointHistoryDto
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointHistory
@@ -23,7 +24,7 @@ interface QueryPointHistoryPort {
         type: PointType? = null,
         isCancel: Boolean? = null,
         pageData: PageData = PageData.DEFAULT
-    ): List<PointHistoryVO>
+    ): List<PointHistoryDto>
 
     fun queryPointHistoryBySchoolIdAndType(
         schoolId: UUID,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -20,9 +20,10 @@ interface QueryPointHistoryPort {
     fun queryPointHistoryByStudentGcnAndNameAndType(
         gcn: String,
         studentName: String,
-        type: PointType?,
-        isCancel: Boolean? = null
-    ): List<QueryPointHistoryResponse.Point>
+        type: PointType? = null,
+        isCancel: Boolean? = null,
+        pageData: PageData = PageData.DEFAULT
+    ): List<PointHistoryVO>
 
     fun queryPointHistoryBySchoolIdAndType(
         schoolId: UUID,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/vo/PointHistoryVO.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/spi/vo/PointHistoryVO.kt
@@ -1,0 +1,11 @@
+package team.aliens.dms.domain.point.spi.vo
+
+import team.aliens.dms.domain.point.model.PointType
+import java.time.LocalDate
+
+data class PointHistoryVO(
+    val date: LocalDate,
+    val type: PointType,
+    val name: String,
+    val score: Int
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryPointHistoryUseCase.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.point.usecase
 
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
@@ -15,7 +16,7 @@ class QueryPointHistoryUseCase(
     private val queryPointHistoryPort: QueryPointHistoryPort
 ) {
 
-    fun execute(type: PointRequestType): QueryPointHistoryResponse {
+    fun execute(type: PointRequestType, pageData: PageData): QueryPointHistoryResponse {
         val currentStudentId = securityPort.getCurrentUserId()
         val currentStudent = queryStudentPort.queryStudentById(currentStudentId) ?: throw StudentNotFoundException
 
@@ -28,7 +29,8 @@ class QueryPointHistoryUseCase(
                 gcn = gcn,
                 studentName = name,
                 type = pointType,
-                isCancel = false
+                isCancel = false,
+                pageData = pageData
             )
 
         val (bonusTotal, minusTotal) =

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryStudentPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryStudentPointHistoryUseCase.kt
@@ -1,0 +1,40 @@
+package team.aliens.dms.domain.point.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
+import team.aliens.dms.domain.point.dto.QueryStudentPointHistoryResponse
+import team.aliens.dms.domain.point.spi.PointQueryManagerPort
+import team.aliens.dms.domain.point.spi.PointQueryStudentPort
+import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import java.util.UUID
+
+@ReadOnlyUseCase
+class QueryStudentPointHistoryUseCase(
+    private val securityPort: PointSecurityPort,
+    private val queryManagerPort: PointQueryManagerPort,
+    private val queryStudentPort: PointQueryStudentPort,
+    private val queryPointHistoryPort: QueryPointHistoryPort
+) {
+
+    fun execute(studentId: UUID, pageData: PageData): QueryStudentPointHistoryResponse {
+        val currentUserId = securityPort.getCurrentUserId()
+        val manager = queryManagerPort.queryManagerById(currentUserId) ?: throw ManagerNotFoundException
+
+        val student = queryStudentPort.queryStudentById(studentId) ?: throw StudentNotFoundException
+        if (student.schoolId != manager.schoolId) {
+            throw SchoolMismatchException
+        }
+
+        val pointHistories = queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+            studentName = student.name,
+            gcn = student.gcn,
+            pageData = pageData
+        )
+
+        return QueryStudentPointHistoryResponse(pointHistories)
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryStudentPointHistoryUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/QueryStudentPointHistoryUseCase.kt
@@ -32,7 +32,8 @@ class QueryStudentPointHistoryUseCase(
         val pointHistories = queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
             studentName = student.name,
             gcn = student.gcn,
-            pageData = pageData
+            pageData = pageData,
+            isCancel = false
         )
 
         return QueryStudentPointHistoryResponse(pointHistories)

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -15,7 +15,7 @@ import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
-import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
+import team.aliens.dms.domain.point.dto.PointHistoryDto
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.Student
@@ -74,13 +74,13 @@ class QueryPointHistoryUseCaseTests {
     fun `상벌점 내역 조회 성공(BONUS)`() {
         // given
         val pointStubs = listOf(
-            PointHistoryVO(
+            PointHistoryDto(
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
-            PointHistoryVO(
+            PointHistoryDto(
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name2",
@@ -123,13 +123,13 @@ class QueryPointHistoryUseCaseTests {
     fun `상벌점 내역 조회 성공(MINUS)`() {
         // given
         val pointStubs = listOf(
-            PointHistoryVO(
+            PointHistoryDto(
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name",
                 score = 5
             ),
-            PointHistoryVO(
+            PointHistoryDto(
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",
@@ -170,13 +170,13 @@ class QueryPointHistoryUseCaseTests {
     fun `상벌점 내역 조회 성공(ALL)`() {
         // given
         val pointStubs = listOf(
-            PointHistoryVO(
+            PointHistoryDto(
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
-            PointHistoryVO(
+            PointHistoryDto(
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -94,8 +94,15 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(gcn, name, PointType.BONUS, false))
-            .willReturn(pointStubs)
+        given(
+            queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+                gcn = gcn,
+                studentName = name,
+                type = PointType.BONUS,
+                isCancel = false,
+                pageData = pageStub
+            )
+        ).willReturn(pointStubs)
 
         given(queryPointHistoryPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(15, 0))
@@ -136,8 +143,15 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(gcn, name, PointType.MINUS, false))
-            .willReturn(pointStubs)
+        given(
+            queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+                gcn = gcn,
+                studentName = name,
+                type = PointType.MINUS,
+                isCancel = false,
+                pageData = pageStub
+            )
+        ).willReturn(pointStubs)
 
         given(queryPointHistoryPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(15, 10))
@@ -176,8 +190,15 @@ class QueryPointHistoryUseCaseTests {
         given(queryStudentPort.queryStudentById(currentStudentId))
             .willReturn(studentStub)
 
-        given(queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(gcn, name, null, false))
-            .willReturn(pointStubs)
+        given(
+            queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+                gcn = gcn,
+                studentName = name,
+                type = null,
+                isCancel = false,
+                pageData = pageStub
+            )
+        ).willReturn(pointStubs)
 
         given(queryPointHistoryPort.queryBonusAndMinusTotalPointByStudentGcnAndName(gcn, name))
             .willReturn(Pair(10, 5))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.PointRequestType
-import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
@@ -60,6 +60,13 @@ class QueryPointHistoryUseCaseTests {
         )
     }
 
+    private val pageStub by lazy {
+        PageData(
+            page = 0,
+            size = 10
+        )
+    }
+
     private val gcn = studentStub.gcn
     private val name = studentStub.name
 
@@ -94,7 +101,7 @@ class QueryPointHistoryUseCaseTests {
             .willReturn(Pair(15, 0))
 
         // when
-        val response = queryPointHistoryUseCase.execute(PointRequestType.BONUS)
+        val response = queryPointHistoryUseCase.execute(PointRequestType.BONUS, pageStub)
 
         println(response)
 
@@ -136,7 +143,7 @@ class QueryPointHistoryUseCaseTests {
             .willReturn(Pair(15, 10))
 
         // when
-        val response = queryPointHistoryUseCase.execute(PointRequestType.MINUS)
+        val response = queryPointHistoryUseCase.execute(PointRequestType.MINUS, pageStub)
 
         // then
         assertAll(
@@ -176,7 +183,7 @@ class QueryPointHistoryUseCaseTests {
             .willReturn(Pair(10, 5))
 
         // when
-        val response = queryPointHistoryUseCase.execute(PointRequestType.ALL)
+        val response = queryPointHistoryUseCase.execute(PointRequestType.ALL, pageStub)
 
         // then
         assertAll(
@@ -196,7 +203,7 @@ class QueryPointHistoryUseCaseTests {
 
         // when & then
         assertThrows<StudentNotFoundException> {
-            queryPointHistoryUseCase.execute(PointRequestType.ALL)
+            queryPointHistoryUseCase.execute(PointRequestType.ALL, pageStub)
         }
     }
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryPointHistoryUseCaseTests.kt
@@ -15,6 +15,7 @@ import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.Student
@@ -66,13 +67,13 @@ class QueryPointHistoryUseCaseTests {
     fun `상벌점 내역 조회 성공(BONUS)`() {
         // given
         val pointStubs = listOf(
-            QueryPointHistoryResponse.Point(
+            PointHistoryVO(
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
-            QueryPointHistoryResponse.Point(
+            PointHistoryVO(
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name2",
@@ -108,13 +109,13 @@ class QueryPointHistoryUseCaseTests {
     fun `상벌점 내역 조회 성공(MINUS)`() {
         // given
         val pointStubs = listOf(
-            QueryPointHistoryResponse.Point(
+            PointHistoryVO(
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name",
                 score = 5
             ),
-            QueryPointHistoryResponse.Point(
+            PointHistoryVO(
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",
@@ -148,13 +149,13 @@ class QueryPointHistoryUseCaseTests {
     fun `상벌점 내역 조회 성공(ALL)`() {
         // given
         val pointStubs = listOf(
-            QueryPointHistoryResponse.Point(
+            PointHistoryVO(
                 date = LocalDate.now(),
                 type = PointType.BONUS,
                 name = "test name",
                 score = 10
             ),
-            QueryPointHistoryResponse.Point(
+            PointHistoryVO(
                 date = LocalDate.now(),
                 type = PointType.MINUS,
                 name = "test name2",

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
@@ -141,7 +141,7 @@ class QueryStudentPointHistoryUseCaseTest {
         every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
 
         every { queryStudentPort.queryStudentById(studentId) } returns null
-        
+
         every {
             queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
                 gcn = studentStub.gcn,

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
@@ -11,17 +11,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
 import team.aliens.dms.domain.manager.model.Manager
+import team.aliens.dms.domain.point.dto.PointHistoryDto
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointQueryManagerPort
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointSecurityPort
 import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
-import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.Student
-import team.aliens.dms.domain.user.exception.UserNotFoundException
 import java.time.LocalDate
 import java.util.UUID
 
@@ -81,7 +80,7 @@ class QueryStudentPointHistoryUseCaseTest {
     }
 
     private val pointHistoryStub by lazy {
-        PointHistoryVO(
+        PointHistoryDto(
             name = "호실 청결상태 우수",
             type = PointType.BONUS,
             score = 10,
@@ -90,7 +89,7 @@ class QueryStudentPointHistoryUseCaseTest {
     }
 
     private val pointHistoryStub2 by lazy {
-        PointHistoryVO(
+        PointHistoryDto(
             name = "타호실",
             type = PointType.MINUS,
             score = 10,
@@ -107,7 +106,7 @@ class QueryStudentPointHistoryUseCaseTest {
 
     @Test
     fun `학생 상벌점 내역 조회 성공`() {
-        //given
+        // given
         every { securityPort.getCurrentUserId() } returns currentUserId
 
         every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
@@ -123,10 +122,10 @@ class QueryStudentPointHistoryUseCaseTest {
             )
         } returns listOf(pointHistoryStub, pointHistoryStub2)
 
-        //when
+        // when
         val result = queryStudentPointHistoryUseCase.execute(studentId, pageStub).pointHistories
 
-        //then
+        // then
         assertAll(
             { assertEquals(result.size, 2) },
             { assertEquals(result[0], pointHistoryStub) }
@@ -135,7 +134,7 @@ class QueryStudentPointHistoryUseCaseTest {
 
     @Test
     fun `학생 미존재`() {
-        //given
+        // given
         every { securityPort.getCurrentUserId() } returns currentUserId
 
         every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
@@ -151,7 +150,7 @@ class QueryStudentPointHistoryUseCaseTest {
             )
         } returns listOf(pointHistoryStub, pointHistoryStub2)
 
-        //when & then
+        // when & then
         assertThrows<StudentNotFoundException> {
             queryStudentPointHistoryUseCase.execute(studentId, pageStub)
         }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
@@ -1,0 +1,196 @@
+package team.aliens.dms.domain.point.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
+import team.aliens.dms.domain.manager.model.Manager
+import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.point.spi.PointQueryManagerPort
+import team.aliens.dms.domain.point.spi.PointQueryStudentPort
+import team.aliens.dms.domain.point.spi.PointSecurityPort
+import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
+import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class QueryStudentPointHistoryUseCaseTest {
+
+    private val securityPort: PointSecurityPort = mockk()
+    private val queryManagerPort: PointQueryManagerPort = mockk()
+    private val queryStudentPort: PointQueryStudentPort = mockk()
+    private val queryPointHistoryPort: QueryPointHistoryPort = mockk()
+
+    private val queryStudentPointHistoryUseCase = QueryStudentPointHistoryUseCase(
+        securityPort, queryManagerPort, queryStudentPort, queryPointHistoryPort
+    )
+
+    private val currentUserId = UUID.randomUUID()
+    private val studentId = UUID.randomUUID()
+    private val roomId = UUID.randomUUID()
+    private val managerId = currentUserId
+    private val schoolId = UUID.randomUUID()
+    private val otherSchoolId = UUID.randomUUID()
+
+    private val managerStub by lazy {
+        Manager(
+            id = managerId,
+            schoolId = schoolId,
+            name = "사감쌤"
+        )
+    }
+
+    private val studentStub by lazy {
+        Student(
+            id = studentId,
+            schoolId = schoolId,
+            name = "이하성",
+            grade = 2,
+            classRoom = 1,
+            number = 15,
+            roomId = roomId,
+            sex = Sex.MALE,
+            roomNumber = 422
+        )
+    }
+
+    private val otherSchoolStudentStub by lazy {
+        Student(
+            id = studentId,
+            schoolId = otherSchoolId,
+            name = "홍길동",
+            grade = 1,
+            classRoom = 1,
+            number = 11,
+            roomId = roomId,
+            sex = Sex.MALE,
+            roomNumber = 422
+        )
+    }
+
+    private val pointHistoryStub by lazy {
+        PointHistoryVO(
+            name = "호실 청결상태 우수",
+            type = PointType.BONUS,
+            score = 10,
+            date = LocalDate.now()
+        )
+    }
+
+    private val pointHistoryStub2 by lazy {
+        PointHistoryVO(
+            name = "타호실",
+            type = PointType.MINUS,
+            score = 10,
+            date = LocalDate.now()
+        )
+    }
+
+    private val pageStub by lazy {
+        PageData(
+            page = 0,
+            size = 10
+        )
+    }
+
+    @Test
+    fun `학생 상벌점 내역 조회 성공`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns currentUserId
+
+        every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
+
+        every { queryStudentPort.queryStudentById(studentId) } returns studentStub
+
+        every {
+            queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+                gcn = studentStub.gcn,
+                studentName = studentStub.name,
+                isCancel = false,
+                pageData = pageStub
+            )
+        } returns listOf(pointHistoryStub, pointHistoryStub2)
+
+        //when
+        val result = queryStudentPointHistoryUseCase.execute(studentId, pageStub).pointHistories
+
+        //then
+        assertAll(
+            { assertEquals(result.size, 2) },
+            { assertEquals(result[0], pointHistoryStub) }
+        )
+    }
+
+    @Test
+    fun `학생 미존재`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns currentUserId
+
+        every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
+
+        every { queryStudentPort.queryStudentById(studentId) } returns null
+        
+        every {
+            queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+                gcn = studentStub.gcn,
+                studentName = studentStub.name,
+                isCancel = false,
+                pageData = pageStub
+            )
+        } returns listOf(pointHistoryStub, pointHistoryStub2)
+
+        //when & then
+        assertThrows<StudentNotFoundException> {
+            queryStudentPointHistoryUseCase.execute(studentId, pageStub)
+        }
+    }
+
+    @Test
+    fun `다른 학교 학생인경우`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns currentUserId
+
+        every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
+
+        every { queryStudentPort.queryStudentById(studentId) } returns otherSchoolStudentStub
+
+        every {
+            queryPointHistoryPort.queryPointHistoryByStudentGcnAndNameAndType(
+                gcn = studentStub.gcn,
+                studentName = studentStub.name,
+                isCancel = false,
+                pageData = pageStub
+            )
+        } returns listOf(pointHistoryStub, pointHistoryStub2)
+
+        //when & then
+        assertThrows<SchoolMismatchException> {
+            queryStudentPointHistoryUseCase.execute(studentId, pageStub)
+        }
+    }
+
+    @Test
+    fun `관리자 미존재`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryManagerPort.queryManagerById(managerId) } returns null
+
+        // when & then
+        assertThrows<ManagerNotFoundException> {
+            queryStudentPointHistoryUseCase.execute(studentId, pageStub)
+        }
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/QueryStudentPointHistoryUseCaseTest.kt
@@ -158,7 +158,7 @@ class QueryStudentPointHistoryUseCaseTest {
 
     @Test
     fun `다른 학교 학생인경우`() {
-        //given
+        // given
         every { securityPort.getCurrentUserId() } returns currentUserId
 
         every { queryManagerPort.queryManagerById(currentUserId) } returns managerStub
@@ -174,7 +174,7 @@ class QueryStudentPointHistoryUseCaseTest {
             )
         } returns listOf(pointHistoryStub, pointHistoryStub2)
 
-        //when & then
+        // when & then
         assertThrows<SchoolMismatchException> {
             queryStudentPointHistoryUseCase.execute(studentId, pageStub)
         }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -97,6 +97,7 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.DELETE, "/points/options/{point-option-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.POST, "/points/history").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/points/history").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.GET, "/points/history/students/{student-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/points/history/file").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PUT, "/points/history/{point-history-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/points/options").hasAuthority(MANAGER.name)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -4,11 +4,11 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.common.dto.PageData
+import team.aliens.dms.domain.point.dto.PointHistoryDto
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointHistoryPort
-import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
@@ -65,7 +65,7 @@ class PointHistoryPersistenceAdapter(
         type: PointType?,
         isCancel: Boolean?,
         pageData: PageData
-    ): List<PointHistoryVO> {
+    ): List<PointHistoryDto> {
         return queryFactory
             .select(
                 QQueryPointHistoryVO(
@@ -87,7 +87,7 @@ class PointHistoryPersistenceAdapter(
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .fetch()
             .map {
-                PointHistoryVO(
+                PointHistoryDto(
                     date = it.date.toLocalDate(),
                     type = it.pointType,
                     name = it.pointName,

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -5,10 +5,10 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
-import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
 import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.PointHistoryPort
+import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
@@ -63,8 +63,9 @@ class PointHistoryPersistenceAdapter(
         gcn: String,
         studentName: String,
         type: PointType?,
-        isCancel: Boolean?
-    ): List<QueryPointHistoryResponse.Point> {
+        isCancel: Boolean?,
+        pageData: PageData
+    ): List<PointHistoryVO> {
         return queryFactory
             .select(
                 QQueryPointHistoryVO(
@@ -81,10 +82,12 @@ class PointHistoryPersistenceAdapter(
                 type?.let { pointHistoryJpaEntity.pointType.eq(it) },
                 isCancel?.let { pointHistoryJpaEntity.isCancel.eq(it) }
             )
+            .offset(pageData.offset)
+            .limit(pageData.size)
             .orderBy(pointHistoryJpaEntity.createdAt.desc())
             .fetch()
             .map {
-                QueryPointHistoryResponse.Point(
+                PointHistoryVO(
                     date = it.date.toLocalDate(),
                     type = it.pointType,
                     name = it.pointName,

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -49,8 +49,13 @@ import javax.validation.constraints.NotNull
 class PointWebAdapter(
     private val queryPointHistoryUseCase: QueryPointHistoryUseCase,
     private val createPointOptionUseCase: CreatePointOptionUseCase,
+    private val removePointOptionUseCase: RemovePointOptionUseCase,
     private val grantPointUseCase: GrantPointUseCase,
     private val queryAllPointHistoryUseCase: QueryAllPointHistoryUseCase,
+    private val exportAllPointHistoryUseCase: ExportAllPointHistoryUseCase,
+    private val cancelGrantedPointUseCase: CancelGrantedPointUseCase,
+    private val queryPointOptionsUseCase: QueryPointOptionsUseCase,
+    private val queryStudentPointHistoryUseCase: QueryStudentPointHistoryUseCase
 ) {
 
     @GetMapping

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -23,6 +23,7 @@ import team.aliens.dms.domain.point.dto.GrantPointRequest
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
+import team.aliens.dms.domain.point.dto.QueryStudentPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointOptionsResponse
 import team.aliens.dms.domain.point.dto.request.CreatePointOptionWebRequest
 import team.aliens.dms.domain.point.dto.request.GrantPointWebRequest
@@ -32,6 +33,7 @@ import team.aliens.dms.domain.point.usecase.ExportAllPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.GrantPointUseCase
 import team.aliens.dms.domain.point.usecase.QueryAllPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.QueryPointHistoryUseCase
+import team.aliens.dms.domain.point.usecase.QueryStudentPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.QueryPointOptionsUseCase
 import team.aliens.dms.domain.point.usecase.RemovePointOptionUseCase
 import java.net.URLEncoder
@@ -49,15 +51,14 @@ class PointWebAdapter(
     private val createPointOptionUseCase: CreatePointOptionUseCase,
     private val grantPointUseCase: GrantPointUseCase,
     private val queryAllPointHistoryUseCase: QueryAllPointHistoryUseCase,
-    private val exportAllPointHistoryUseCase: ExportAllPointHistoryUseCase,
-    private val removePointOptionUseCase: RemovePointOptionUseCase,
-    private val cancelGrantedPointUseCase: CancelGrantedPointUseCase,
-    private val queryPointOptionsUseCase: QueryPointOptionsUseCase
 ) {
 
     @GetMapping
-    fun getPointHistory(@RequestParam @NotNull type: PointRequestType?): QueryPointHistoryResponse {
-        return queryPointHistoryUseCase.execute(type!!)
+    fun getPointHistory(
+        @RequestParam @NotNull type: PointRequestType?,
+        @ModelAttribute pageData: PageData
+    ): QueryPointHistoryResponse {
+        return queryPointHistoryUseCase.execute(type!!, pageData)
     }
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -123,6 +124,14 @@ class PointWebAdapter(
     @GetMapping("/options")
     fun getAllPointOptions(@RequestParam(required = false) keyword: String?): QueryPointOptionsResponse {
         return queryPointOptionsUseCase.execute(keyword)
+    }
+
+    @GetMapping("/history/students/{student-id}")
+    fun getAllStudentPointHistory(
+        @PathVariable("student-id") studentId: UUID,
+        @ModelAttribute pageData: PageData
+    ): QueryStudentPointHistoryResponse {
+        return queryStudentPointHistoryUseCase.execute(studentId, pageData)
     }
 }
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -23,8 +23,8 @@ import team.aliens.dms.domain.point.dto.GrantPointRequest
 import team.aliens.dms.domain.point.dto.PointRequestType
 import team.aliens.dms.domain.point.dto.QueryAllPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointHistoryResponse
-import team.aliens.dms.domain.point.dto.QueryStudentPointHistoryResponse
 import team.aliens.dms.domain.point.dto.QueryPointOptionsResponse
+import team.aliens.dms.domain.point.dto.QueryStudentPointHistoryResponse
 import team.aliens.dms.domain.point.dto.request.CreatePointOptionWebRequest
 import team.aliens.dms.domain.point.dto.request.GrantPointWebRequest
 import team.aliens.dms.domain.point.usecase.CancelGrantedPointUseCase
@@ -33,8 +33,8 @@ import team.aliens.dms.domain.point.usecase.ExportAllPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.GrantPointUseCase
 import team.aliens.dms.domain.point.usecase.QueryAllPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.QueryPointHistoryUseCase
-import team.aliens.dms.domain.point.usecase.QueryStudentPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.QueryPointOptionsUseCase
+import team.aliens.dms.domain.point.usecase.QueryStudentPointHistoryUseCase
 import team.aliens.dms.domain.point.usecase.RemovePointOptionUseCase
 import java.net.URLEncoder
 import java.time.LocalDateTime

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -91,7 +91,7 @@ class PointWebAdapter(
     }
 
     @GetMapping("/history")
-    fun getAllPointHistory(
+    fun getPointHistories(
         @RequestParam @NotNull type: PointRequestType?,
         @ModelAttribute pageData: PageWebData
     ): QueryAllPointHistoryResponse {
@@ -127,11 +127,10 @@ class PointWebAdapter(
     }
 
     @GetMapping("/history/students/{student-id}")
-    fun getAllStudentPointHistory(
+    fun getStudentsPointHistory(
         @PathVariable("student-id") studentId: UUID,
         @ModelAttribute pageData: PageData
     ): QueryStudentPointHistoryResponse {
         return queryStudentPointHistoryUseCase.execute(studentId, pageData)
     }
 }
-


### PR DESCRIPTION
## 작업 내용 설명
- [x] GET /points/history/students/{student-id}
- [x] QueryStudentPointHistoryUseCase

## 주요 변경 사항
- 학생 상벌점 내역 조회 기능 추가
- 기존의 상벌점 내역조회(`QueryPointHistoryUseCase`)에 페이징 추가

## 결과물
<img width="796" alt="스크린샷 2023-02-21 오후 10 18 30" src="https://user-images.githubusercontent.com/52336493/220368456-2afdb13b-2d44-4fce-9b4e-f6a57ac0dd33.png">


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #256 