### PR TITLE
merge: (#261) 학생 잔류 신청내역 엑셀 출력 api

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/file/spi/WriteFilePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/file/spi/WriteFilePort.kt
@@ -1,7 +1,11 @@
 package team.aliens.dms.domain.file.spi
 
 import team.aliens.dms.domain.point.model.PointHistory
+import team.aliens.dms.domain.remain.dto.StudentRemainInfo
 
 interface WriteFilePort {
+
     fun writePointHistoryExcelFile(pointHistories: List<PointHistory>): ByteArray
+
+    fun writeRemainStatusExcelFile(studentRemainInfos: List<StudentRemainInfo>): ByteArray
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/RemainStatusInfo.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/RemainStatusInfo.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.dto
+
+import java.util.UUID
+
+class RemainStatusInfo (
+    val studentId: UUID,
+    val optionName: String
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/StudentRemainInfo.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/StudentRemainInfo.kt
@@ -1,0 +1,11 @@
+package team.aliens.dms.domain.remain.dto
+
+import team.aliens.dms.domain.student.model.Sex
+
+data class StudentRemainInfo(
+    val studentName: String,
+    val studentGcn: String,
+    val studentSex: Sex,
+    val roomNumber: Int,
+    val optionName: String?
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/response/ExportRemainStatusResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/response/ExportRemainStatusResponse.kt
@@ -1,0 +1,6 @@
+package team.aliens.dms.domain.remain.dto.response
+
+class ExportRemainStatusResponse(
+    val fileName: String,
+    val file: ByteArray
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainStatusPort.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.remain.dto.RemainStatusInfo
+import java.util.UUID
+
+interface QueryRemainStatusPort {
+    fun queryByStudentIdIn(studentIds: List<UUID>): List<RemainStatusInfo>
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQuerySchoolPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQuerySchoolPort.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.school.model.School
+import java.util.UUID
+
+interface RemainQuerySchoolPort {
+    fun querySchoolById(schoolId: UUID): School?
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryStudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryStudentPort.kt
@@ -4,5 +4,5 @@ import team.aliens.dms.domain.student.model.Student
 import java.util.UUID
 
 interface RemainQueryStudentPort {
-    fun queryStudentBySchoolId(schoolId: UUID): List<Student>
+    fun queryStudentsBySchoolId(schoolId: UUID): List<Student>
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryStudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryStudentPort.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.student.model.Student
+import java.util.UUID
+
+interface RemainQueryStudentPort {
+    fun queryStudentBySchoolId(schoolId: UUID): List<Student>
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
@@ -1,0 +1,4 @@
+package team.aliens.dms.domain.remain.spi
+
+interface RemainStatusPort : QueryRemainStatusPort {
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ExportRemainStatusUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ExportRemainStatusUseCase.kt
@@ -31,7 +31,7 @@ class ExportRemainStatusUseCase(
         val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
         val school = querySchoolPort.querySchoolById(manager.schoolId) ?: throw SchoolNotFoundException
 
-        val studentList = queryStudentPort.queryStudentBySchoolId(manager.schoolId)
+        val studentList = queryStudentPort.queryStudentsBySchoolId(manager.schoolId)
 
         val remainStatusMap = queryRemainStatusPort.queryByStudentIdIn(
             studentIds = studentList.map { it.id }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ExportRemainStatusUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ExportRemainStatusUseCase.kt
@@ -1,0 +1,58 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.file.model.File
+import team.aliens.dms.domain.file.spi.WriteFilePort
+import team.aliens.dms.domain.remain.dto.StudentRemainInfo
+import team.aliens.dms.domain.remain.dto.response.ExportRemainStatusResponse
+import team.aliens.dms.domain.remain.spi.QueryRemainStatusPort
+import team.aliens.dms.domain.remain.spi.RemainQuerySchoolPort
+import team.aliens.dms.domain.remain.spi.RemainQueryStudentPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolNotFoundException
+import team.aliens.dms.domain.school.model.School
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.time.LocalDateTime
+
+@ReadOnlyUseCase
+class ExportRemainStatusUseCase(
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: RemainQueryUserPort,
+    private val querySchoolPort: RemainQuerySchoolPort,
+    private val queryStudentPort: RemainQueryStudentPort,
+    private val queryRemainStatusPort: QueryRemainStatusPort,
+    private val writeFilePort: WriteFilePort
+) {
+
+    fun execute(): ExportRemainStatusResponse {
+
+        val currentUserId = securityPort.getCurrentUserId()
+        val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+        val school = querySchoolPort.querySchoolById(manager.schoolId) ?: throw SchoolNotFoundException
+
+        val studentList = queryStudentPort.queryStudentBySchoolId(manager.schoolId)
+
+        val remainStatusMap = queryRemainStatusPort.queryByStudentIdIn(
+            studentIds = studentList.map { it.id }
+        ).associateBy { it.studentId }
+
+        val studentRemainInfos = studentList.map { student ->
+            StudentRemainInfo(
+                studentName = student.name,
+                studentGcn = student.gcn,
+                studentSex = student.sex,
+                roomNumber = student.roomNumber,
+                optionName = remainStatusMap[student.id]?.optionName
+            )
+        }
+
+        return ExportRemainStatusResponse(
+            file = writeFilePort.writeRemainStatusExcelFile(studentRemainInfos),
+            fileName = getFileName(school)
+        )
+    }
+
+    private fun getFileName(school: School) =
+        "${school.name.replace(" ", "")}_잔류_신청결과_${LocalDateTime.now().format(File.FILE_DATE_FORMAT)}"
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/school/spi/SchoolPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/school/spi/SchoolPort.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.domain.school.spi
 import team.aliens.dms.domain.auth.spi.AuthQuerySchoolPort
 import team.aliens.dms.domain.manager.spi.ManagerQuerySchoolPort
 import team.aliens.dms.domain.point.spi.PointQuerySchoolPort
+import team.aliens.dms.domain.remain.spi.RemainQuerySchoolPort
 import team.aliens.dms.domain.student.spi.StudentQuerySchoolPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQuerySchoolPort
 
@@ -13,5 +14,6 @@ interface SchoolPort :
     StudentQuerySchoolPort,
     AuthQuerySchoolPort,
     StudyRoomQuerySchoolPort,
-    PointQuerySchoolPort {
+    PointQuerySchoolPort,
+    RemainQuerySchoolPort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentPort.kt
@@ -5,6 +5,7 @@ import team.aliens.dms.domain.manager.spi.ManagerCommandStudentPort
 import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
 import team.aliens.dms.domain.meal.spi.MealQueryStudentPort
 import team.aliens.dms.domain.point.spi.PointQueryStudentPort
+import team.aliens.dms.domain.remain.spi.RemainQueryStudentPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryStudentPort
 import team.aliens.dms.domain.user.spi.UserQueryStudentPort
 
@@ -17,5 +18,6 @@ interface StudentPort :
     ManagerQueryStudentPort,
     ManagerCommandStudentPort,
     StudyRoomQueryStudentPort,
-    PointQueryStudentPort {
+    PointQueryStudentPort,
+    RemainQueryStudentPort {
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/ExportRemainStatusUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/ExportRemainStatusUseCaseTests.kt
@@ -1,0 +1,149 @@
+package team.aliens.dms.domain.remain.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.file.spi.WriteFilePort
+import team.aliens.dms.domain.remain.dto.RemainStatusInfo
+import team.aliens.dms.domain.remain.dto.StudentRemainInfo
+import team.aliens.dms.domain.remain.spi.QueryRemainStatusPort
+import team.aliens.dms.domain.remain.spi.RemainQuerySchoolPort
+import team.aliens.dms.domain.remain.spi.RemainQueryStudentPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolNotFoundException
+import team.aliens.dms.domain.school.model.School
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class ExportRemainStatusUseCaseTests {
+
+    private val securityPort: RemainSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: RemainQueryUserPort = mockk(relaxed = true)
+    private val querySchoolPort: RemainQuerySchoolPort = mockk(relaxed = true)
+    private val queryStudentPort: RemainQueryStudentPort = mockk(relaxed = true)
+    private val queryRemainStatusPort: QueryRemainStatusPort = mockk(relaxed = true)
+    private val writeFilePort: WriteFilePort = mockk(relaxed = true)
+
+    private val exportRemainStatusUseCase = ExportRemainStatusUseCase(
+        securityPort, queryUserPort, querySchoolPort, queryStudentPort, queryRemainStatusPort, writeFilePort
+    )
+
+    private val managerId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = managerId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val schoolStub by lazy {
+        School(
+            id = schoolId,
+            name = "대덕소프트웨어마이스터고등학교",
+            code = "test code",
+            question = "test question",
+            answer = "test answer",
+            address = "test address",
+            contractStartedAt = LocalDate.now(),
+            contractEndedAt = LocalDate.now(),
+        )
+    }
+
+    private val studentId = UUID.randomUUID()
+
+    private val studentStub by lazy {
+        Student(
+            id = studentId,
+            roomId = UUID.randomUUID(),
+            roomNumber = 123,
+            schoolId = UUID.randomUUID(),
+            grade = 1,
+            classRoom = 1,
+            number = 1,
+            name = "김은빈",
+            profileImageUrl = "https://~",
+            sex = Sex.FEMALE
+        )
+    }
+
+    private val remainStatusInfoStub by lazy {
+        RemainStatusInfo(
+            studentId = studentId,
+            optionName = "잔류"
+        )
+    }
+
+    @Test
+    fun `잔류항목 생성 성공`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+        every { querySchoolPort.querySchoolById(schoolId) } returns schoolStub
+        every { queryStudentPort.queryStudentsBySchoolId(schoolId) } returns listOf(studentStub)
+        every { queryRemainStatusPort.queryByStudentIdIn(listOf(studentId)) } returns listOf(remainStatusInfoStub)
+
+        val studentRemainInfoSlot = slot<List<StudentRemainInfo>>()
+        every { writeFilePort.writeRemainStatusExcelFile(capture(studentRemainInfoSlot)) } returns byteArrayOf()
+
+        // when
+        val response = exportRemainStatusUseCase.execute()
+
+        // then
+        val studentRemainInfo = studentRemainInfoSlot.captured[0]
+
+        assertAll(
+            { assertEquals(studentRemainInfo.studentName, studentStub.name) },
+            { assertEquals(studentRemainInfo.studentGcn, studentStub.gcn) },
+            { assertEquals(studentRemainInfo.roomNumber, studentStub.roomNumber) },
+            { assertEquals(studentRemainInfo.studentSex, studentStub.sex) },
+            { assertEquals(studentRemainInfo.optionName, remainStatusInfoStub.optionName) },
+            { assert(response.fileName.startsWith("${schoolStub.name.replace(" ", "")}_잔류_신청결과_")) }
+        )
+    }
+
+    @Test
+    fun `유저 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+        every { queryUserPort.queryUserById(managerId) } returns null
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            exportRemainStatusUseCase.execute()
+        }
+    }
+
+    @Test
+    fun `학교 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+        every { querySchoolPort.querySchoolById(schoolId) } returns null
+
+        // when & then
+        assertThrows<SchoolNotFoundException> {
+            exportRemainStatusUseCase.execute()
+        }
+    }
+}

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/Sex.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/Sex.kt
@@ -1,13 +1,10 @@
 package team.aliens.dms.domain.student.model
 
-enum class Sex {
-    MALE,
-    FEMALE,
-    ALL
+enum class Sex(
+    val korean: String
+) {
+    MALE("남"),
+    FEMALE("여"),
+    ALL("전체")
     ;
-
-    companion object {
-        const val MALE_KOREAN = "남"
-        const val FEMALE_KOREAN = "여"
-    }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -128,7 +128,7 @@ class SecurityConfiguration(
             // /remains
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
-            .antMatchers(HttpMethod.GET, "/remains/status/file").hasAnyAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.GET, "/remains/status/file").hasAuthority(MANAGER.name)
             .anyRequest().denyAll()
 
         http

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -128,6 +128,7 @@ class SecurityConfiguration(
             // /remains
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.GET, "/remains/status/file").hasAnyAuthority(MANAGER.name)
             .anyRequest().denyAll()
 
         http

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
@@ -1,0 +1,42 @@
+package team.aliens.dms.persistence.remain
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.remain.dto.RemainStatusInfo
+import team.aliens.dms.domain.remain.spi.RemainStatusPort
+import team.aliens.dms.persistence.remain.entity.QRemainOptionJpaEntity.remainOptionJpaEntity
+import team.aliens.dms.persistence.remain.entity.QRemainStatusJpaEntity.remainStatusJpaEntity
+import team.aliens.dms.persistence.remain.mapper.RemainStatusMapper
+import team.aliens.dms.persistence.remain.repository.RemainStatusJpaRepository
+import team.aliens.dms.persistence.remain.repository.vo.QRemainStatusInfoVO
+import java.util.UUID
+
+@Component
+class RemainStatusPersistenceAdapter(
+    private val remainStatusRepository: RemainStatusJpaRepository,
+    private val remainStatusMapper: RemainStatusMapper,
+    private val queryFactory: JPAQueryFactory,
+) : RemainStatusPort {
+
+    override fun queryByStudentIdIn(studentIds: List<UUID>): List<RemainStatusInfo> {
+        return queryFactory
+            .select(
+                QRemainStatusInfoVO(
+                    remainStatusJpaEntity.student.id,
+                    remainOptionJpaEntity.title
+                )
+            )
+            .from(remainStatusJpaEntity)
+            .join(remainStatusJpaEntity.remainOption, remainOptionJpaEntity)
+            .where(
+                remainStatusJpaEntity.student.id.`in`(studentIds)
+            )
+            .fetch()
+            .map {
+                RemainStatusInfo(
+                    studentId = it.studentId,
+                    optionName = it.optionName
+                )
+            }
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/repository/vo/RemainStatusInfoVO.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/repository/vo/RemainStatusInfoVO.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.persistence.remain.repository.vo
+
+import com.querydsl.core.annotations.QueryProjection
+import java.util.UUID
+
+data class RemainStatusInfoVO @QueryProjection constructor(
+    val studentId: UUID,
+    val optionName: String
+)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -10,19 +10,19 @@ import org.springframework.stereotype.Component
 import team.aliens.dms.domain.manager.dto.Sort
 import team.aliens.dms.domain.point.spi.vo.StudentWithPointVO
 import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.model.VerifiedStudent
 import team.aliens.dms.domain.student.spi.StudentPort
-import team.aliens.dms.persistence.school.entity.QSchoolJpaEntity.schoolJpaEntity
-import team.aliens.dms.persistence.room.entity.QRoomJpaEntity.roomJpaEntity
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
+import team.aliens.dms.persistence.room.entity.QRoomJpaEntity.roomJpaEntity
+import team.aliens.dms.persistence.school.entity.QSchoolJpaEntity.schoolJpaEntity
 import team.aliens.dms.persistence.student.entity.QStudentJpaEntity.studentJpaEntity
 import team.aliens.dms.persistence.student.mapper.StudentMapper
-import team.aliens.dms.persistence.student.repository.StudentJpaRepository
-import team.aliens.dms.persistence.user.entity.QUserJpaEntity.userJpaEntity
-import java.util.UUID
-import team.aliens.dms.domain.student.model.VerifiedStudent
 import team.aliens.dms.persistence.student.mapper.VerifiedStudentMapper
+import team.aliens.dms.persistence.student.repository.StudentJpaRepository
 import team.aliens.dms.persistence.student.repository.VerifiedStudentJpaRepository
 import team.aliens.dms.persistence.student.repository.vo.QQueryStudentWithPointVO
+import team.aliens.dms.persistence.user.entity.QUserJpaEntity.userJpaEntity
+import java.util.UUID
 
 @Component
 class StudentPersistenceAdapter(
@@ -113,6 +113,21 @@ class StudentPersistenceAdapter(
         studentRepository.delete(
             studentMapper.toEntity(student)
         )
+    }
+
+    override fun queryStudentsBySchoolId(schoolId: UUID): List<Student> {
+        return queryFactory
+            .selectFrom(studentJpaEntity)
+            .join(studentJpaEntity.room, roomJpaEntity)
+            .join(studentJpaEntity.user, userJpaEntity)
+            .where(
+                userJpaEntity.school.id.eq(schoolId)
+            )
+            .orderBy(roomJpaEntity.number.asc())
+            .fetch()
+            .map {
+                studentMapper.toDomain(it)!!
+            }
     }
 
     override fun queryStudentsWithPointHistory(studentIds: List<UUID>): List<StudentWithPointVO> {

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -118,7 +118,7 @@ class StudentPersistenceAdapter(
     override fun queryStudentsBySchoolId(schoolId: UUID): List<Student> {
         return queryFactory
             .selectFrom(studentJpaEntity)
-            .join(studentJpaEntity.room, roomJpaEntity)
+            .join(studentJpaEntity.room, roomJpaEntity).fetchJoin()
             .join(studentJpaEntity.user, userJpaEntity)
             .where(
                 userJpaEntity.school.id.eq(schoolId)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapter.kt
@@ -16,6 +16,7 @@ import team.aliens.dms.domain.file.FileExtension.XLSX
 import team.aliens.dms.domain.file.spi.ParseFilePort
 import team.aliens.dms.domain.file.spi.WriteFilePort
 import team.aliens.dms.domain.point.model.PointHistory
+import team.aliens.dms.domain.remain.dto.StudentRemainInfo
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.VerifiedStudent
 import team.aliens.dms.thirdparty.parser.exception.ExcelExtensionMismatchException
@@ -78,8 +79,8 @@ class ExcelAdapter : ParseFilePort, WriteFilePort {
     }
 
     private fun transferToSex(sex: String) = when (sex) {
-        Sex.MALE_KOREAN -> Sex.MALE
-        Sex.FEMALE_KOREAN -> Sex.FEMALE
+        Sex.MALE.korean -> Sex.MALE
+        Sex.FEMALE.korean -> Sex.FEMALE
         else -> throw ExcelSexMismatchException
     }
 
@@ -104,9 +105,29 @@ class ExcelAdapter : ParseFilePort, WriteFilePort {
         )
     }
 
+    override fun writeRemainStatusExcelFile(studentRemainInfos: List<StudentRemainInfo>): ByteArray {
+
+        val attributes = listOf("학생 이름", "학번", "성별", "호실", "신청 항목")
+
+        val remainInfosList: List<List<String?>> = studentRemainInfos.map {
+            listOf(
+                it.studentName,
+                it.studentGcn,
+                it.studentSex.korean,
+                it.roomNumber.toString(),
+                it.optionName
+            )
+        }
+
+        return createExcelSheet(
+            attributes = attributes,
+            datasList = remainInfosList
+        )
+    }
+
     private fun createExcelSheet(
         attributes: List<String>,
-        datasList: List<List<String>>
+        datasList: List<List<String?>>
     ): ByteArray {
         val workbook = XSSFWorkbook()
         val sheet = workbook.createSheet()
@@ -127,7 +148,7 @@ class ExcelAdapter : ParseFilePort, WriteFilePort {
 
     private fun insertDatasAtRow(
         headerRow: XSSFRow,
-        attributes: List<String>,
+        attributes: List<String?>,
         style: XSSFCellStyle
     ) {
         attributes.forEachIndexed { j, text ->

--- a/dms-infrastructure/src/test/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapterTests.kt
+++ b/dms-infrastructure/src/test/kotlin/team/aliens/dms/thirdparty/parser/ExcelAdapterTests.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import team.aliens.dms.domain.point.model.PointHistory
 import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.domain.remain.dto.StudentRemainInfo
+import team.aliens.dms.domain.student.model.Sex
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -62,4 +64,36 @@ class ExcelAdapterTests {
             { assertEquals(datasList.captured[0].size, attributes.captured.size) }
         )
     }
+
+    private val studentRemainInfos by lazy {
+        listOf(
+            StudentRemainInfo(
+                studentName = "",
+                studentGcn = "1234",
+                studentSex = Sex.FEMALE,
+                roomNumber = 200,
+                optionName = ""
+            )
+        )
+    }
+
+    @Test
+    fun `속성과 요소의 수가 일치한다 (writeRemainStatusExcelFile)`() {
+
+        // given
+        val attributes = slot<List<String>>()
+        val datasList = slot<List<List<String>>>()
+
+        every { excelAdapter["createExcelSheet"](capture(attributes), capture(datasList)) } returns byteArrayOf()
+
+        // when
+        excelAdapter.writeRemainStatusExcelFile(studentRemainInfos)
+
+        // then
+        assertAll(
+            { assertEquals(studentRemainInfos.size, datasList.captured.size) },
+            { assertEquals(datasList.captured[0].size, attributes.captured.size) }
+        )
+    }
+
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -64,10 +64,6 @@ class RemainWebAdapter(
             HttpHeaders.CONTENT_DISPOSITION,
             "attachment; filename=${URLEncoder.encode(response.fileName, "UTF-8")}.xlsx"
         )
-        httpResponse.setHeader(
-            HttpHeaders.CONTENT_TYPE,
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        )
         return response.file
     }
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -1,7 +1,9 @@
 package team.aliens.dms.domain.remain
 
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,8 +15,11 @@ import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.request.UpdateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
 import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
+import team.aliens.dms.domain.remain.usecase.ExportRemainStatusUseCase
 import team.aliens.dms.domain.remain.usecase.UpdateRemainOptionUseCase
+import java.net.URLEncoder
 import java.util.UUID
+import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
 
@@ -24,6 +29,7 @@ import javax.validation.constraints.NotNull
 class RemainWebAdapter(
     private val createRemainOptionUseCase: CreateRemainOptionUseCase,
     private val updateRemainOptionUseCase: UpdateRemainOptionUseCase,
+    private val exportRemainStatusUseCase: ExportRemainStatusUseCase
 ) {
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -47,5 +53,21 @@ class RemainWebAdapter(
             title = request.title!!,
             description = request.description!!
         )
+    }
+
+    @GetMapping("/status/file")
+    fun exportRemainStatus(
+        httpResponse: HttpServletResponse
+    ): ByteArray {
+        val response = exportRemainStatusUseCase.execute()
+        httpResponse.setHeader(
+            HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=${URLEncoder.encode(response.fileName, "UTF-8")}.xlsx"
+        )
+        httpResponse.setHeader(
+            HttpHeaders.CONTENT_TYPE,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        return response.file
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] ExportRemainStatusUseCase
- [x] GET remains/status/file

## 주요 변경 사항
- 학생 잔류 신청내역 엑셀 출력 api
- 성별 한국어 companion object로 있던거 이동했습니다

- remain 도메인에서 student 엔티티를 건들면 도메인끼리 주는 영향이 커질 것 같아서, 쿼리를 따로 날리도록 분리했습니다. (학생 쿼리 1번 +  remainStatus에 대한 쿼리 1번)

## 결과물

신청하지 않은 학생은 빈칸입니다

<img src="https://user-images.githubusercontent.com/81006587/220591911-dd4c4978-9c44-47d4-a868-55ca74e04d3c.png" height=150px>


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #261