### PR TITLE
merge: (#264) 잔류 항목 삭제 api

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainOptionPort.kt
@@ -5,4 +5,6 @@ import team.aliens.dms.domain.remain.model.RemainOption
 interface CommandRemainOptionPort {
 
     fun saveRemainOption(remainOption: RemainOption): RemainOption
+
+    fun deleteRemainOption(remainOption: RemainOption)
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainStatusPort.kt
@@ -1,0 +1,7 @@
+package team.aliens.dms.domain.remain.spi
+
+import java.util.UUID
+
+interface CommandRemainStatusPort {
+    fun deleteRemainStatusByRemainOptionId(remainOptionId: UUID)
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
@@ -1,0 +1,4 @@
+package team.aliens.dms.domain.remain.spi
+
+interface RemainStatusPort : CommandRemainStatusPort {
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/RemoveRemainOptionUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/RemoveRemainOptionUseCase.kt
@@ -1,0 +1,36 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
+import team.aliens.dms.domain.remain.spi.CommandRemainOptionPort
+import team.aliens.dms.domain.remain.spi.CommandRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.util.UUID
+
+@UseCase
+class RemoveRemainOptionUseCase(
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: RemainQueryUserPort,
+    private val queryRemainOptionPort: QueryRemainOptionPort,
+    private val commandRemainOptionPort: CommandRemainOptionPort,
+    private val commandRemainStatusPort: CommandRemainStatusPort
+) {
+
+    fun execute(remainOptionId: UUID) {
+        val currentUserId = securityPort.getCurrentUserId()
+        val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
+
+        if (remainOption.schoolId != manager.schoolId) {
+            throw SchoolMismatchException
+        }
+
+        commandRemainStatusPort.deleteRemainStatusByRemainOptionId(remainOption.id)
+        commandRemainOptionPort.deleteRemainOption(remainOption)
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/RemoveRemainOptionUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/RemoveRemainOptionUseCaseTests.kt
@@ -1,0 +1,131 @@
+package team.aliens.dms.domain.remain.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.spi.CommandRemainOptionPort
+import team.aliens.dms.domain.remain.spi.CommandRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class RemoveRemainOptionUseCaseTests {
+
+    private val securityPort: RemainSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: RemainQueryUserPort = mockk(relaxed = true)
+    private val queryRemainOptionPort: QueryRemainOptionPort = mockk(relaxed = true)
+    private val commandRemainOptionPort: CommandRemainOptionPort = mockk(relaxed = true)
+    private val commandRemainStatusPort: CommandRemainStatusPort = mockk(relaxed = true)
+
+    private val removeRemainOptionUseCase = RemoveRemainOptionUseCase(
+        securityPort, queryUserPort, queryRemainOptionPort, commandRemainOptionPort, commandRemainStatusPort
+    )
+
+    private val managerId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = managerId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val remainOptionId = UUID.randomUUID()
+    private val title = "title"
+    private val description = "descripton"
+
+    private val remainOptionStub by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = schoolId,
+            title = title,
+            description = description
+        )
+    }
+
+    @Test
+    fun `잔류항목 삭제 성공`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns remainOptionStub
+
+        // when & then
+        assertDoesNotThrow {
+            removeRemainOptionUseCase.execute(remainOptionId)
+        }
+    }
+
+    @Test
+    fun `잔류항목이 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns null
+
+        // when & then
+        assertThrows<RemainOptionNotFoundException> {
+            removeRemainOptionUseCase.execute(remainOptionId)
+        }
+    }
+
+    private val otherRemainOptionStub by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = UUID.randomUUID(),
+            title = title,
+            description = description
+        )
+    }
+
+    @Test
+    fun `같은 학교의 매니저가 아님`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns userStub
+
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns otherRemainOptionStub
+
+        // when & then
+        assertThrows<SchoolMismatchException> {
+            removeRemainOptionUseCase.execute(remainOptionId)
+        }
+    }
+
+    @Test
+    fun `유저가 존재하지 않음`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns managerId
+
+        every { queryUserPort.queryUserById(managerId) } returns null
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            removeRemainOptionUseCase.execute(remainOptionId)
+        }
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -128,6 +128,7 @@ class SecurityConfiguration(
             // /remains
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.DELETE, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
             .anyRequest().denyAll()
 
         http

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
@@ -20,6 +20,12 @@ class RemainOptionPersistenceAdapter(
         )
     )!!
 
+    override fun deleteRemainOption(remainOption: RemainOption) {
+        remainOptionRepository.delete(
+            remainOptionMapper.toEntity(remainOption)
+        )
+    }
+
     override fun queryRemainOptionById(remainOptionId: UUID) = remainOptionMapper.toDomain(
         remainOptionRepository.findByIdOrNull(remainOptionId)
     )

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
@@ -1,0 +1,20 @@
+package team.aliens.dms.persistence.remain
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.remain.spi.RemainStatusPort
+import team.aliens.dms.persistence.remain.mapper.RemainStatusMapper
+import team.aliens.dms.persistence.remain.repository.RemainStatusJpaRepository
+import java.util.UUID
+
+@Component
+class RemainStatusPersistenceAdapter(
+    private val remainStatusRepository: RemainStatusJpaRepository,
+    private val remainStatusMapper: RemainStatusMapper,
+    private val queryFactory: JPAQueryFactory,
+) : RemainStatusPort {
+
+    override fun deleteRemainStatusByRemainOptionId(remainOptionId: UUID) {
+        remainStatusRepository.deleteByRemainOptionId(remainOptionId)
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/repository/RemainStatusJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/repository/RemainStatusJpaRepository.kt
@@ -7,4 +7,5 @@ import java.util.UUID
 
 @Repository
 interface RemainStatusJpaRepository : CrudRepository<RemainStatusJpaEntity, UUID> {
+    fun deleteByRemainOptionId(remainOptionId: UUID)
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.domain.remain
 
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,6 +14,7 @@ import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.request.UpdateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
 import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
+import team.aliens.dms.domain.remain.usecase.RemoveRemainOptionUseCase
 import team.aliens.dms.domain.remain.usecase.UpdateRemainOptionUseCase
 import java.util.UUID
 import javax.validation.Valid
@@ -24,6 +26,7 @@ import javax.validation.constraints.NotNull
 class RemainWebAdapter(
     private val createRemainOptionUseCase: CreateRemainOptionUseCase,
     private val updateRemainOptionUseCase: UpdateRemainOptionUseCase,
+    private val removeRemainOptionUseCase: RemoveRemainOptionUseCase
 ) {
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -47,5 +50,11 @@ class RemainWebAdapter(
             title = request.title!!,
             description = request.description!!
         )
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/options/{remain-option-id}")
+    fun removeRemainOption(@PathVariable("remain-option-id") @NotNull remainOptionId: UUID?) {
+        removeRemainOptionUseCase.execute(remainOptionId!!)
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x]  RemoveRemainOptionUseCase
- [x]  /remains/option/{remain-option-id}

## 주요 변경 사항
- 잔류 항목 삭제 api
- 이전 PR이랑 동일한 클래스 추가된건, 머지할때 conflict 해결하면서 합치겠습니다

## 결과물

![image](https://user-images.githubusercontent.com/81006587/220603461-b1eb2d12-96a9-4808-9f6a-805f6e4a3e45.png)


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #264