### PR TITLE
merge: (#262) 잔류 신청 항목 목록 보기 API

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/QueryRemainOptionsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/QueryRemainOptionsResponse.kt
@@ -3,7 +3,7 @@ package team.aliens.dms.domain.remain.dto
 import java.util.UUID
 
 data class QueryRemainOptionsResponse(
-    val selectedOption: String?,
+    val appliedRemainOption: String?,
     val remainOptions: List<RemainOptionElement>
 ) {
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/QueryRemainOptionsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/QueryRemainOptionsResponse.kt
@@ -1,0 +1,15 @@
+package team.aliens.dms.domain.remain.dto
+
+import java.util.UUID
+
+data class QueryRemainOptionsResponse(
+    val selectedOption: String?,
+    val remainOptions: List<RemainOptionElement>
+) {
+
+    data class RemainOptionElement(
+        val id: UUID,
+        val title: String,
+        val description: String
+    )
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/QueryRemainOptionsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/dto/QueryRemainOptionsResponse.kt
@@ -3,13 +3,13 @@ package team.aliens.dms.domain.remain.dto
 import java.util.UUID
 
 data class QueryRemainOptionsResponse(
-    val appliedRemainOption: String?,
     val remainOptions: List<RemainOptionElement>
 ) {
 
     data class RemainOptionElement(
         val id: UUID,
         val title: String,
-        val description: String
+        val description: String,
+        val isApplied: Boolean
     )
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainOptionPort.kt
@@ -7,6 +7,6 @@ interface QueryRemainOptionPort {
 
     fun queryRemainOptionById(remainOptionId: UUID): RemainOption?
 
-    fun queryAllRemainOptionBySchoolId(schoolId: UUID): List<RemainOption>
+    fun queryAllRemainOptionsBySchoolId(schoolId: UUID): List<RemainOption>
 
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainOptionPort.kt
@@ -4,5 +4,9 @@ import team.aliens.dms.domain.remain.model.RemainOption
 import java.util.UUID
 
 interface QueryRemainOptionPort {
+
     fun queryRemainOptionById(remainOptionId: UUID): RemainOption?
+
+    fun queryAllRemainOptionBySchoolId(schoolId: UUID): List<RemainOption>
+
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/QueryRemainStatusPort.kt
@@ -3,7 +3,7 @@ package team.aliens.dms.domain.remain.spi
 import team.aliens.dms.domain.remain.model.RemainStatus
 import java.util.UUID
 
-interface RemainQueryRemainStatusPort {
+interface QueryRemainStatusPort {
 
     fun queryRemainStatusById(userId: UUID): RemainStatus?
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainAvailableTimePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainAvailableTimePort.kt
@@ -1,6 +1,6 @@
 package team.aliens.dms.domain.remain.spi
 
-interface RemainAvailableTimePort:
+interface RemainAvailableTimePort :
     CommandRemainAvailableTimePort,
     QueryRemainAvailableTimePort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainOptionPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainOptionPort.kt
@@ -1,4 +1,6 @@
 package team.aliens.dms.domain.remain.spi
 
-interface RemainOptionPort: CommandRemainOptionPort, QueryRemainOptionPort {
+interface RemainOptionPort :
+    CommandRemainOptionPort,
+    QueryRemainOptionPort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryRemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainQueryRemainStatusPort.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.remain.spi
+
+import team.aliens.dms.domain.remain.model.RemainStatus
+import java.util.UUID
+
+interface RemainQueryRemainStatusPort {
+
+    fun queryRemainStatusById(userId: UUID): RemainStatus?
+
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
@@ -1,4 +1,6 @@
 package team.aliens.dms.domain.remain.spi
 
-interface RemainStatusPort : CommandRemainStatusPort, QueryRemainStatusPort {
+interface RemainStatusPort :
+    CommandRemainStatusPort,
+    QueryRemainStatusPort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
@@ -1,0 +1,4 @@
+package team.aliens.dms.domain.remain.spi
+
+interface RemainStatusPort : RemainQueryRemainStatusPort {
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/RemainStatusPort.kt
@@ -1,4 +1,4 @@
 package team.aliens.dms.domain.remain.spi
 
-interface RemainStatusPort : RemainQueryRemainStatusPort {
+interface RemainStatusPort : QueryRemainStatusPort {
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
@@ -21,7 +21,7 @@ class QueryRemainOptionsUseCase(
         val currentUserId = securityPort.getCurrentUserId()
         val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 
-        val remainOptions = queryRemainOptionPort.queryAllRemainOptionBySchoolId(currentUser.schoolId)
+        val remainOptions = queryRemainOptionPort.queryAllRemainOptionsBySchoolId(currentUser.schoolId)
             .map {
                 RemainOptionElement(
                     id = it.id,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
@@ -1,0 +1,42 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse
+import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse.RemainOptionElement
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryRemainStatusPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+
+@ReadOnlyUseCase
+class QueryRemainOptionsUseCase(
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: RemainQueryUserPort,
+    private val queryRemainOptionPort: QueryRemainOptionPort,
+    private val queryRemainStatusPort: RemainQueryRemainStatusPort
+) {
+
+    fun execute(): QueryRemainOptionsResponse {
+        val currentUserId = securityPort.getCurrentUserId()
+        val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val remainOptions = queryRemainOptionPort.queryAllRemainOptionBySchoolId(currentUser.schoolId)
+            .map {
+                RemainOptionElement(
+                    id = it.id,
+                    title = it.title,
+                    description = it.description
+                )
+            }
+
+        val remainStatus = queryRemainStatusPort.queryRemainStatusById(currentUserId)
+
+        return QueryRemainOptionsResponse(
+            selectedOption = remainStatus?.let {
+                queryRemainOptionPort.queryRemainOptionById(it.remainOptionId)?.title
+            },
+            remainOptions = remainOptions
+        )
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
@@ -4,7 +4,7 @@ import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse
 import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse.RemainOptionElement
 import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
-import team.aliens.dms.domain.remain.spi.RemainQueryRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainStatusPort
 import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.remain.spi.RemainSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
@@ -14,7 +14,7 @@ class QueryRemainOptionsUseCase(
     private val securityPort: RemainSecurityPort,
     private val queryUserPort: RemainQueryUserPort,
     private val queryRemainOptionPort: QueryRemainOptionPort,
-    private val queryRemainStatusPort: RemainQueryRemainStatusPort
+    private val queryRemainStatusPort: QueryRemainStatusPort
 ) {
 
     fun execute(): QueryRemainOptionsResponse {

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
@@ -21,21 +21,19 @@ class QueryRemainOptionsUseCase(
         val currentUserId = securityPort.getCurrentUserId()
         val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 
+        val remainStatus = queryRemainStatusPort.queryRemainStatusById(currentUserId)
+
         val remainOptions = queryRemainOptionPort.queryAllRemainOptionsBySchoolId(currentUser.schoolId)
             .map {
                 RemainOptionElement(
                     id = it.id,
                     title = it.title,
-                    description = it.description
+                    description = it.description,
+                    isApplied = it.id == remainStatus?.remainOptionId
                 )
             }
 
-        val remainStatus = queryRemainStatusPort.queryRemainStatusById(currentUserId)
-
         return QueryRemainOptionsResponse(
-            appliedRemainOption = remainOptions.find {
-                it.id == remainStatus?.remainOptionId
-            }?.title,
             remainOptions = remainOptions
         )
     }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
@@ -34,7 +34,7 @@ class QueryRemainOptionsUseCase(
 
         return QueryRemainOptionsResponse(
             appliedRemainOption = remainOptions.find {
-                it.id == remainStatus!!.remainOptionId
+                it.id == remainStatus?.remainOptionId
             }?.title,
             remainOptions = remainOptions
         )

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCase.kt
@@ -33,9 +33,9 @@ class QueryRemainOptionsUseCase(
         val remainStatus = queryRemainStatusPort.queryRemainStatusById(currentUserId)
 
         return QueryRemainOptionsResponse(
-            selectedOption = remainStatus?.let {
-                queryRemainOptionPort.queryRemainOptionById(it.remainOptionId)?.title
-            },
+            appliedRemainOption = remainOptions.find {
+                it.id == remainStatus!!.remainOptionId
+            }?.title,
             remainOptions = remainOptions
         )
     }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
@@ -9,7 +9,6 @@ import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.auth.model.Authority
-import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse.RemainOptionElement
 import team.aliens.dms.domain.remain.model.RemainOption
 import team.aliens.dms.domain.remain.model.RemainStatus
 import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
@@ -65,14 +64,6 @@ class QueryRemainOptionsUseCaseTests {
         )
     }
 
-    private val remainOptionElementStub by lazy {
-        RemainOptionElement(
-            id = remainOptionId,
-            title = "title",
-            description = "description"
-        )
-    }
-
     private val remainOption by lazy {
         RemainOption(
             id = remainOptionId,
@@ -99,7 +90,7 @@ class QueryRemainOptionsUseCaseTests {
         given(queryUserPort.queryUserById(userId))
             .willReturn(userStub)
 
-        given(queryRemainOptionPort.queryAllRemainOptionBySchoolId(schoolId))
+        given(queryRemainOptionPort.queryAllRemainOptionsBySchoolId(schoolId))
             .willReturn(listOf(remainOption))
 
         given(queryRemainStatusPort.queryRemainStatusById(userId))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
@@ -12,7 +12,7 @@ import team.aliens.dms.domain.auth.model.Authority
 import team.aliens.dms.domain.remain.model.RemainOption
 import team.aliens.dms.domain.remain.model.RemainStatus
 import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
-import team.aliens.dms.domain.remain.spi.RemainQueryRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainStatusPort
 import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.remain.spi.RemainSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
@@ -33,7 +33,7 @@ class QueryRemainOptionsUseCaseTests {
     private lateinit var queryRemainOptionPort: QueryRemainOptionPort
 
     @MockBean
-    private lateinit var queryRemainStatusPort: RemainQueryRemainStatusPort
+    private lateinit var queryRemainStatusPort: QueryRemainStatusPort
 
     private lateinit var queryRemainOptionsUseCase: QueryRemainOptionsUseCase
 
@@ -64,7 +64,7 @@ class QueryRemainOptionsUseCaseTests {
         )
     }
 
-    private val remainOption by lazy {
+    private val remainOptionStub by lazy {
         RemainOption(
             id = remainOptionId,
             schoolId = schoolId,
@@ -91,7 +91,7 @@ class QueryRemainOptionsUseCaseTests {
             .willReturn(userStub)
 
         given(queryRemainOptionPort.queryAllRemainOptionsBySchoolId(schoolId))
-            .willReturn(listOf(remainOption))
+            .willReturn(listOf(remainOptionStub))
 
         given(queryRemainStatusPort.queryRemainStatusById(userId))
             .willReturn(remainStatusStub)

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
@@ -1,0 +1,128 @@
+package team.aliens.dms.domain.remain.usecase
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse.RemainOptionElement
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.model.RemainStatus
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryRemainStatusPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.time.LocalDateTime
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class QueryRemainOptionsUseCaseTests {
+
+    @MockBean
+    private lateinit var securityPort: RemainSecurityPort
+
+    @MockBean
+    private lateinit var queryUserPort: RemainQueryUserPort
+
+    @MockBean
+    private lateinit var queryRemainOptionPort: QueryRemainOptionPort
+
+    @MockBean
+    private lateinit var queryRemainStatusPort: RemainQueryRemainStatusPort
+
+    private lateinit var queryRemainOptionsUseCase: QueryRemainOptionsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        queryRemainOptionsUseCase = QueryRemainOptionsUseCase(
+            securityPort,
+            queryUserPort,
+            queryRemainOptionPort,
+            queryRemainStatusPort
+        )
+    }
+
+    private val userId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+    private val remainOptionId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = userId,
+            schoolId = schoolId,
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.STUDENT,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val remainOptionElementStub by lazy {
+        RemainOptionElement(
+            id = remainOptionId,
+            title = "title",
+            description = "description"
+        )
+    }
+
+    private val remainOption by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = schoolId,
+            title = "title",
+            description = "description"
+        )
+    }
+
+    private val remainStatusStub by lazy {
+        RemainStatus(
+            id = UUID.randomUUID(),
+            remainOptionId = remainOptionId,
+            createdAt = LocalDateTime.MIN
+        )
+    }
+
+    @Test
+    fun `잔류 신청 항목 목록 보기 성공`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(userStub)
+
+        given(queryRemainOptionPort.queryAllRemainOptionBySchoolId(schoolId))
+            .willReturn(listOf(remainOption))
+
+        given(queryRemainStatusPort.queryRemainStatusById(userId))
+            .willReturn(remainStatusStub)
+
+        // when & then
+        assertDoesNotThrow {
+            queryRemainOptionsUseCase.execute()
+        }
+    }
+
+    @Test
+    fun `유저를 찾지 못함`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(null)
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            queryRemainOptionsUseCase.execute()
+        }
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/QueryRemainOptionsUseCaseTests.kt
@@ -90,11 +90,11 @@ class QueryRemainOptionsUseCaseTests {
         given(queryUserPort.queryUserById(userId))
             .willReturn(userStub)
 
-        given(queryRemainOptionPort.queryAllRemainOptionsBySchoolId(schoolId))
-            .willReturn(listOf(remainOptionStub))
-
         given(queryRemainStatusPort.queryRemainStatusById(userId))
             .willReturn(remainStatusStub)
+
+        given(queryRemainOptionPort.queryAllRemainOptionsBySchoolId(schoolId))
+            .willReturn(listOf(remainOptionStub))
 
         // when & then
         assertDoesNotThrow {

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -128,6 +128,7 @@ class SecurityConfiguration(
             // /remains
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
+            .antMatchers(HttpMethod.GET, "/remains/options").hasAnyAuthority(STUDENT.name, MANAGER.name)
             .anyRequest().denyAll()
 
         http

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
@@ -24,8 +24,9 @@ class RemainOptionPersistenceAdapter(
         remainOptionRepository.findByIdOrNull(remainOptionId)
     )
 
-    override fun queryAllRemainOptionBySchoolId(schoolId: UUID) = remainOptionRepository.findAllBySchoolId(schoolId)
-        .map {
-            remainOptionMapper.toDomain(it)!!
-        }
+    override fun queryAllRemainOptionsBySchoolId(schoolId: UUID) =
+        remainOptionRepository.findAllBySchoolId(schoolId)
+            .map {
+                remainOptionMapper.toDomain(it)!!
+            }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainOptionPersistenceAdapter.kt
@@ -23,4 +23,9 @@ class RemainOptionPersistenceAdapter(
     override fun queryRemainOptionById(remainOptionId: UUID) = remainOptionMapper.toDomain(
         remainOptionRepository.findByIdOrNull(remainOptionId)
     )
+
+    override fun queryAllRemainOptionBySchoolId(schoolId: UUID) = remainOptionRepository.findAllBySchoolId(schoolId)
+        .map {
+            remainOptionMapper.toDomain(it)!!
+        }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
@@ -1,0 +1,20 @@
+package team.aliens.dms.persistence.remain
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.remain.spi.RemainStatusPort
+import team.aliens.dms.persistence.remain.mapper.RemainStatusMapper
+import team.aliens.dms.persistence.remain.repository.RemainStatusJpaRepository
+import java.util.UUID
+
+@Component
+class RemainStatusPersistenceAdapter(
+    private val remainStatusRepository: RemainStatusJpaRepository,
+    private val remainStatusMapper: RemainStatusMapper
+) : RemainStatusPort {
+
+    override fun queryRemainStatusById(userId: UUID) = remainStatusMapper.toDomain(
+        remainStatusRepository.findByIdOrNull(userId)
+    )
+
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/repository/RemainOptionJpaRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/repository/RemainOptionJpaRepository.kt
@@ -7,4 +7,7 @@ import java.util.UUID
 
 @Repository
 interface RemainOptionJpaRepository : CrudRepository<RemainOptionJpaEntity, UUID> {
+
+    fun findAllBySchoolId(schoolId: UUID): List<RemainOptionJpaEntity>
+
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.domain.remain
 
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -9,10 +10,12 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import team.aliens.dms.domain.remain.dto.QueryRemainOptionsResponse
 import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.request.UpdateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
 import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
+import team.aliens.dms.domain.remain.usecase.QueryRemainOptionsUseCase
 import team.aliens.dms.domain.remain.usecase.UpdateRemainOptionUseCase
 import java.util.UUID
 import javax.validation.Valid
@@ -24,6 +27,7 @@ import javax.validation.constraints.NotNull
 class RemainWebAdapter(
     private val createRemainOptionUseCase: CreateRemainOptionUseCase,
     private val updateRemainOptionUseCase: UpdateRemainOptionUseCase,
+    private val queryRemainOptionsUseCase: QueryRemainOptionsUseCase
 ) {
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -47,5 +51,10 @@ class RemainWebAdapter(
             title = request.title!!,
             description = request.description!!
         )
+    }
+
+    @GetMapping("/options")
+    fun getRemainOptions(): QueryRemainOptionsResponse {
+        return queryRemainOptionsUseCase.execute()
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] GET /remains/options
- [x] QueryRemainOptionsUseCase

## 주요 변경 사항
- 잔류 신청 항목 목록 보기 API

## 결과물
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/103026813/220700546-402f4247-bdf0-4c57-a18e-72b3d9ed3ffb.png">

## 체크리스트
- [X] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [X] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #262 