### PR TITLE
merge: (#269) 잔류 신청 api

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/exception/RemainCanNotAppliedException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/exception/RemainCanNotAppliedException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.remain.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.remain.error.RemainAvailableTimeErrorCode
+
+object RemainCanNotAppliedException : DmsException(
+    RemainAvailableTimeErrorCode.REMAIN_AVAILABLE_TIME_NOT_FOUND
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/exception/RemainCanNotAppliedException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/exception/RemainCanNotAppliedException.kt
@@ -4,5 +4,5 @@ import team.aliens.dms.common.error.DmsException
 import team.aliens.dms.domain.remain.error.RemainAvailableTimeErrorCode
 
 object RemainCanNotAppliedException : DmsException(
-    RemainAvailableTimeErrorCode.REMAIN_AVAILABLE_TIME_NOT_FOUND
+    RemainAvailableTimeErrorCode.REMAIN_CAN_NOT_APPLIED
 )

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainStatusPort.kt
@@ -4,4 +4,5 @@ import java.util.UUID
 
 interface CommandRemainStatusPort {
     fun deleteRemainStatusByRemainOptionId(remainOptionId: UUID)
+    fun saveRemainStatus(remainStatus: RemainStatus): RemainStatus
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainStatusPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/spi/CommandRemainStatusPort.kt
@@ -1,8 +1,11 @@
 package team.aliens.dms.domain.remain.spi
 
+import team.aliens.dms.domain.remain.model.RemainStatus
 import java.util.UUID
 
 interface CommandRemainStatusPort {
+
     fun deleteRemainStatusByRemainOptionId(remainOptionId: UUID)
+
     fun saveRemainStatus(remainStatus: RemainStatus): RemainStatus
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
@@ -1,9 +1,12 @@
 package team.aliens.dms.domain.remain.usecase
 
 import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.remain.exception.RemainAvailableTimeNotFoundException
+import team.aliens.dms.domain.remain.exception.RemainCanNotAppliedException
 import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
 import team.aliens.dms.domain.remain.model.RemainStatus
 import team.aliens.dms.domain.remain.spi.CommandRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainAvailableTimePort
 import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
 import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.remain.spi.RemainSecurityPort
@@ -16,6 +19,7 @@ class ApplyRemainUseCase(
     private val securityPort: RemainSecurityPort,
     private val queryUserPort: RemainQueryUserPort,
     private val queryRemainOptionPort: QueryRemainOptionPort,
+    private val queryRemainAvailableTimePort: QueryRemainAvailableTimePort,
     private val commandRemainStatusPort: CommandRemainStatusPort
 ) {
 
@@ -23,6 +27,13 @@ class ApplyRemainUseCase(
 
         val currentUserId = securityPort.getCurrentUserId()
         val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val remainAvailableTime = queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(currentUser.schoolId)
+            ?: throw RemainAvailableTimeNotFoundException
+
+        if (!remainAvailableTime.isAvailable()) {
+            throw RemainCanNotAppliedException
+        }
 
         val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
@@ -10,6 +10,7 @@ import team.aliens.dms.domain.remain.spi.QueryRemainAvailableTimePort
 import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
 import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
 import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.school.exception.SchoolMismatchException
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import java.time.LocalDateTime
 import java.util.UUID
@@ -36,6 +37,10 @@ class ApplyRemainUseCase(
         }
 
         val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
+
+        if (remainOption.schoolId != currentUser.schoolId) {
+            throw SchoolMismatchException
+        }
 
         commandRemainStatusPort.saveRemainStatus(
             RemainStatus(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
@@ -29,17 +29,17 @@ class ApplyRemainUseCase(
         val currentUserId = securityPort.getCurrentUserId()
         val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 
+        val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
+
+        if (remainOption.schoolId != currentUser.schoolId) {
+            throw SchoolMismatchException
+        }
+
         val remainAvailableTime = queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(currentUser.schoolId)
             ?: throw RemainAvailableTimeNotFoundException
 
         if (!remainAvailableTime.isAvailable()) {
             throw RemainCanNotAppliedException
-        }
-
-        val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
-
-        if (remainOption.schoolId != currentUser.schoolId) {
-            throw SchoolMismatchException
         }
 
         commandRemainStatusPort.saveRemainStatus(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCase.kt
@@ -1,0 +1,37 @@
+package team.aliens.dms.domain.remain.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
+import team.aliens.dms.domain.remain.model.RemainStatus
+import team.aliens.dms.domain.remain.spi.CommandRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.time.LocalDateTime
+import java.util.UUID
+
+@UseCase
+class ApplyRemainUseCase(
+    private val securityPort: RemainSecurityPort,
+    private val queryUserPort: RemainQueryUserPort,
+    private val queryRemainOptionPort: QueryRemainOptionPort,
+    private val commandRemainStatusPort: CommandRemainStatusPort
+) {
+
+    fun execute(remainOptionId: UUID) {
+
+        val currentUserId = securityPort.getCurrentUserId()
+        val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val remainOption = queryRemainOptionPort.queryRemainOptionById(remainOptionId) ?: throw RemainOptionNotFoundException
+
+        commandRemainStatusPort.saveRemainStatus(
+            RemainStatus(
+                id = currentUser.id,
+                remainOptionId = remainOption.id,
+                createdAt = LocalDateTime.now()
+            )
+        )
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCaseTests.kt
@@ -1,0 +1,96 @@
+package team.aliens.dms.domain.remain.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.remain.exception.RemainOptionNotFoundException
+import team.aliens.dms.domain.remain.model.RemainOption
+import team.aliens.dms.domain.remain.spi.CommandRemainStatusPort
+import team.aliens.dms.domain.remain.spi.QueryRemainOptionPort
+import team.aliens.dms.domain.remain.spi.RemainQueryUserPort
+import team.aliens.dms.domain.remain.spi.RemainSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.util.UUID
+
+@ExtendWith(SpringExtension::class)
+class ApplyRemainUseCaseTests {
+
+    private val securityPort: RemainSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: RemainQueryUserPort = mockk(relaxed = true)
+    private val queryRemainOptionPort: QueryRemainOptionPort = mockk(relaxed = true)
+    private val commandRemainStatusPort: CommandRemainStatusPort = mockk(relaxed = true)
+
+    private val applyRemainUseCase = ApplyRemainUseCase(
+        securityPort, queryUserPort, queryRemainOptionPort, commandRemainStatusPort
+    )
+
+    private val userId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = userId,
+            schoolId = UUID.randomUUID(),
+            accountId = "accountId",
+            password = "password",
+            email = "email",
+            authority = Authority.MANAGER,
+            createdAt = null,
+            deletedAt = null
+        )
+    }
+
+    private val remainOptionId = UUID.randomUUID()
+
+    private val remainOptionStub by lazy {
+        RemainOption(
+            id = remainOptionId,
+            schoolId = UUID.randomUUID(),
+            title = "",
+            description = ""
+        )
+    }
+
+    @Test
+    fun `잔류 신청 성공`() {
+        //givenr
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns remainOptionStub
+
+        // when & then
+        assertDoesNotThrow {
+            applyRemainUseCase.execute(remainOptionId)
+        }
+    }
+
+    @Test
+    fun `유저가 존재하지 않음`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns null
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            applyRemainUseCase.execute(remainOptionId)
+        }
+    }
+
+    @Test
+    fun `잔류 항목이 존재하지 않음`() {
+        //given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns null
+
+        // when & then
+        assertThrows<RemainOptionNotFoundException> {
+            applyRemainUseCase.execute(remainOptionId)
+        }
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/remain/usecase/ApplyRemainUseCaseTests.kt
@@ -69,9 +69,9 @@ class ApplyRemainUseCaseTests {
         //given
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns remainOptionStub
         every { queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId) } returns remainAvailableTimeStub
         every { remainAvailableTimeStub.isAvailable() } returns true
-        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns remainOptionStub
 
         // when & then
         assertDoesNotThrow {
@@ -96,6 +96,7 @@ class ApplyRemainUseCaseTests {
         //given
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns remainOptionStub
         every { queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId) } returns remainAvailableTimeStub
         every { remainAvailableTimeStub.isAvailable() } returns false
 
@@ -110,8 +111,6 @@ class ApplyRemainUseCaseTests {
         //given
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
-        every { queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId) } returns remainAvailableTimeStub
-        every { remainAvailableTimeStub.isAvailable() } returns true
         every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns null
 
         // when & then
@@ -134,9 +133,9 @@ class ApplyRemainUseCaseTests {
         //given
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns otherRemainOptionStub
         every { queryRemainAvailableTimePort.queryRemainAvailableTimeBySchoolId(schoolId) } returns remainAvailableTimeStub
         every { remainAvailableTimeStub.isAvailable() } returns true
-        every { queryRemainOptionPort.queryRemainOptionById(remainOptionId) } returns otherRemainOptionStub
 
         // when & then
         assertThrows<SchoolMismatchException> {

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/remain/error/RemainAvailableTimeErrorCode.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/remain/error/RemainAvailableTimeErrorCode.kt
@@ -7,9 +7,10 @@ enum class RemainAvailableTimeErrorCode(
     private val message: String
 ) : ErrorProperty {
 
+    REMAIN_CAN_NOT_APPLIED(403, "Remain Can Not Apply"),
     REMAIN_AVAILABLE_TIME_CAN_NOT_ACCESS(403, "Remain Available Time Can Not Access"),
 
-    REMAIN_AVAILABLE_TIME_NOT_FOUND(404, "Remain Available Time Not Found")
+    REMAIN_AVAILABLE_TIME_NOT_FOUND(404, "Remain Available Time Not Found"),
     ;
 
     override fun status() = status

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -126,6 +126,7 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.GET, "/study-rooms/my").hasAuthority(STUDENT.name)
 
             // /remains
+            .antMatchers(HttpMethod.PUT, "/remains/{remain-option-id}").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.POST, "/remains/options").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/remains/available-time").hasAnyAuthority(STUDENT.name, MANAGER.name)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
@@ -43,4 +43,9 @@ class RemainStatusPersistenceAdapter(
     override fun deleteRemainStatusByRemainOptionId(remainOptionId: UUID) {
         remainStatusRepository.deleteByRemainOptionId(remainOptionId)
     }
+    override fun saveRemainStatus(remainStatus: RemainStatus) = remainStatusMapper.toDomain(
+        remainStatusRepository.save(
+            remainStatusMapper.toEntity(remainStatus)
+        )
+    )!!
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/RemainStatusPersistenceAdapter.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.persistence.remain
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.remain.dto.RemainStatusInfo
+import team.aliens.dms.domain.remain.model.RemainStatus
 import team.aliens.dms.domain.remain.spi.RemainStatusPort
 import team.aliens.dms.persistence.remain.entity.QRemainOptionJpaEntity.remainOptionJpaEntity
 import team.aliens.dms.persistence.remain.entity.QRemainStatusJpaEntity.remainStatusJpaEntity
@@ -43,6 +44,7 @@ class RemainStatusPersistenceAdapter(
     override fun deleteRemainStatusByRemainOptionId(remainOptionId: UUID) {
         remainStatusRepository.deleteByRemainOptionId(remainOptionId)
     }
+
     override fun saveRemainStatus(remainStatus: RemainStatus) = remainStatusMapper.toDomain(
         remainStatusRepository.save(
             remainStatusMapper.toEntity(remainStatus)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/entity/RemainStatusJpaEntity.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/remain/entity/RemainStatusJpaEntity.kt
@@ -4,6 +4,7 @@ import team.aliens.dms.persistence.BaseTimeEntity
 import team.aliens.dms.persistence.student.entity.StudentJpaEntity
 import java.time.LocalDateTime
 import java.util.UUID
+import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.FetchType
@@ -23,7 +24,7 @@ class RemainStatusJpaEntity(
     val id: UUID,
 
     @MapsId
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)", nullable = false)
     val student: StudentJpaEntity?,
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/remain/RemainWebAdapter.kt
@@ -19,6 +19,7 @@ import team.aliens.dms.domain.remain.dto.request.CreateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.request.UpdateRemainAvailableTimeWebRequest
 import team.aliens.dms.domain.remain.dto.request.UpdateRemainOptionWebRequest
 import team.aliens.dms.domain.remain.dto.response.CreateRemainOptionResponse
+import team.aliens.dms.domain.remain.usecase.ApplyRemainUseCase
 import team.aliens.dms.domain.remain.usecase.CreateRemainOptionUseCase
 import team.aliens.dms.domain.remain.usecase.ExportRemainStatusUseCase
 import team.aliens.dms.domain.remain.usecase.QueryRemainAvailableTimeUseCase
@@ -35,6 +36,7 @@ import javax.validation.constraints.NotNull
 @RequestMapping("/remains")
 @RestController
 class RemainWebAdapter(
+    private val applyRemainUseCase: ApplyRemainUseCase,
     private val createRemainOptionUseCase: CreateRemainOptionUseCase,
     private val updateRemainOptionUseCase: UpdateRemainOptionUseCase,
     private val queryRemainAvailableTimeUseCase: QueryRemainAvailableTimeUseCase,
@@ -42,6 +44,11 @@ class RemainWebAdapter(
     private val updateRemainAvailableTimeUseCase: UpdateRemainAvailableTimeUseCase,
     private val exportRemainStatusUseCase: ExportRemainStatusUseCase
 ) {
+
+    @PutMapping("/{remain-option-id}")
+    fun applyRemainOption(@PathVariable("remain-option-id") @NotNull remainOptionId: UUID?) {
+        applyRemainUseCase.execute(remainOptionId!!)
+    }
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/options")


### PR DESCRIPTION
## 작업 내용 설명
- [x] ApplyRemainUseCase
- [x] PUT remains/{remain-option-id}

## 주요 변경 사항
- 잔류 신청 api

## 결과물
![image](https://user-images.githubusercontent.com/81006587/220639266-d30e7e3f-7ef0-4a59-a7e6-53afdb64a8bb.png)

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #269