### PR TITLE
merge: (#300) 삭제된 student 조회 막기

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/RemoveStudentUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/RemoveStudentUseCase.kt
@@ -8,6 +8,7 @@ import team.aliens.dms.domain.manager.spi.ManagerQueryUserPort
 import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.school.validateSameSchool
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import team.aliens.dms.domain.student.spi.CommandStudentPort
 import team.aliens.dms.domain.student.spi.StudentCommandRemainStatusPort
 import team.aliens.dms.domain.student.spi.StudentCommandStudyRoomPort
 import team.aliens.dms.domain.student.spi.StudentQueryStudyRoomPort
@@ -24,6 +25,7 @@ class RemoveStudentUseCase(
     private val commandRemainStatusPort: StudentCommandRemainStatusPort,
     private val queryStudyRoomPort: StudentQueryStudyRoomPort,
     private val commandStudyRoomPort: StudentCommandStudyRoomPort,
+    private val commandStudentPort: CommandStudentPort,
     private val commandUserPort: ManagerCommandUserPort
 ) {
 
@@ -49,6 +51,10 @@ class RemoveStudentUseCase(
                 studyRoom.unApply()
             )
         }
+
+        commandStudentPort.saveStudent(
+            student.copy(deletedAt = LocalDateTime.now())
+        )
 
         commandUserPort.saveUser(
             studentUser.copy(deletedAt = LocalDateTime.now())

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/RemoveStudentUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/RemoveStudentUseCaseTests.kt
@@ -18,6 +18,7 @@ import team.aliens.dms.domain.school.exception.SchoolMismatchException
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.spi.CommandStudentPort
 import team.aliens.dms.domain.student.spi.StudentCommandRemainStatusPort
 import team.aliens.dms.domain.student.spi.StudentCommandStudyRoomPort
 import team.aliens.dms.domain.student.spi.StudentQueryStudyRoomPort
@@ -51,6 +52,9 @@ class RemoveStudentUseCaseTests {
     private lateinit var commandStudyRoomPort: StudentCommandStudyRoomPort
 
     @MockBean
+    private lateinit var commandStudentPort: CommandStudentPort
+
+    @MockBean
     private lateinit var commandUserPort: ManagerCommandUserPort
 
     private lateinit var removeStudentUseCase: RemoveStudentUseCase
@@ -59,7 +63,7 @@ class RemoveStudentUseCaseTests {
     fun setUp() {
         removeStudentUseCase = RemoveStudentUseCase(
             securityPort, queryUserPort, queryStudentPort, commandRemainStatusPort,
-            queryStudyRoomPort, commandStudyRoomPort, commandUserPort
+            queryStudyRoomPort, commandStudyRoomPort, commandStudentPort, commandUserPort
         )
     }
 

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentWithdrawalUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/StudentWithdrawalUseCaseTests.kt
@@ -8,6 +8,11 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.spi.CommandStudentPort
+import team.aliens.dms.domain.student.spi.QueryStudentPort
 import team.aliens.dms.domain.student.spi.StudentCommandRemainStatusPort
 import team.aliens.dms.domain.student.spi.StudentCommandStudyRoomPort
 import team.aliens.dms.domain.student.spi.StudentCommandUserPort
@@ -25,14 +30,17 @@ import java.util.UUID
 class StudentWithdrawalUseCaseTests {
 
     private val securityPort: StudentSecurityPort = mockk(relaxed = true)
+    private val queryStudentPort: QueryStudentPort = mockk(relaxed = true)
     private val queryUserPort: StudentQueryUserPort = mockk(relaxed = true)
     private val commandRemainStatusPort: StudentCommandRemainStatusPort = mockk(relaxed = true)
     private val queryStudyRoomPort: StudentQueryStudyRoomPort = mockk(relaxed = true)
     private val commandStudyRoomPort: StudentCommandStudyRoomPort = mockk(relaxed = true)
+    private val commandStudentPort: CommandStudentPort = mockk(relaxed = true)
     private val commandUserPort: StudentCommandUserPort = mockk(relaxed = true)
 
     private val studentWithdrawalUseCase = StudentWithdrawalUseCase(
-        securityPort, queryUserPort, commandRemainStatusPort, queryStudyRoomPort, commandStudyRoomPort, commandUserPort
+        securityPort, queryStudentPort, queryUserPort, commandRemainStatusPort, queryStudyRoomPort,
+        commandStudyRoomPort, commandStudentPort, commandUserPort
     )
 
     private val currentStudentId = UUID.randomUUID()
@@ -47,6 +55,22 @@ class StudentWithdrawalUseCaseTests {
             authority = Authority.STUDENT,
             createdAt = null,
             deletedAt = null
+        )
+    }
+
+    private val studentStub by lazy {
+        Student(
+            id = currentStudentId,
+            roomId = UUID.randomUUID(),
+            roomNumber = "216",
+            roomLocation = "A",
+            schoolId = UUID.randomUUID(),
+            grade = 2,
+            classRoom = 1,
+            number = 20,
+            name = "김범진",
+            profileImageUrl = "profile image url",
+            sex = Sex.FEMALE
         )
     }
 
@@ -72,6 +96,8 @@ class StudentWithdrawalUseCaseTests {
 
         every { queryUserPort.queryUserById(currentStudentId) } returns userStub
 
+        every { queryStudentPort.queryStudentById(currentStudentId) } returns studentStub
+
         every { queryStudyRoomPort.querySeatByStudentId(currentStudentId) } returns null
 
         // when & then
@@ -94,9 +120,26 @@ class StudentWithdrawalUseCaseTests {
     }
 
     @Test
+    fun `학생이 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns currentStudentId
+
+        every { queryUserPort.queryUserById(currentStudentId) } returns userStub
+
+        every { queryStudentPort.queryStudentById(currentStudentId) } returns null
+
+        // when & then
+        assertThrows<StudentNotFoundException> {
+            studentWithdrawalUseCase.execute()
+        }
+    }
+
+    @Test
     fun `자습실이 존재하지 않음`() {
         // given
         every { securityPort.getCurrentUserId() } returns currentStudentId
+
+        every { queryStudentPort.queryStudentById(currentStudentId) } returns studentStub
 
         every { queryUserPort.queryUserById(currentStudentId) } returns userStub
 

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/Student.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/student/model/Student.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.student.model
 
 import team.aliens.dms.common.annotation.Aggregate
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Aggregate
@@ -26,8 +27,9 @@ data class Student(
 
     val profileImageUrl: String? = PROFILE_IMAGE,
 
-    val sex: Sex
+    val sex: Sex,
 
+    val deletedAt: LocalDateTime? = null
 ) {
 
     val gcn: String = processGcn(this.grade, this.classRoom, this.number)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -77,6 +77,7 @@ class StudentPersistenceAdapter(
         return queryFactory
             .selectFrom(studentJpaEntity)
             .join(studentJpaEntity.user, userJpaEntity).fetchJoin()
+            .join(studentJpaEntity.room, roomJpaEntity).fetchJoin()
             .join(userJpaEntity.school, schoolJpaEntity)
             .leftJoin(pointHistoryJpaEntity)
             .on(eqStudentRecentPointHistory())

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/entity/StudentJpaEntity.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/entity/StudentJpaEntity.kt
@@ -1,8 +1,10 @@
 package team.aliens.dms.persistence.student.entity
 
+import org.hibernate.annotations.Where
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.persistence.room.entity.RoomJpaEntity
 import team.aliens.dms.persistence.user.entity.UserJpaEntity
+import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.CascadeType
 import javax.persistence.Column
@@ -25,6 +27,7 @@ import javax.persistence.UniqueConstraint
         UniqueConstraint(columnNames = arrayOf("grade", "class_room", "number"))
     ]
 )
+@Where(clause = "deleted_at is null")
 class StudentJpaEntity(
 
     @Id
@@ -60,6 +63,8 @@ class StudentJpaEntity(
 
     @Column(columnDefinition = "VARCHAR(6)", nullable = false)
     @Enumerated(EnumType.STRING)
-    val sex: Sex
+    val sex: Sex,
 
+    @Column(columnDefinition = "DATETIME")
+    val deletedAt: LocalDateTime?
 )

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/mapper/StudentMapper.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/mapper/StudentMapper.kt
@@ -27,7 +27,8 @@ class StudentMapper(
                 number = it.number,
                 name = it.name,
                 profileImageUrl = it.profileImageUrl,
-                sex = it.sex
+                sex = it.sex,
+                deletedAt = it.deletedAt
             )
         }
     }
@@ -46,7 +47,8 @@ class StudentMapper(
             number = domain.number,
             name = domain.name,
             profileImageUrl = domain.profileImageUrl!!,
-            sex = domain.sex
+            sex = domain.sex,
+            deletedAt = domain.deletedAt
         )
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] 삭제된 student 조회 막기

## 주요 변경 사항
- student table에 deletedAt 추가
    - 조회시 user에 있는 deleteAt으로 join 해서 걸러도 되긴 합니다
    - 근데 user 정보가 필요 없을때도 매번 조인해야하고, jpql이 조금 복잡해진다는 단점이 있어서 비정규화 시켜놨습니다
    - (그리고 그렇게 하려면 @Where annotation을 사용할 수 없어서, 매번 쿼리에 조인과 비교문을 추가해줘야 할 수도 있습니다)
    - 의견 있으시다면 말씀해주세요

## 결과물
![image](https://user-images.githubusercontent.com/81006587/222123349-8030d101-dc5a-4bc8-afa2-b03c1e6cd0f0.png)

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #300