### PR TITLE
bug: cancel시 최근 total 기준으로 계산

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/CancelGrantedPointUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/point/usecase/CancelGrantedPointUseCase.kt
@@ -27,7 +27,14 @@ class CancelGrantedPointUseCase(
 
         validateSameSchool(manager.schoolId, pointHistory.schoolId)
 
-        commandPointHistoryPort.savePointHistory(pointHistory.cancelHistory())
+        val pointTotal = queryPointHistoryPort.queryBonusAndMinusTotalPointByStudentGcnAndName(
+            gcn = pointHistory.studentGcn,
+            studentName = pointHistory.studentName
+        )
+
+        commandPointHistoryPort.savePointHistory(
+            pointHistory.cancelHistory(pointTotal)
+        )
         commandPointHistoryPort.deletePointHistory(pointHistory)
     }
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/CancelGrantedPointUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/point.usecase/CancelGrantedPointUseCaseTests.kt
@@ -77,7 +77,7 @@ class CancelGrantedPointUseCaseTests {
 
         every { queryPointHistoryPort.queryBonusAndMinusTotalPointByStudentGcnAndName(
             pointHistoryStub.studentGcn, pointHistoryStub.studentName
-        ) }returns Pair(0,0)
+        ) } returns Pair(0,0)
 
         // when & then
         assertDoesNotThrow {

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/point/model/PointHistory.kt
@@ -31,13 +31,13 @@ data class PointHistory(
     val schoolId: UUID
 
 ) {
-    fun cancelHistory(): PointHistory {
+    fun cancelHistory(pointTotal: Pair<Int, Int>): PointHistory {
 
         if (this.isCancel) {
             throw PointHistoryCanNotCancelException
         }
 
-        val (bonusTotal, minusTotal) = calculateCanceledPointTotal()
+        val (bonusTotal, minusTotal) = calculateCanceledPointTotal(pointTotal)
 
         return PointHistory(
             isCancel = true,
@@ -53,11 +53,11 @@ data class PointHistory(
         )
     }
 
-    private fun calculateCanceledPointTotal(): Pair<Int, Int> {
+    private fun calculateCanceledPointTotal(pointTotal: Pair<Int, Int>): Pair<Int, Int> {
         return if (this.pointType == PointType.BONUS) {
-            Pair(this.bonusTotal - this.pointScore, this.minusTotal)
+            Pair(pointTotal.first - this.pointScore, pointTotal.second)
         } else {
-            Pair(this.bonusTotal, this.minusTotal - pointScore)
+            Pair(pointTotal.first, pointTotal.second - this.pointScore)
         }
     }
 }

--- a/dms-domain/src/test/kotlin/team/aliens/dms/point/model/PointHistoryTests.kt
+++ b/dms-domain/src/test/kotlin/team/aliens/dms/point/model/PointHistoryTests.kt
@@ -28,8 +28,10 @@ class PointHistoryTests {
             schoolId = UUID.randomUUID()
         )
 
+        val pointTotal = Pair(3, 0)
+
         // when
-        val canceledHistory = pointHistory.cancelHistory()
+        val canceledHistory = pointHistory.cancelHistory(pointTotal)
 
         // then
         assertAll(
@@ -55,9 +57,11 @@ class PointHistoryTests {
             schoolId = UUID.randomUUID()
         )
 
+        val pointTotal = Pair(3, 0)
+
         // when & then
         assertThrows<PointHistoryCanNotCancelException> {
-            canceledPointHistory.cancelHistory()
+            canceledPointHistory.cancelHistory(pointTotal)
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] 기존 cancelPointHistory는 해당 부여 내역의 total을 기준으로 계산
    - 해당 부여 내역이 아닌, 최근 내역으로 total 계산하도록 변경

## 주요 변경 사항

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?