### PR TITLE
merge: (#329) 인증코드 검사 삭제

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/exception/UnverifiedAuthCodeException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/exception/UnverifiedAuthCodeException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.auth.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.auth.error.AuthErrorCode
+
+object UnverifiedAuthCodeException: DmsException(
+    AuthErrorCode.UNVERIFIED_AUTH_CODE
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/spi/AuthCodeLimitPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/auth/spi/AuthCodeLimitPort.kt
@@ -1,5 +1,8 @@
 package team.aliens.dms.domain.auth.spi
 
+import team.aliens.dms.domain.student.spi.StudentQueryAuthCodeLimitPort
+
 interface AuthCodeLimitPort :
     QueryAuthCodeLimitPort,
+    StudentQueryAuthCodeLimitPort,
     CommandAuthCodeLimitPort

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryAuthCodeLimitPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/spi/StudentQueryAuthCodeLimitPort.kt
@@ -1,0 +1,7 @@
+package team.aliens.dms.domain.student.spi
+
+import team.aliens.dms.domain.auth.model.AuthCodeLimit
+
+interface StudentQueryAuthCodeLimitPort {
+    fun queryAuthCodeLimitByEmail(email: String): AuthCodeLimit?
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCase.kt
@@ -1,8 +1,6 @@
 package team.aliens.dms.domain.student.usecase
 
 import team.aliens.dms.common.annotation.UseCase
-import team.aliens.dms.domain.auth.exception.AuthCodeMismatchException
-import team.aliens.dms.domain.auth.exception.AuthCodeNotFoundException
 import team.aliens.dms.domain.auth.model.Authority
 import team.aliens.dms.domain.room.exception.RoomNotFoundException
 import team.aliens.dms.domain.school.exception.AnswerMismatchException
@@ -62,7 +60,6 @@ class SignUpUseCase(
 
         val school = validateSchool(schoolCode, schoolAnswer)
 
-        validateAuthCode(authCode, email)
         validateUserDuplicated(accountId, email, grade, classRoom, number)
 
         /**
@@ -116,17 +113,6 @@ class SignUpUseCase(
                 )
             }
         )
-    }
-
-    private fun validateAuthCode(authCode: String, email: String) {
-        /**
-         * 이메일 인증코드 검사
-         **/
-        val authCodeEntity = queryAuthCodePort.queryAuthCodeByEmail(email) ?: throw AuthCodeNotFoundException
-
-        if (authCode != authCodeEntity.code) {
-            throw AuthCodeMismatchException
-        }
     }
 
     private fun validateSchool(schoolCode: String, schoolAnswer: String): School {

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.domain.student.usecase
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -9,6 +8,7 @@ import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.auth.exception.AuthCodeLimitNotFoundException
+import team.aliens.dms.domain.auth.exception.UnverifiedAuthCodeException
 import team.aliens.dms.domain.auth.model.AuthCodeLimit
 import team.aliens.dms.domain.auth.model.EmailType
 import team.aliens.dms.domain.room.model.Room
@@ -182,8 +182,8 @@ class SignUpUseCaseTests {
 //        given(queryUserPort.existsUserByEmail(email))
 //            .willReturn(false)
 //
-//        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-//            .willReturn(authCodeStub)
+//        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+//            .willReturn(authCodeLimitStub)
 //
 //        given(queryUserPort.existsUserByAccountId(accountId))
 //            .willReturn(false)
@@ -411,11 +411,10 @@ class SignUpUseCaseTests {
         given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
             .willReturn(unverifiedAuthCodeLimitStub)
 
-        // when
-        val isVerified = unverifiedAuthCodeLimitStub.isVerified
-
-        // then
-        assertThat(isVerified).isFalse
+        // when & then
+        assertThrows<UnverifiedAuthCodeException> {
+            signUpUseCase.execute(requestStub)
+        }
     }
 
 //    @Test

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
@@ -247,44 +247,6 @@ class SignUpUseCaseTests {
     }
 
     @Test
-    fun `이메일 인증코드가 존재하지 않음`() {
-        // given
-        given(querySchoolPort.querySchoolByCode(code))
-            .willReturn(schoolStub)
-
-        given(queryUserPort.existsUserByEmail(email))
-            .willReturn(false)
-
-        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-            .willReturn(null)
-
-        // when & then
-        assertThrows<AuthCodeNotFoundException> {
-            signUpUseCase.execute(requestStub)
-        }
-    }
-
-    @Test
-    fun `이메일 인증코드가 일치하지 않음`() {
-        val wrongCodeAuthCode = authCodeStub.copy(code = "wrong code")
-
-        // given
-        given(querySchoolPort.querySchoolByCode(code))
-            .willReturn(schoolStub)
-
-        given(queryUserPort.existsUserByEmail(email))
-            .willReturn(false)
-
-        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-            .willReturn(wrongCodeAuthCode)
-
-        // when & then
-        assertThrows<AuthCodeMismatchException> {
-            signUpUseCase.execute(requestStub)
-        }
-    }
-
-    @Test
     fun `학번 이미 존재`() {
         // given
         given(querySchoolPort.querySchoolByCode(code))

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
@@ -7,9 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.aliens.dms.domain.auth.exception.AuthCodeMismatchException
-import team.aliens.dms.domain.auth.exception.AuthCodeNotFoundException
 import team.aliens.dms.domain.auth.model.AuthCode
+import team.aliens.dms.domain.auth.model.AuthCodeLimit
 import team.aliens.dms.domain.auth.model.EmailType
 import team.aliens.dms.domain.room.model.Room
 import team.aliens.dms.domain.school.exception.AnswerMismatchException
@@ -25,7 +24,7 @@ import team.aliens.dms.domain.student.spi.CommandStudentPort
 import team.aliens.dms.domain.student.spi.QueryStudentPort
 import team.aliens.dms.domain.student.spi.StudentCommandUserPort
 import team.aliens.dms.domain.student.spi.StudentJwtPort
-import team.aliens.dms.domain.student.spi.StudentQueryAuthCodePort
+import team.aliens.dms.domain.student.spi.StudentQueryAuthCodeLimitPort
 import team.aliens.dms.domain.student.spi.StudentQueryRoomPort
 import team.aliens.dms.domain.student.spi.StudentQuerySchoolPort
 import team.aliens.dms.domain.student.spi.StudentQueryUserPort
@@ -52,10 +51,10 @@ class SignUpUseCaseTests {
     private lateinit var querySchoolPort: StudentQuerySchoolPort
 
     @MockBean
-    private lateinit var queryAuthCodePort: StudentQueryAuthCodePort
+    private lateinit var queryUserPort: StudentQueryUserPort
 
     @MockBean
-    private lateinit var queryUserPort: StudentQueryUserPort
+    private lateinit var queryAuthCodeLimitPort: StudentQueryAuthCodeLimitPort
 
     @MockBean
     private lateinit var queryVerifiedStudentPort: StudentQueryVerifiedStudentPort
@@ -79,7 +78,7 @@ class SignUpUseCaseTests {
             commandUserPort,
             querySchoolPort,
             queryUserPort,
-            queryAuthCodePort,
+            queryAuthCodeLimitPort,
             queryVerifiedStudentPort,
             queryRoomPort,
             securityPort,
@@ -110,11 +109,14 @@ class SignUpUseCaseTests {
         )
     }
 
-    private val authCodeStub by lazy {
-        AuthCode(
-            code = "123412",
+    private val authCodeLimitStub by lazy {
+        AuthCodeLimit(
+            id = UUID.randomUUID(),
             email = email,
-            type = EmailType.SIGNUP
+            type = EmailType.SIGNUP,
+            attemptCount = 0,
+            isVerified = true,
+            expirationTime = 1800
         )
     }
 
@@ -234,8 +236,8 @@ class SignUpUseCaseTests {
         given(querySchoolPort.querySchoolByCode(code))
             .willReturn(schoolStub)
 
-        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-            .willReturn(authCodeStub)
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(authCodeLimitStub)
 
         given(queryUserPort.existsUserByEmail(email))
             .willReturn(true)
@@ -255,8 +257,8 @@ class SignUpUseCaseTests {
         given(queryUserPort.existsUserByEmail(email))
             .willReturn(false)
 
-        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-            .willReturn(authCodeStub)
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(authCodeLimitStub)
 
         given(
             queryStudentPort.existsStudentByGradeAndClassRoomAndNumber(
@@ -281,8 +283,8 @@ class SignUpUseCaseTests {
         given(queryUserPort.existsUserByEmail(email))
             .willReturn(false)
 
-        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-            .willReturn(authCodeStub)
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(authCodeLimitStub)
 
         given(
             queryStudentPort.existsStudentByGradeAndClassRoomAndNumber(
@@ -341,8 +343,8 @@ class SignUpUseCaseTests {
         given(queryUserPort.existsUserByEmail(email))
             .willReturn(false)
 
-        given(queryAuthCodePort.queryAuthCodeByEmail(email))
-            .willReturn(authCodeStub)
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(authCodeLimitStub)
 
         given(
             queryStudentPort.existsStudentByGradeAndClassRoomAndNumber(

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCaseTests.kt
@@ -414,7 +414,7 @@ class SignUpUseCaseTests {
         // when
         val isVerified = unverifiedAuthCodeLimitStub.isVerified
 
-        // when & then
+        // then
         assertThat(isVerified).isFalse
     }
 

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/auth/error/AuthErrorCode.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/auth/error/AuthErrorCode.kt
@@ -11,6 +11,7 @@ enum class AuthErrorCode(
     AUTH_CODE_MISMATCH(ErrorStatus.UNAUTHORIZED, "Auth Code Mismatch"),
     EMAIL_MISMATCH(ErrorStatus.UNAUTHORIZED, "Email Mismatch"),
     PASSWORD_MISMATCH(ErrorStatus.UNAUTHORIZED, "Password Mismatch"),
+    UNVERIFIED_AUTH_CODE(ErrorStatus.UNAUTHORIZED, "Unverified Auth Code"),
 
     REFRESH_TOKEN_NOT_FOUND(ErrorStatus.NOT_FOUND, "Refresh Token Not Found"),
     AUTH_CODE_NOT_FOUND(ErrorStatus.NOT_FOUND, "Auth Code Not Found"),

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/auth/AuthCodeLimitPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/auth/AuthCodeLimitPersistenceAdapter.kt
@@ -25,4 +25,9 @@ class AuthCodeLimitPersistenceAdapter(
             authCodeLimitMapper.toEntity(authCodeLimit)
         )
     )!!
+
+    override fun queryAuthCodeLimitByEmail(email: String): AuthCodeLimit? =
+        authCodeLimitMapper.toDomain(
+            authCodeLimitRepository.findByEmail(email)
+        )
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/auth/repository/AuthCodeLimitRepository.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/auth/repository/AuthCodeLimitRepository.kt
@@ -10,4 +10,6 @@ import java.util.UUID
 interface AuthCodeLimitRepository : CrudRepository<AuthCodeLimitEntity, UUID> {
 
     fun findByEmailAndType(email: String, type: EmailType): AuthCodeLimitEntity?
+
+    fun findByEmail(email: String): AuthCodeLimitEntity?
 }


### PR DESCRIPTION
## 작업 내용 설명
- [X] 회원가입 할 때 불필요한 인증코드 검사 로직 제거

## 주요 변경 사항
- 회원가입에서 인증코드 검사 제거

## 결과물

## 체크리스트
- [X] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [X] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #329 