### PR TITLE
merge: List 요소 validation 안됨

### DIFF
--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/PointWebAdapter.kt
@@ -43,6 +43,7 @@ import java.net.URLEncoder
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.servlet.http.HttpServletResponse
+import javax.validation.ConstraintViolationException
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
 
@@ -107,7 +108,9 @@ class PointWebAdapter(
         grantPointUseCase.execute(
             GrantPointRequest(
                 pointOptionId = webRequest.pointOptionId!!,
-                studentIdList = webRequest.studentIdList!!
+                studentIdList = webRequest.studentIdList!!.map {
+                    it ?: throw ConstraintViolationException(setOf())
+                }
             )
         )
     }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/dto/request/GrantPointWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/point/dto/request/GrantPointWebRequest.kt
@@ -8,5 +8,5 @@ data class GrantPointWebRequest(
     val pointOptionId: UUID?,
 
     @field:NotNull
-    val studentIdList: List<UUID>?
+    val studentIdList: List<UUID?>?
 )


### PR DESCRIPTION
## 작업 내용 설명
- [x] studentId 목록을 List<UUID>로 받을때, 요소가 null인 경우 null check 안되고 그대로 null로 들어와서 500 발생

## 주요 변경 사항
- web request 값은 스프링에서 주입해주는거라서 List의 요소가 자바 객체이면서 null인 경우엔 null check를 못하는 것 같습니다..
- 그래서 수동으로 체크해서 에러 던지는 코드를 추가했습니다
    - 반환되는 에러 형식이 그냥 validation 하는거랑 다르긴 해서 다른 방법에 대한 아이디어 있으시면 말씀해주세용 

## 결과물
![image](https://user-images.githubusercontent.com/81006587/223431168-fd083a49-c049-4a81-aaa9-15e09f4cd63c.png)

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #