### PR TITLE
merge: (#358) 이용시간 삭제 api

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/exception/TimeSlotInUseException.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/exception/TimeSlotInUseException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.domain.studyroom.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.domain.studyroom.error.StudyRoomErrorCode
+
+object TimeSlotInUseException : DmsException(
+    StudyRoomErrorCode.TIME_SLOT_IN_USE
+)

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
@@ -1,12 +1,12 @@
 package team.aliens.dms.domain.studyroom.spi
 
+import java.util.UUID
 import team.aliens.dms.domain.studyroom.model.Seat
 import team.aliens.dms.domain.studyroom.model.SeatApplication
 import team.aliens.dms.domain.studyroom.model.StudyRoom
 import team.aliens.dms.domain.studyroom.model.TimeSlot
 import team.aliens.dms.domain.studyroom.spi.vo.SeatApplicationVO
 import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
-import java.util.UUID
 
 interface QueryStudyRoomPort {
 
@@ -31,4 +31,6 @@ interface QueryStudyRoomPort {
     fun existsSeatApplicationBySeatIdAndTimeSlotId(seatId: UUID, timeSlotId: UUID): Boolean
 
     fun existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId: UUID, timeSlotId: UUID): Boolean
+
+    fun existsStudyRoomTimeSlotByTimeSlotId(timeSlotId: UUID): Boolean
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/RemoveTimeSlotUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/RemoveTimeSlotUseCase.kt
@@ -1,0 +1,35 @@
+package team.aliens.dms.domain.studyroom.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.school.validateSameSchool
+import team.aliens.dms.domain.studyroom.exception.TimeSlotInUseException
+import team.aliens.dms.domain.studyroom.exception.TimeSlotNotFoundException
+import team.aliens.dms.domain.studyroom.spi.CommandStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import java.util.UUID
+
+@UseCase
+class RemoveTimeSlotUseCase(
+    private val securityPort: StudyRoomSecurityPort,
+    private val queryUserPort: StudyRoomQueryUserPort,
+    private val queryStudyRoomPort: QueryStudyRoomPort,
+    private val commandStudyRoomPort: CommandStudyRoomPort
+) {
+    fun execute(timeSlotId: UUID) {
+        val currentManagerId = securityPort.getCurrentUserId()
+        val currentManager = queryUserPort.queryUserById(currentManagerId) ?: throw UserNotFoundException
+
+        val timeSlot = queryStudyRoomPort.queryTimeSlotById(timeSlotId) ?: throw TimeSlotNotFoundException
+        validateSameSchool(currentManager.schoolId, timeSlot.schoolId)
+
+        if (queryStudyRoomPort.existsStudyRoomTimeSlotByTimeSlotId(timeSlotId)) {
+            throw TimeSlotInUseException
+        }
+
+        commandStudyRoomPort.deleteSeatApplicationByTimeSlotId(timeSlotId)
+        commandStudyRoomPort.deleteTimeSlotById(timeSlotId)
+    }
+}

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/RemoveTimeSlotUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/RemoveTimeSlotUseCaseTests.kt
@@ -1,0 +1,97 @@
+package team.aliens.dms.domain.studyroom.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.studyroom.exception.TimeSlotNotFoundException
+import team.aliens.dms.domain.studyroom.model.TimeSlot
+import team.aliens.dms.domain.studyroom.spi.CommandStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.model.User
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.UUID
+
+class RemoveTimeSlotUseCaseTests {
+
+    private val securityPort: StudyRoomSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: StudyRoomQueryUserPort = mockk(relaxed = true)
+    private val queryStudyRoomPort: QueryStudyRoomPort = mockk(relaxed = true)
+    private val commandStudyRoomPort: CommandStudyRoomPort = mockk(relaxed = true)
+
+    private val removeTimeSlotUseCase = RemoveTimeSlotUseCase(
+        securityPort, queryUserPort, queryStudyRoomPort, commandStudyRoomPort
+    )
+
+    private val userId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+    private val timeSlotId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        User(
+            id = userId,
+            schoolId = schoolId,
+            accountId = "test account id",
+            password = "test password",
+            email = "test email",
+            authority = Authority.STUDENT,
+            createdAt = LocalDateTime.now(),
+            deletedAt = null
+        )
+    }
+
+    private val timeSlotStub by lazy {
+        TimeSlot(
+            id = UUID.randomUUID(),
+            schoolId = schoolId,
+            startTime = LocalTime.of(0, 0),
+            endTime = LocalTime.of(0, 0)
+        )
+    }
+
+    @Test
+    fun `이용시간 삭제 성공`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
+
+        // when
+        removeTimeSlotUseCase.execute(timeSlotId)
+
+        // then
+        verify(exactly = 1) { commandStudyRoomPort.deleteSeatApplicationByTimeSlotId(timeSlotId) }
+        verify(exactly = 1) { commandStudyRoomPort.deleteTimeSlotById(timeSlotId) }
+    }
+
+    @Test
+    fun `유저가 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns null
+
+        // when
+        assertThrows<UserNotFoundException> {
+            removeTimeSlotUseCase.execute(timeSlotId)
+        }
+    }
+
+    @Test
+    fun `이용시간이 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns null
+
+        // when
+        assertThrows<TimeSlotNotFoundException> {
+            removeTimeSlotUseCase.execute(timeSlotId)
+        }
+    }
+}

--- a/dms-domain/src/main/kotlin/team/aliens/dms/domain/studyroom/error/StudyRoomErrorCode.kt
+++ b/dms-domain/src/main/kotlin/team/aliens/dms/domain/studyroom/error/StudyRoomErrorCode.kt
@@ -14,7 +14,8 @@ enum class StudyRoomErrorCode(
     STUDY_ROOM_NOT_FOUND(ErrorStatus.NOT_FOUND, "Study Room Not Found"),
     TIME_SLOT_NOT_FOUND(ErrorStatus.NOT_FOUND, "Study Room Time Slot Not Found"),
 
-    STUDY_ROOM_ALREADY_EXISTS(ErrorStatus.CONFLICT, "Study Room Already Exists")
+    STUDY_ROOM_ALREADY_EXISTS(ErrorStatus.CONFLICT, "Study Room Already Exists"),
+    TIME_SLOT_IN_USE(ErrorStatus.CONFLICT, "Time Slot In Use")
     ;
 
     override fun status(): Int = status

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -117,6 +117,7 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.GET, "/study-rooms/list/managers").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/study-rooms/types/{type-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/study-rooms/my").hasAuthority(STUDENT.name)
+            .antMatchers(HttpMethod.DELETE, "/study-rooms/time-slots/{time-slot-id}").hasAuthority(MANAGER.name)
             // /remains
             .antMatchers(HttpMethod.PUT, "/remains/available-time").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PUT, "/remains/{remain-option-id}").hasAuthority(STUDENT.name)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -157,6 +157,9 @@ class StudyRoomPersistenceAdapter(
             )
         )
 
+    override fun existsStudyRoomTimeSlotByTimeSlotId(timeSlotId: UUID) =
+        studyRoomTimeSlotRepository.existsByTimeSlotId(timeSlotId)
+
     override fun saveAllSeats(seats: List<Seat>) =
         seatRepository.saveAll(
             seats.map { seatMapper.toEntity(it) }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
@@ -37,6 +37,7 @@ import team.aliens.dms.domain.studyroom.usecase.QueryCurrentAppliedStudyRoomUseC
 import team.aliens.dms.domain.studyroom.usecase.QuerySeatTypesUseCase
 import team.aliens.dms.domain.studyroom.usecase.RemoveSeatTypeUseCase
 import team.aliens.dms.domain.studyroom.usecase.RemoveStudyRoomUseCase
+import team.aliens.dms.domain.studyroom.usecase.RemoveTimeSlotUseCase
 import team.aliens.dms.domain.studyroom.usecase.StudentQueryStudyRoomUseCase
 import team.aliens.dms.domain.studyroom.usecase.StudentQueryStudyRoomsUseCase
 import team.aliens.dms.domain.studyroom.usecase.UnApplySeatUseCase
@@ -64,7 +65,8 @@ class StudyRoomWebAdapter(
     private val studentQueryStudyRoomsUseCase: StudentQueryStudyRoomsUseCase,
     private val managerQueryStudyRoomsUseCase: ManagerQueryStudyRoomsUseCase,
     private val removeSeatTypeUseCase: RemoveSeatTypeUseCase,
-    private val queryCurrentAppliedStudyRoomUseCase: QueryCurrentAppliedStudyRoomUseCase
+    private val queryCurrentAppliedStudyRoomUseCase: QueryCurrentAppliedStudyRoomUseCase,
+    private val removeTimeSlotUseCase: RemoveTimeSlotUseCase
 ) {
 
     @GetMapping("/available-time")
@@ -228,5 +230,11 @@ class StudyRoomWebAdapter(
     @GetMapping("/my")
     fun getMyStudyRoom(): QueryCurrentAppliedStudyRoomResponse {
         return queryCurrentAppliedStudyRoomUseCase.execute()
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/time-slots/{time-slot-id}")
+    fun removeTimeSlot(@PathVariable("time-slot-id") timeSlotId: UUID) {
+        removeTimeSlotUseCase.execute(timeSlotId)
     }
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/CreateStudyRoomWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/CreateStudyRoomWebRequest.kt
@@ -1,12 +1,12 @@
 package team.aliens.dms.domain.studyroom.dto
 
-import team.aliens.dms.common.validator.NotNullElements
 import java.util.UUID
 import javax.validation.Valid
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size
+import team.aliens.dms.common.validator.NotNullElements
 
 data class CreateStudyRoomWebRequest(
 
@@ -49,6 +49,7 @@ data class CreateStudyRoomWebRequest(
     @field:Min(0)
     val availableGrade: Int?,
 
+    @field:Size(min = 1)
     @field:NotNullElements
     val timeSlotIds: List<UUID>?,
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/UpdateStudyRoomWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/UpdateStudyRoomWebRequest.kt
@@ -1,12 +1,12 @@
 package team.aliens.dms.domain.studyroom.dto
 
-import team.aliens.dms.common.validator.NotNullElements
 import java.util.UUID
 import javax.validation.Valid
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size
+import team.aliens.dms.common.validator.NotNullElements
 
 data class UpdateStudyRoomWebRequest(
 
@@ -49,6 +49,7 @@ data class UpdateStudyRoomWebRequest(
     @field:Min(0)
     val availableGrade: Int?,
 
+    @field:Size(min = 1)
     @field:NotNullElements
     val timeSlotIds: List<UUID>?,
 


### PR DESCRIPTION
## 작업 내용 설명
- [ ] DELETE /study-rooms/time-slots/{time-slot-id}
- [ ] RemoveTimeSLotUseCase

## 주요 변경 사항
- api 개발
- timeSlotId size 제한 설정

## 결과물
![image](https://user-images.githubusercontent.com/81006587/226233184-b3c803c2-c7fe-4462-9847-61017fe75de2.png)


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #358 