### PR TITLE
merge: (#360) 이용시간 조회 api + 자습실 상세 조회시 이용시간 정보 반환

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/ManagerQueryStudyRoomResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/ManagerQueryStudyRoomResponse.kt
@@ -1,15 +1,14 @@
 package team.aliens.dms.domain.studyroom.dto
 
-import team.aliens.dms.domain.student.model.Sex
-import team.aliens.dms.domain.studyroom.model.SeatStatus
 import java.time.LocalTime
 import java.util.UUID
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.studyroom.model.SeatStatus
 
 data class ManagerQueryStudyRoomResponse(
     val floor: Int,
     val name: String,
-    val timeSlotStartTime: LocalTime,
-    val timeSlotEndTime: LocalTime,
+    val timeSlots: List<TimeSlotElement>,
     val totalAvailableSeat: Int,
     val availableSex: Sex,
     val availableGrade: Int,
@@ -45,4 +44,10 @@ data class ManagerQueryStudyRoomResponse(
             val profileImageUrl: String
         )
     }
+
+    data class TimeSlotElement(
+        val id: UUID,
+        val startTime: LocalTime,
+        val endTime: LocalTime
+    )
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/QueryTimeSlotsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/QueryTimeSlotsResponse.kt
@@ -1,0 +1,14 @@
+package team.aliens.dms.domain.studyroom.dto
+
+import java.time.LocalTime
+import java.util.UUID
+
+data class QueryTimeSlotsResponse(
+    val timeSlots: List<TimeSlotElement>
+) {
+    data class TimeSlotElement(
+        val id: UUID,
+        val startTime: LocalTime,
+        val endTime: LocalTime
+    )
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/StudentQueryStudyRoomResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/dto/StudentQueryStudyRoomResponse.kt
@@ -1,14 +1,13 @@
 package team.aliens.dms.domain.studyroom.dto
 
-import team.aliens.dms.domain.student.model.Sex
-import team.aliens.dms.domain.studyroom.model.SeatStatus
 import java.time.LocalTime
 import java.util.UUID
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.studyroom.model.SeatStatus
 
 data class StudentQueryStudyRoomResponse(
     val floor: Int,
-    val timeSlotStartTime: LocalTime,
-    val timeSlotEndTime: LocalTime,
+    val timeSlots: List<TimeSlotElement>,
     val name: String,
     val totalAvailableSeat: Int,
     val inUseHeadcount: Int,
@@ -45,4 +44,10 @@ data class StudentQueryStudyRoomResponse(
             val name: String
         )
     }
+
+    data class TimeSlotElement(
+        val id: UUID,
+        val startTime: LocalTime,
+        val endTime: LocalTime
+    )
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
@@ -1,12 +1,12 @@
 package team.aliens.dms.domain.studyroom.spi
 
+import java.util.UUID
 import team.aliens.dms.domain.studyroom.model.Seat
 import team.aliens.dms.domain.studyroom.model.SeatApplication
 import team.aliens.dms.domain.studyroom.model.StudyRoom
 import team.aliens.dms.domain.studyroom.model.TimeSlot
 import team.aliens.dms.domain.studyroom.spi.vo.SeatApplicationVO
 import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
-import java.util.UUID
 
 interface QueryStudyRoomPort {
 
@@ -27,6 +27,8 @@ interface QueryStudyRoomPort {
     fun queryTimeSlotsBySchoolId(schoolId: UUID): List<TimeSlot>
 
     fun queryTimeSlotById(timeSlotId: UUID): TimeSlot?
+
+    fun queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId: UUID, studyRoomId: UUID): List<TimeSlot>
 
     fun existsSeatApplicationBySeatIdAndTimeSlotId(seatId: UUID, timeSlotId: UUID): Boolean
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCase.kt
@@ -34,7 +34,7 @@ class ManagerQueryStudyRoomUseCase(
 
         val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(user.schoolId, studyRoom.id)
             .apply {
-                if (!any { it.id == timeSlotId }) {
+                if (none { it.id == timeSlotId }) {
                     throw StudyRoomNotFoundException
                 }
             }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCase.kt
@@ -32,7 +32,7 @@ class ManagerQueryStudyRoomUseCase(
         val timeSlot = queryStudyRoomPort.queryTimeSlotById(timeSlotId) ?: throw TimeSlotNotFoundException
         validateSameSchool(user.schoolId, timeSlot.schoolId)
 
-        val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolId(user.schoolId)
+        val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(user.schoolId, studyRoom.id)
             .apply {
                 if (!any { it.id == timeSlotId }) {
                     throw StudyRoomNotFoundException

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/QueryTimeSlotsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/QueryTimeSlotsUseCase.kt
@@ -1,0 +1,32 @@
+package team.aliens.dms.domain.studyroom.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.studyroom.dto.QueryTimeSlotsResponse
+import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+
+@ReadOnlyUseCase
+class QueryTimeSlotsUseCase(
+    private val securityPort: StudyRoomSecurityPort,
+    private val queryUserPort: StudyRoomQueryUserPort,
+    private val queryStudyRoomPort: QueryStudyRoomPort
+) {
+    fun execute(): QueryTimeSlotsResponse {
+        val currentUserId = securityPort.getCurrentUserId()
+        val currentUser = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+
+        val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolId(currentUser.schoolId)
+
+        return QueryTimeSlotsResponse(
+            timeSlots = timeSlots.map {
+                QueryTimeSlotsResponse.TimeSlotElement(
+                    id = it.id,
+                    startTime = it.startTime,
+                    endTime = it.endTime
+                )
+            }
+        )
+    }
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCase.kt
@@ -28,7 +28,7 @@ class StudentQueryStudyRoomUseCase(
         val studyRoom = queryStudyRoomPort.queryStudyRoomById(studyRoomId) ?: throw StudyRoomNotFoundException
         validateSameSchool(user.schoolId, studyRoom.schoolId)
 
-        val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolId(user.schoolId)
+        val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(user.schoolId, studyRoomId)
             .apply {
                 if (!any { it.id == timeSlotId }) {
                     throw StudyRoomNotFoundException

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCase.kt
@@ -34,7 +34,7 @@ class StudentQueryStudyRoomUseCase(
 
         val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(user.schoolId, studyRoomId)
             .apply {
-                if (!any { it.id == timeSlotId }) {
+                if (none { it.id == timeSlotId }) {
                     throw StudyRoomNotFoundException
                 }
             }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCase.kt
@@ -8,6 +8,7 @@ import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse.SeatEl
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse.SeatElement.StudentElement
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse.SeatElement.TypeElement
 import team.aliens.dms.domain.studyroom.exception.StudyRoomNotFoundException
+import team.aliens.dms.domain.studyroom.exception.TimeSlotNotFoundException
 import team.aliens.dms.domain.studyroom.model.SeatStatus
 import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
@@ -27,6 +28,9 @@ class StudentQueryStudyRoomUseCase(
 
         val studyRoom = queryStudyRoomPort.queryStudyRoomById(studyRoomId) ?: throw StudyRoomNotFoundException
         validateSameSchool(user.schoolId, studyRoom.schoolId)
+
+        val timeSlot = queryStudyRoomPort.queryTimeSlotById(timeSlotId) ?: throw TimeSlotNotFoundException
+        validateSameSchool(user.schoolId, timeSlot.schoolId)
 
         val timeSlots = queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(user.schoolId, studyRoomId)
             .apply {

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCaseTests.kt
@@ -2,6 +2,9 @@ package team.aliens.dms.domain.studyroom.usecase
 
 import io.mockk.every
 import io.mockk.mockk
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.UUID
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -17,9 +20,6 @@ import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import team.aliens.dms.domain.user.model.User
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.util.UUID
 
 class ManagerQueryStudyRoomUseCaseTests {
 
@@ -82,8 +82,8 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns true
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(timeSlotStub)
 
         // when & then
         assertDoesNotThrow {
@@ -117,21 +117,6 @@ class ManagerQueryStudyRoomUseCaseTests {
     }
 
     @Test
-    fun `자습실에 대한 이용시간이 존재하지 않음`() {
-        // given
-        every { securityPort.getCurrentUserId() } returns userId
-        every { queryUserPort.queryUserById(userId) } returns userStub
-        every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns false
-
-        // when & then
-        assertThrows<StudyRoomNotFoundException> {
-            managerQueryRoomUseCase.execute(studyRoomId, timeSlotId)
-        }
-    }
-
-    @Test
     fun `이용시간이 존재하지 않음`() {
         // given
         every { securityPort.getCurrentUserId() } returns userId
@@ -141,6 +126,21 @@ class ManagerQueryStudyRoomUseCaseTests {
 
         // when & then
         assertThrows<TimeSlotNotFoundException> {
+            managerQueryRoomUseCase.execute(studyRoomId, timeSlotId)
+        }
+    }
+
+    @Test
+    fun `자습실에 대한 이용시간이 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
+        every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf()
+
+        // when & then
+        assertThrows<StudyRoomNotFoundException> {
             managerQueryRoomUseCase.execute(studyRoomId, timeSlotId)
         }
     }
@@ -165,6 +165,7 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns otherUserId
         every { queryUserPort.queryUserById(userId) } returns otherUserStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(timeSlotStub)
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
 
         // when & then
@@ -188,7 +189,7 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns true
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(otherTimeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns otherTimeSlotStub
 
         // when & then

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/ManagerQueryStudyRoomUseCaseTests.kt
@@ -83,7 +83,7 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(timeSlotStub)
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(timeSlotStub)
 
         // when & then
         assertDoesNotThrow {
@@ -137,7 +137,7 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf()
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf()
 
         // when & then
         assertThrows<StudyRoomNotFoundException> {
@@ -165,7 +165,7 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns otherUserId
         every { queryUserPort.queryUserById(userId) } returns otherUserStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(timeSlotStub)
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(timeSlotStub)
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
 
         // when & then
@@ -189,7 +189,7 @@ class ManagerQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(otherTimeSlotStub)
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(otherTimeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns otherTimeSlotStub
 
         // when & then

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCaseTests.kt
@@ -187,8 +187,8 @@ class StudentQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(otherTimeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns otherTimeSlotStub
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(otherTimeSlotStub)
 
         // when & then
         assertThrows<SchoolMismatchException> {

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCaseTests.kt
@@ -82,7 +82,7 @@ class StudentQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(timeSlotStub)
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(timeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
 
         // when & then
@@ -123,7 +123,7 @@ class StudentQueryStudyRoomUseCaseTests {
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf()
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf()
 
         // when & then
         assertThrows<StudyRoomNotFoundException> {
@@ -187,7 +187,7 @@ class StudentQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(otherTimeSlotStub)
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolIdAndStudyRoomId(schoolId, studyRoomId) } returns listOf(otherTimeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns otherTimeSlotStub
 
         // when & then

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomUseCaseTests.kt
@@ -2,6 +2,9 @@ package team.aliens.dms.domain.studyroom.usecase
 
 import io.mockk.every
 import io.mockk.mockk
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.UUID
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -17,9 +20,6 @@ import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import team.aliens.dms.domain.user.model.User
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.util.UUID
 
 class StudentQueryStudyRoomUseCaseTests {
 
@@ -82,7 +82,7 @@ class StudentQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns true
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(timeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
 
         // when & then
@@ -123,7 +123,7 @@ class StudentQueryStudyRoomUseCaseTests {
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns false
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf()
 
         // when & then
         assertThrows<StudyRoomNotFoundException> {
@@ -137,8 +137,6 @@ class StudentQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns true
-        every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns null
 
         // when & then
@@ -189,7 +187,7 @@ class StudentQueryStudyRoomUseCaseTests {
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
         every { queryStudyRoomPort.queryStudyRoomById(studyRoomId) } returns studyRoomStub
-        every { queryStudyRoomPort.existsStudyRoomTimeSlotByStudyRoomIdAndTimeSlotId(studyRoomId, timeSlotId) } returns true
+        every { queryStudyRoomPort.queryTimeSlotsBySchoolId(schoolId) } returns listOf(otherTimeSlotStub)
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns otherTimeSlotStub
 
         // when & then

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/JacksonConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/JacksonConfiguration.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.global.config
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
@@ -13,6 +14,7 @@ class JacksonConfiguration {
     fun jackson2ObjectMapperBuilder(): Jackson2ObjectMapperBuilder {
         return Jackson2ObjectMapperBuilder()
             .serializers(LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")))
+            .serializers(LocalTimeSerializer(DateTimeFormatter.ofPattern("HH:mm")))
             .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
     }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfiguration.kt
@@ -117,6 +117,7 @@ class SecurityConfiguration(
             .antMatchers(HttpMethod.GET, "/study-rooms/list/managers").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/study-rooms/types/{type-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/study-rooms/my").hasAuthority(STUDENT.name)
+            .antMatchers(HttpMethod.GET, "/study-rooms/time-slots").hasAnyAuthority(STUDENT.name, MANAGER.name)
             // /remains
             .antMatchers(HttpMethod.PUT, "/remains/available-time").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PUT, "/remains/{remain-option-id}").hasAuthority(STUDENT.name)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -120,6 +120,11 @@ class StudyRoomPersistenceAdapter(
                 )
             )
             .from(studyRoomJpaEntity)
+            .join(studyRoomTimeSlotJpaEntity)
+            .on(
+                studyRoomTimeSlotJpaEntity.studyRoom.id.eq(studyRoomJpaEntity.id),
+                studyRoomTimeSlotJpaEntity.timeSlot.id.eq(timeSlotId)
+            )
             .leftJoin(seatJpaEntity)
             .on(studyRoomJpaEntity.id.eq(seatJpaEntity.studyRoom.id))
             .leftJoin(seatApplicationJpaEntity)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
@@ -22,6 +22,7 @@ import team.aliens.dms.domain.studyroom.dto.ManagerQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.dto.QueryAvailableTimeResponse
 import team.aliens.dms.domain.studyroom.dto.QueryCurrentAppliedStudyRoomResponse
 import team.aliens.dms.domain.studyroom.dto.QuerySeatTypesResponse
+import team.aliens.dms.domain.studyroom.dto.QueryTimeSlotsResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.dto.UpdateAvailableTimeWebRequest
@@ -35,6 +36,7 @@ import team.aliens.dms.domain.studyroom.usecase.ManagerQueryStudyRoomsUseCase
 import team.aliens.dms.domain.studyroom.usecase.QueryAvailableTimeUseCase
 import team.aliens.dms.domain.studyroom.usecase.QueryCurrentAppliedStudyRoomUseCase
 import team.aliens.dms.domain.studyroom.usecase.QuerySeatTypesUseCase
+import team.aliens.dms.domain.studyroom.usecase.QueryTimeSlotsUseCase
 import team.aliens.dms.domain.studyroom.usecase.RemoveSeatTypeUseCase
 import team.aliens.dms.domain.studyroom.usecase.RemoveStudyRoomUseCase
 import team.aliens.dms.domain.studyroom.usecase.StudentQueryStudyRoomUseCase
@@ -64,7 +66,8 @@ class StudyRoomWebAdapter(
     private val studentQueryStudyRoomsUseCase: StudentQueryStudyRoomsUseCase,
     private val managerQueryStudyRoomsUseCase: ManagerQueryStudyRoomsUseCase,
     private val removeSeatTypeUseCase: RemoveSeatTypeUseCase,
-    private val queryCurrentAppliedStudyRoomUseCase: QueryCurrentAppliedStudyRoomUseCase
+    private val queryCurrentAppliedStudyRoomUseCase: QueryCurrentAppliedStudyRoomUseCase,
+    private val queryTimeSlotsUseCase: QueryTimeSlotsUseCase,
 ) {
 
     @GetMapping("/available-time")
@@ -228,5 +231,10 @@ class StudyRoomWebAdapter(
     @GetMapping("/my")
     fun getMyStudyRoom(): QueryCurrentAppliedStudyRoomResponse {
         return queryCurrentAppliedStudyRoomUseCase.execute()
+    }
+
+    @GetMapping("/time-slots")
+    fun queryTimeSlots(): QueryTimeSlotsResponse {
+        return queryTimeSlotsUseCase.execute()
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x]  GET /study-rooms/time-slots
- [x]  QueryTimeSlotsUseCase

## 주요 변경 사항
- api 개발
- 자습실 상세 조회시 이용시간 목록 반환
- LocalTime 반환 format 고정

## 결과물
![image](https://user-images.githubusercontent.com/81006587/226278890-e48c0808-6826-4e4b-a2de-b9e75d356422.png)
![image](https://user-images.githubusercontent.com/81006587/226295043-7d897ad6-5236-46ce-ad09-c3cb2930b40c.png)

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #360