### PR TITLE
chore: detekt SecurityConfiguration format exclude

### DIFF
--- a/dms-infrastructure/config/detekt/detekt.yml
+++ b/dms-infrastructure/config/detekt/detekt.yml
@@ -280,6 +280,7 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  excludes: ['**/SecurityConfiguration.kt']
   AnnotationOnSeparateLine:
     active: false
     autoCorrect: true


### PR DESCRIPTION
## 작업 내용 설명
- SecurityConfiguration 빈 line이 자꾸 detekt에 사라져서 해당 파일 한정으로 detekt format 적용되지 않도록 설정했습니다

## 주요 변경 사항

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved # <!-- 이슈번호 -->