### PR TITLE
merge: (#386) 학생 상세 확인 API 수정

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/dto/GetStudentDetailsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/dto/GetStudentDetailsResponse.kt
@@ -5,6 +5,7 @@ import team.aliens.dms.domain.tag.dto.TagResponse
 import java.util.UUID
 
 data class GetStudentDetailsResponse(
+    val id: UUID,
     val name: String,
     val gcn: String,
     val profileImageUrl: String,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/dto/GetStudentDetailsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/dto/GetStudentDetailsResponse.kt
@@ -11,12 +11,18 @@ data class GetStudentDetailsResponse(
     val bonusPoint: Int,
     val minusPoint: Int,
     val roomNumber: String,
-    val roomMates: List<RoomMate>
-
+    val roomMates: List<RoomMate>,
+    val tags: List<TagResponse>
 ) {
     data class RoomMate(
         val id: UUID,
         val name: String,
         val profileImageUrl: String
+    )
+
+    data class TagResponse(
+        val id: UUID,
+        val name: String,
+        val color: String
     )
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/dto/GetStudentDetailsResponse.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/dto/GetStudentDetailsResponse.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.manager.dto
 
 import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.tag.dto.TagResponse
 import java.util.UUID
 
 data class GetStudentDetailsResponse(
@@ -18,11 +19,5 @@ data class GetStudentDetailsResponse(
         val id: UUID,
         val name: String,
         val profileImageUrl: String
-    )
-
-    data class TagResponse(
-        val id: UUID,
-        val name: String,
-        val color: String
     )
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryTagPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryTagPort.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.domain.manager.spi
+
+import team.aliens.dms.domain.tag.model.Tag
+import java.util.UUID
+
+interface ManagerQueryTagPort {
+
+    fun queryTagsByStudentId(studentId: UUID): List<Tag>
+}

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -10,6 +10,7 @@ import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.manager.spi.QueryManagerPort
 import team.aliens.dms.domain.school.validateSameSchool
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
+import team.aliens.dms.domain.tag.dto.TagResponse
 import java.util.UUID
 
 @ReadOnlyUseCase
@@ -47,7 +48,7 @@ class QueryStudentDetailsUseCase(
 
         val tags = queryTagPort.queryTagsByStudentId(studentId)
             .map {
-                GetStudentDetailsResponse.TagResponse(
+                TagResponse(
                     id = it.id,
                     name = it.name,
                     color = it.color

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -5,6 +5,7 @@ import team.aliens.dms.domain.manager.dto.GetStudentDetailsResponse
 import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
 import team.aliens.dms.domain.manager.spi.ManagerQueryPointHistoryPort
 import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
+import team.aliens.dms.domain.manager.spi.ManagerQueryTagPort
 import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.manager.spi.QueryManagerPort
 import team.aliens.dms.domain.school.validateSameSchool
@@ -16,7 +17,8 @@ class QueryStudentDetailsUseCase(
     private val securityPort: ManagerSecurityPort,
     private val queryManagerPort: QueryManagerPort,
     private val queryStudentPort: ManagerQueryStudentPort,
-    private val queryPointHistoryPort: ManagerQueryPointHistoryPort
+    private val queryPointHistoryPort: ManagerQueryPointHistoryPort,
+    private val queryTagPort: ManagerQueryTagPort
 ) {
 
     fun execute(studentId: UUID): GetStudentDetailsResponse {
@@ -43,6 +45,15 @@ class QueryStudentDetailsUseCase(
             )
         }
 
+        val tags = queryTagPort.queryTagsByStudentId(studentId)
+            .map {
+                GetStudentDetailsResponse.TagResponse(
+                    id = it.id,
+                    name = it.name,
+                    color = it.color
+                )
+            }
+
         return GetStudentDetailsResponse(
             name = student.name,
             gcn = student.gcn,
@@ -51,7 +62,8 @@ class QueryStudentDetailsUseCase(
             bonusPoint = bonusPoint,
             minusPoint = minusPoint,
             roomNumber = student.roomNumber,
-            roomMates = roomMates
+            roomMates = roomMates,
+            tags = tags
         )
     }
 }

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCase.kt
@@ -56,6 +56,7 @@ class QueryStudentDetailsUseCase(
             }
 
         return GetStudentDetailsResponse(
+            id = student.id,
             name = student.name,
             gcn = student.gcn,
             profileImageUrl = student.profileImageUrl!!,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/spi/TagPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/spi/TagPort.kt
@@ -1,5 +1,8 @@
 package team.aliens.dms.domain.tag.spi
 
+import team.aliens.dms.domain.manager.spi.ManagerQueryTagPort
+
 interface TagPort :
     QueryTagPort,
-    CommandTagPort
+    CommandTagPort,
+    ManagerQueryTagPort

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentDetailsUseCaseTests.kt
@@ -13,12 +13,14 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.manager.exception.ManagerNotFoundException
 import team.aliens.dms.domain.manager.spi.ManagerQueryPointHistoryPort
 import team.aliens.dms.domain.manager.spi.ManagerQueryStudentPort
+import team.aliens.dms.domain.manager.spi.ManagerQueryTagPort
 import team.aliens.dms.domain.manager.spi.ManagerSecurityPort
 import team.aliens.dms.domain.manager.spi.QueryManagerPort
 import team.aliens.dms.domain.manager.stub.createManagerStub
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.stub.createStudentStub
+import team.aliens.dms.domain.tag.stub.createTagStub
 import java.util.UUID
 
 @ExtendWith(SpringExtension::class)
@@ -36,12 +38,15 @@ class QueryStudentDetailsUseCaseTests {
     @MockBean
     private lateinit var queryPointHistoryPort: ManagerQueryPointHistoryPort
 
+    @MockBean
+    private lateinit var queryTagPort: ManagerQueryTagPort
+
     private lateinit var queryStudentDetailsUseCase: QueryStudentDetailsUseCase
 
     @BeforeEach
     fun setUp() {
         queryStudentDetailsUseCase = QueryStudentDetailsUseCase(
-            securityPort, queryManagerPort, queryStudentPort, queryPointHistoryPort
+            securityPort, queryManagerPort, queryStudentPort, queryPointHistoryPort, queryTagPort
         )
     }
 
@@ -69,6 +74,12 @@ class QueryStudentDetailsUseCaseTests {
         createStudentStub(schoolId = schoolId)
     }
 
+    private val tagsStub by lazy {
+        listOf(
+            createTagStub(schoolId = schoolId)
+        )
+    }
+
     @Test
     fun `학생 상세조회 성공`() {
         // given
@@ -86,6 +97,9 @@ class QueryStudentDetailsUseCaseTests {
 
         given(queryStudentPort.queryUserByRoomNumberAndSchoolId(studentStub.roomNumber, studentStub.schoolId))
             .willReturn(listOf(studentStub, roomMateStub))
+
+        given(queryTagPort.queryTagsByStudentId(studentId))
+            .willReturn(tagsStub)
 
         // when
         val response = queryStudentDetailsUseCase.execute(studentId)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/tag/TagPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/tag/TagPersistenceAdapter.kt
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Component
 import team.aliens.dms.domain.tag.model.StudentTag
 import team.aliens.dms.domain.tag.model.Tag
 import team.aliens.dms.domain.tag.spi.TagPort
+import team.aliens.dms.persistence.student.entity.QStudentJpaEntity
+import team.aliens.dms.persistence.student.entity.QStudentJpaEntity.studentJpaEntity
+import team.aliens.dms.persistence.tag.entity.QStudentTagJpaEntity.studentTagJpaEntity
+import team.aliens.dms.persistence.tag.entity.QTagJpaEntity.tagJpaEntity
 import team.aliens.dms.persistence.tag.entity.StudentTagId
 import team.aliens.dms.persistence.tag.mapper.StudentTagMapper
 import team.aliens.dms.persistence.tag.mapper.TagMapper
@@ -64,5 +68,16 @@ class TagPersistenceAdapter(
         return tagMapper.toDomain(
             tagRepository.save(tagMapper.toEntity(tag))
         )!!
+    }
+
+    override fun queryTagsByStudentId(studentId: UUID): List<Tag> {
+        return queryFactory
+            .selectFrom(tagJpaEntity)
+            .join(studentTagJpaEntity)
+            .on(studentTagJpaEntity.student.id.eq(studentId))
+            .fetch()
+            .map {
+                tagMapper.toDomain(it)!!
+            }
     }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/tag/TagPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/tag/TagPersistenceAdapter.kt
@@ -6,8 +6,6 @@ import org.springframework.stereotype.Component
 import team.aliens.dms.domain.tag.model.StudentTag
 import team.aliens.dms.domain.tag.model.Tag
 import team.aliens.dms.domain.tag.spi.TagPort
-import team.aliens.dms.persistence.student.entity.QStudentJpaEntity
-import team.aliens.dms.persistence.student.entity.QStudentJpaEntity.studentJpaEntity
 import team.aliens.dms.persistence.tag.entity.QStudentTagJpaEntity.studentTagJpaEntity
 import team.aliens.dms.persistence.tag.entity.QTagJpaEntity.tagJpaEntity
 import team.aliens.dms.persistence.tag.entity.StudentTagId
@@ -73,6 +71,7 @@ class TagPersistenceAdapter(
     override fun queryTagsByStudentId(studentId: UUID): List<Tag> {
         return queryFactory
             .selectFrom(tagJpaEntity)
+            .distinct()
             .join(studentTagJpaEntity)
             .on(studentTagJpaEntity.student.id.eq(studentId))
             .fetch()


### PR DESCRIPTION
## 작업 내용 설명
- [ ] /managers/students/{student-id}
- [ ] QueryStudentDetailsUseCase

## 주요 변경 사항
- 태그 목록 반환

## 결과물
![image](https://user-images.githubusercontent.com/103026813/227781347-ef94ff8d-c2bb-435c-8696-32d642ccfbe4.png)

## 체크리스트
- [X] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [X] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #386 