### PR TITLE
merge: (#390) tag 필터링 추가

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryStudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryStudentPort.kt
@@ -14,7 +14,8 @@ interface ManagerQueryStudentPort {
         name: String?,
         sort: Sort,
         schoolId: UUID,
-        pointFilter: PointFilter
+        pointFilter: PointFilter,
+        tags: List<UUID>?
     ): List<StudentWithTag>
 
     fun queryUserByRoomNumberAndSchoolId(roomNumber: String, schoolId: UUID): List<Student>

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryStudentPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/spi/ManagerQueryStudentPort.kt
@@ -15,7 +15,7 @@ interface ManagerQueryStudentPort {
         sort: Sort,
         schoolId: UUID,
         pointFilter: PointFilter,
-        tags: List<UUID>?
+        tagIds: List<UUID>?
     ): List<StudentWithTag>
 
     fun queryUserByRoomNumberAndSchoolId(roomNumber: String, schoolId: UUID): List<Student>

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentsUseCase.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.domain.manager.usecase
 
+import java.util.UUID
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.manager.dto.PointFilter
 import team.aliens.dms.domain.manager.dto.PointFilterType
@@ -22,7 +23,8 @@ class QueryStudentsUseCase(
         sort: Sort,
         filterType: PointFilterType?,
         minPoint: Int?,
-        maxPoint: Int?
+        maxPoint: Int?,
+        tags: List<UUID>?
     ): QueryStudentsResponse {
         val currentUserId = securityPort.getCurrentUserId()
         val manager = queryManagerPort.queryManagerById(currentUserId) ?: throw ManagerNotFoundException
@@ -37,7 +39,8 @@ class QueryStudentsUseCase(
             name = name,
             sort = sort,
             schoolId = manager.schoolId,
-            pointFilter = pointFilter
+            pointFilter = pointFilter,
+            tags = tags
         ).map {
             QueryStudentsResponse.StudentElement(
                 id = it.id,

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentsUseCase.kt
@@ -24,7 +24,7 @@ class QueryStudentsUseCase(
         filterType: PointFilterType?,
         minPoint: Int?,
         maxPoint: Int?,
-        tags: List<UUID>?
+        tagIds: List<UUID>?
     ): QueryStudentsResponse {
         val currentUserId = securityPort.getCurrentUserId()
         val manager = queryManagerPort.queryManagerById(currentUserId) ?: throw ManagerNotFoundException
@@ -40,7 +40,7 @@ class QueryStudentsUseCase(
             sort = sort,
             schoolId = manager.schoolId,
             pointFilter = pointFilter,
-            tags = tags
+            tagIds = tagIds
         ).map {
             QueryStudentsResponse.StudentElement(
                 id = it.id,

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/manager/usecase/QueryStudentsUseCaseTests.kt
@@ -72,6 +72,8 @@ class QueryStudentsUseCaseTests {
         )
     }
 
+    private var tagIdListStub = arrayListOf<UUID>(UUID.randomUUID())
+
     @Test
     fun `학생 목록 조회 성공`() {
         // given
@@ -97,12 +99,12 @@ class QueryStudentsUseCaseTests {
 
         given(
             queryStudentPort.queryStudentsByNameAndSortAndFilter(
-                name, sort, managerStub.schoolId, pointFilterStub
+                name, sort, managerStub.schoolId, pointFilterStub, tagIdListStub
             )
         ).willReturn(listOf(studentWitTagStub))
 
         // when
-        val result = queryStudentsUseCase.execute(name, sort, filterType, 0, 10)
+        val result = queryStudentsUseCase.execute(name, sort, filterType, 0, 10, tagIdListStub)
 
         assertThat(result).isNotNull
     }
@@ -119,7 +121,7 @@ class QueryStudentsUseCaseTests {
         // when & then
         assertThrows<InvalidPointFilterRangeException> {
             queryStudentsUseCase.execute(
-                name, sort, filterType, null, null
+                name, sort, filterType, null, null, tagIdListStub
             )
         }
     }
@@ -136,7 +138,7 @@ class QueryStudentsUseCaseTests {
         // when & then
         assertThrows<InvalidPointFilterRangeException> {
             queryStudentsUseCase.execute(
-                name, sort, filterType, 20, 10
+                name, sort, filterType, 20, 10, tagIdListStub
             )
         }
     }
@@ -151,7 +153,7 @@ class QueryStudentsUseCaseTests {
             .willReturn(null)
 
         assertThrows<ManagerNotFoundException> {
-            queryStudentsUseCase.execute(name, sort, null, null, null)
+            queryStudentsUseCase.execute(name, sort, null, null, null, tagIdListStub)
         }
     }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -120,7 +120,7 @@ class StudentPersistenceAdapter(
         sort: Sort,
         schoolId: UUID,
         pointFilter: PointFilter,
-        tags: List<UUID>?
+        tagIds: List<UUID>?
     ): List<StudentWithTag> {
         return queryFactory
             .selectFrom(studentJpaEntity)
@@ -135,7 +135,7 @@ class StudentPersistenceAdapter(
                 nameContains(name),
                 pointTotalBetween(pointFilter),
                 schoolEq(schoolId),
-                studentHavingTags(tags)
+                studentHavingTags(tagIds)
             )
             .orderBy(
                 sortFilter(sort),

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -183,7 +183,6 @@ class StudentPersistenceAdapter(
 
     private fun tagIdsIn(tagIds: List<UUID>?) =
         tagIds?.run { studentTagJpaEntity.tag.id.`in`(tagIds) }
-        //if (tagIds?.isNotEmpty() == true) studentTagJpaEntity.tag.id.`in`(tagIds) else null
 
     private fun eqTag(): BooleanExpression? {
         return tagJpaEntity.id.`in`(

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
@@ -29,7 +29,6 @@ import java.util.UUID
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
-import team.aliens.dms.common.validator.NotNullElements
 
 @Validated
 @RequestMapping("/managers")

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
@@ -84,7 +84,7 @@ class ManagerWebAdapter(
             filterType = filterType,
             minPoint = minPoint,
             maxPoint = maxPoint,
-            tags = tagIds
+            tagIds = tagIds
         )
     }
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/manager/ManagerWebAdapter.kt
@@ -29,6 +29,7 @@ import java.util.UUID
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
+import team.aliens.dms.common.validator.NotNullElements
 
 @Validated
 @RequestMapping("/managers")
@@ -74,14 +75,16 @@ class ManagerWebAdapter(
         @RequestParam @NotNull sort: Sort?,
         @RequestParam(name = "filter_type", required = false) filterType: PointFilterType?,
         @RequestParam(name = "min_point", required = false) minPoint: Int?,
-        @RequestParam(name = "max_point", required = false) maxPoint: Int?
+        @RequestParam(name = "max_point", required = false) maxPoint: Int?,
+        @RequestParam(name = "tag_id", required = false) tagIds: List<UUID>?
     ): QueryStudentsResponse {
         return queryStudentsUseCase.execute(
             name = name,
             sort = sort!!,
             filterType = filterType,
             minPoint = minPoint,
-            maxPoint = maxPoint
+            maxPoint = maxPoint,
+            tags = tagIds
         )
     }
 


### PR DESCRIPTION
## 작업 내용 설명
- [x] 학생목록 조회api에서 태그 필터링 추가

## 주요 변경 사항
- QueryStudentsUseCase
- StudentPersistenceAdapter

## 결과물
<img width="837" alt="image" src="https://user-images.githubusercontent.com/52336493/228002996-61b63f1c-359f-4b3d-a088-d72261d5a583.png">


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #390