### PR TITLE
merge: (#397) 태그 수정 시 중복 예외 제거

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCase.kt
@@ -26,7 +26,7 @@ class UpdateTagUseCase(
         val tag = queryTagPort.queryTagById(tagId) ?: throw TagNotFoundException
         validateSameSchool(tag.schoolId, manager.schoolId)
 
-        if (newName == tag.name) {
+        if (newName != tag.name && queryTagPort.existsByNameAndSchoolId(newName, manager.schoolId)) {
             throw TagAlreadyExistsException
         }
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCase.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.domain.tag.usecase
 
 import team.aliens.dms.common.annotation.UseCase
 import team.aliens.dms.domain.school.validateSameSchool
+import team.aliens.dms.domain.tag.exception.TagAlreadyExistsException
 import team.aliens.dms.domain.tag.exception.TagNotFoundException
 import team.aliens.dms.domain.tag.spi.CommandTagPort
 import team.aliens.dms.domain.tag.spi.QueryTagPort
@@ -24,6 +25,10 @@ class UpdateTagUseCase(
         
         val tag = queryTagPort.queryTagById(tagId) ?: throw TagNotFoundException
         validateSameSchool(tag.schoolId, manager.schoolId)
+
+        if (newName == tag.name) {
+            throw TagAlreadyExistsException
+        }
 
         commandTagPort.saveTag(
             tag.copy(

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCase.kt
@@ -2,7 +2,6 @@ package team.aliens.dms.domain.tag.usecase
 
 import team.aliens.dms.common.annotation.UseCase
 import team.aliens.dms.domain.school.validateSameSchool
-import team.aliens.dms.domain.tag.exception.TagAlreadyExistsException
 import team.aliens.dms.domain.tag.exception.TagNotFoundException
 import team.aliens.dms.domain.tag.spi.CommandTagPort
 import team.aliens.dms.domain.tag.spi.QueryTagPort
@@ -22,10 +21,6 @@ class UpdateTagUseCase(
     fun execute(tagId: UUID, newName: String, newColor: String) {
         val currentUserId = securityPort.getCurrentUserId()
         val manager = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
-
-        if (queryTagPort.existsByNameAndSchoolId(newName, manager.schoolId)) {
-            throw TagAlreadyExistsException
-        }
         
         val tag = queryTagPort.queryTagById(tagId) ?: throw TagNotFoundException
         validateSameSchool(tag.schoolId, manager.schoolId)

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCaseTests.kt
@@ -60,6 +60,7 @@ class UpdateTagUseCaseTests {
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns userStub
         every { queryTagPort.queryTagById(tagId) } returns tagStub
+        every { queryTagPort.existsByNameAndSchoolId(newName, userStub.schoolId) } returns false
 
         // when & then
         assertDoesNotThrow {
@@ -127,12 +128,13 @@ class UpdateTagUseCaseTests {
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns userStub
         every { queryTagPort.queryTagById(tagId) } returns tagStub
+        every { queryTagPort.existsByNameAndSchoolId(newName, userStub.schoolId) } returns true
 
         // when & then
         assertThrows<TagAlreadyExistsException> {
             updateTagUseCase.execute(
                 tagId = tagId,
-                newName = "1OUT",
+                newName = newName,
                 newColor = newColor
             )
         }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCaseTests.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.tag.exception.TagAlreadyExistsException
 import team.aliens.dms.domain.tag.exception.TagNotFoundException
 import team.aliens.dms.domain.tag.spi.CommandTagPort
 import team.aliens.dms.domain.tag.spi.QueryTagPort
@@ -71,7 +72,7 @@ class UpdateTagUseCaseTests {
     }
 
     @Test
-    fun `태그가 존재하지 않음`() {
+    fun `태그를 찾을 수 없음`() {
         // given
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns userStub
@@ -105,7 +106,7 @@ class UpdateTagUseCaseTests {
     }
 
     @Test
-    fun `유저가 존재하지 않음`() {
+    fun `유저를 찾을 수 없음`() {
         // given
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns null
@@ -115,6 +116,23 @@ class UpdateTagUseCaseTests {
             updateTagUseCase.execute(
                 tagId = tagId,
                 newName = newName,
+                newColor = newColor
+            )
+        }
+    }
+
+    @Test
+    fun `태그가 이미 존재함`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns currentUserId
+        every { queryUserPort.queryUserById(currentUserId) } returns userStub
+        every { queryTagPort.queryTagById(tagId) } returns tagStub
+
+        // when & then
+        assertThrows<TagAlreadyExistsException> {
+            updateTagUseCase.execute(
+                tagId = tagId,
+                newName = "1OUT",
                 newColor = newColor
             )
         }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateTagUseCaseTests.kt
@@ -17,7 +17,6 @@ import team.aliens.dms.domain.tag.stub.createTagStub
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import team.aliens.dms.domain.user.stub.createUserStub
 import java.util.UUID
-import team.aliens.dms.domain.tag.exception.TagAlreadyExistsException
 
 @ExtendWith(SpringExtension::class)
 class UpdateTagUseCaseTests {
@@ -60,7 +59,6 @@ class UpdateTagUseCaseTests {
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns userStub
         every { queryTagPort.queryTagById(tagId) } returns tagStub
-        every { queryTagPort.existsByNameAndSchoolId(newName, schoolId) } returns false
 
         // when & then
         assertDoesNotThrow {
@@ -77,7 +75,6 @@ class UpdateTagUseCaseTests {
         // given
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns userStub
-        every { queryTagPort.existsByNameAndSchoolId(newName, schoolId) } returns false
         every { queryTagPort.queryTagById(tagId) } returns null
 
         // when & then
@@ -95,28 +92,10 @@ class UpdateTagUseCaseTests {
         // given
         every { securityPort.getCurrentUserId() } returns currentUserId
         every { queryUserPort.queryUserById(currentUserId) } returns userStub
-        every { queryTagPort.existsByNameAndSchoolId("Updated", schoolId) } returns false
         every { queryTagPort.queryTagById(tagId) } returns diffSchoolTagStub
 
         // when & then
         assertThrows<SchoolMismatchException> {
-            updateTagUseCase.execute(
-                tagId = tagId,
-                newName = newName,
-                newColor = newColor
-            )
-        }
-    }
-
-    @Test
-    fun `변경할 태그 이름이 중복됨`() {
-        // given
-        every { securityPort.getCurrentUserId() } returns currentUserId
-        every { queryUserPort.queryUserById(currentUserId) } returns userStub
-        every { queryTagPort.existsByNameAndSchoolId("Updated", schoolId) } returns true
-
-        // when & then
-        assertThrows<TagAlreadyExistsException> {
             updateTagUseCase.execute(
                 tagId = tagId,
                 newName = newName,


### PR DESCRIPTION
## 작업 내용 설명
- [X] 태그 수정 시 중복 예외 제거

## 주요 변경 사항
- 태그 색상만 변경하려고 하면 TagAlreadyExistsException이 반환되서 제거했습니다

## 결과물
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/103026813/228251893-b9c213b4-9f5b-4bb6-8d56-f2b07272ebd5.png">

## 체크리스트
- [X] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [X] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #397 