### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -37,7 +37,7 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.ECR_DEV_REPOSITORY }}
           username: ${{ steps.ecr.outputs.username }}

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -36,7 +36,7 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.ECR_REPOSITORY }}
           username: ${{ steps.ecr.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore