### PR TITLE
merge: (#414) 자습실에 해당하는 seatType 조회

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QuerySeatTypePort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QuerySeatTypePort.kt
@@ -1,11 +1,13 @@
 package team.aliens.dms.domain.studyroom.spi
 
-import team.aliens.dms.domain.studyroom.model.SeatType
 import java.util.UUID
+import team.aliens.dms.domain.studyroom.model.SeatType
 
 interface QuerySeatTypePort {
 
     fun queryAllSeatTypeBySchoolId(schoolId: UUID): List<SeatType>
+
+    fun queryAllSeatTypeByStudyRoomId(studyRoomId: UUID): List<SeatType>
 
     fun existsSeatTypeByName(name: String): Boolean
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/QuerySeatTypesUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/QuerySeatTypesUseCase.kt
@@ -15,7 +15,7 @@ class QuerySeatTypesUseCase(
     private val querySeatTypePort: QuerySeatTypePort
 ) {
 
-    fun execute(): QuerySeatTypesResponse {
+    fun execute(studyRoomId: UUID?): QuerySeatTypesResponse {
         val currentUserId = securityPort.getCurrentUserId()
         val user = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/QuerySeatTypesUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/QuerySeatTypesUseCase.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.domain.studyroom.usecase
 
+import java.util.UUID
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.studyroom.dto.QuerySeatTypesResponse
 import team.aliens.dms.domain.studyroom.dto.QuerySeatTypesResponse.TypeElement
@@ -19,15 +20,18 @@ class QuerySeatTypesUseCase(
         val currentUserId = securityPort.getCurrentUserId()
         val user = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
 
-        val seatTypes = querySeatTypePort
-            .queryAllSeatTypeBySchoolId(user.schoolId).map {
+        val seatTypes = studyRoomId?.let {
+            querySeatTypePort.queryAllSeatTypeByStudyRoomId(studyRoomId)
+        } ?: querySeatTypePort.queryAllSeatTypeBySchoolId(user.schoolId)
+
+        return QuerySeatTypesResponse(
+            seatTypes.map {
                 TypeElement(
                     id = it.id,
                     name = it.name,
                     color = it.color
                 )
             }
-
-        return QuerySeatTypesResponse(seatTypes)
+        )
     }
 }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/stub/StudyRoomStub.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/stub/StudyRoomStub.kt
@@ -1,13 +1,14 @@
 package team.aliens.dms.domain.studyroom.stub
 
+import java.time.LocalTime
+import java.util.UUID
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.studyroom.model.Seat
 import team.aliens.dms.domain.studyroom.model.SeatApplication
 import team.aliens.dms.domain.studyroom.model.SeatStatus
+import team.aliens.dms.domain.studyroom.model.SeatType
 import team.aliens.dms.domain.studyroom.model.StudyRoom
 import team.aliens.dms.domain.studyroom.model.TimeSlot
-import java.time.LocalTime
-import java.util.UUID
 
 internal fun createStudyRoomStub(
     id: UUID = UUID.randomUUID(),
@@ -77,4 +78,16 @@ internal fun createSeatApplicationStub(
     seatId = seatId,
     timeSlotId = timeSlotId,
     studentId = studentId
+)
+
+internal fun createSeatTypeStub(
+    id: UUID = UUID.randomUUID(),
+    schoolId: UUID = UUID.randomUUID(),
+    name: String = "자리",
+    color: String = "#FFFFFF",
+) = SeatType(
+    id = id,
+    schoolId = schoolId,
+    name = name,
+    color = color
 )

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/QuerySeatTypesUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/QuerySeatTypesUseCaseTests.kt
@@ -1,0 +1,88 @@
+package team.aliens.dms.domain.studyroom.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import team.aliens.dms.domain.studyroom.spi.QuerySeatTypePort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
+import team.aliens.dms.domain.studyroom.stub.createSeatTypeStub
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.domain.user.stub.createUserStub
+
+class QuerySeatTypesUseCaseTests {
+
+    private val securityPort: StudyRoomSecurityPort = mockk(relaxed = true)
+    private val queryUserPort: StudyRoomQueryUserPort = mockk(relaxed = true)
+    private val querySeatTypePort: QuerySeatTypePort = mockk(relaxed = true)
+
+    private val querySeatTypesUseCase = QuerySeatTypesUseCase(
+        securityPort, queryUserPort, querySeatTypePort
+    )
+
+    private val userId = UUID.randomUUID()
+    private val schoolId = UUID.randomUUID()
+    private val studyRoomId = UUID.randomUUID()
+
+    private val userStub by lazy {
+        createUserStub(
+            id = userId,
+            schoolId = schoolId
+        )
+    }
+
+    private val seatTypesStub by lazy {
+        listOf(createSeatTypeStub())
+    }
+
+    @Test
+    fun `자리 종류 조회 성공 (studyRoomId가 null인 경우)`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { querySeatTypePort.queryAllSeatTypeBySchoolId(schoolId) } returns seatTypesStub
+
+        // when
+        val response = querySeatTypesUseCase.execute(null)
+
+        // then
+        assertAll(
+            { verify(exactly = 1) { querySeatTypePort.queryAllSeatTypeBySchoolId(schoolId) } },
+            { assertEquals(response.types.size, seatTypesStub.size) }
+        )
+    }
+
+    @Test
+    fun `자리 종류 조회 성공 (studyRoomId가 null이 아닌 경우)`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { querySeatTypePort.queryAllSeatTypeByStudyRoomId(studyRoomId) } returns seatTypesStub
+
+        // when
+        val response = querySeatTypesUseCase.execute(studyRoomId)
+
+        // then
+        assertAll(
+            { verify(exactly = 1) { querySeatTypePort.queryAllSeatTypeByStudyRoomId(studyRoomId) } },
+            { assertEquals(response.types.size, seatTypesStub.size) }
+        )
+    }
+
+    @Test
+    fun `유저가 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns null
+
+        // when
+        assertThrows<UserNotFoundException> {
+            querySeatTypesUseCase.execute(null)
+        }
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/SeatTypePersistenceAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/persistence/studyroom/SeatTypePersistenceAdapter.kt
@@ -1,23 +1,40 @@
 package team.aliens.dms.persistence.studyroom
 
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.util.UUID
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.studyroom.model.SeatType
 import team.aliens.dms.domain.studyroom.spi.SeatTypePort
+import team.aliens.dms.persistence.studyroom.entity.QSeatJpaEntity.seatJpaEntity
+import team.aliens.dms.persistence.studyroom.entity.QSeatTypeJpaEntity.seatTypeJpaEntity
+import team.aliens.dms.persistence.studyroom.entity.QStudyRoomJpaEntity.studyRoomJpaEntity
 import team.aliens.dms.persistence.studyroom.mapper.SeatTypeMapper
 import team.aliens.dms.persistence.studyroom.repository.SeatTypeJpaRepository
-import java.util.UUID
 
 @Component
 class SeatTypePersistenceAdapter(
     private val seatTypeMapper: SeatTypeMapper,
-    private val seatTypeRepository: SeatTypeJpaRepository
+    private val seatTypeRepository: SeatTypeJpaRepository,
+    private val queryFactory: JPAQueryFactory,
 ) : SeatTypePort {
 
     override fun queryAllSeatTypeBySchoolId(schoolId: UUID) = seatTypeRepository
         .findAllBySchoolId(schoolId).map {
             seatTypeMapper.toDomain(it)!!
         }
+
+    override fun queryAllSeatTypeByStudyRoomId(studyRoomId: UUID) =
+        queryFactory
+            .select(seatTypeJpaEntity).distinct()
+            .from(studyRoomJpaEntity)
+            .join(seatJpaEntity).on(studyRoomJpaEntity.id.eq(seatJpaEntity.studyRoom.id))
+            .join(seatJpaEntity.type, seatTypeJpaEntity)
+            .where(studyRoomJpaEntity.id.eq(studyRoomId))
+            .fetch()
+            .map {
+                seatTypeMapper.toDomain(it)!!
+            }
 
     override fun existsSeatTypeByName(name: String) = seatTypeRepository.existsByName(name)
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
@@ -101,7 +101,7 @@ class StudyRoomWebAdapter(
     }
 
     @GetMapping("/types")
-    fun getSeatTypes(@RequestParam(name = "study_room_id") studyRoomId: UUID?): QuerySeatTypesResponse {
+    fun getSeatTypes(@RequestParam(name = "study_room_id", required = false) studyRoomId: UUID?): QuerySeatTypesResponse {
         return querySeatTypesUseCase.execute(studyRoomId)
     }
 

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/studyroom/StudyRoomWebAdapter.kt
@@ -101,8 +101,8 @@ class StudyRoomWebAdapter(
     }
 
     @GetMapping("/types")
-    fun getSeatTypes(): QuerySeatTypesResponse {
-        return querySeatTypesUseCase.execute()
+    fun getSeatTypes(@RequestParam(name = "study_room_id") studyRoomId: UUID?): QuerySeatTypesResponse {
+        return querySeatTypesUseCase.execute(studyRoomId)
     }
 
     @ResponseStatus(HttpStatus.CREATED)


### PR DESCRIPTION
## 작업 내용 설명
- [x]  파라미터로 자습실 자리중 존재하는 seatType만 조회 가능하도록 설정

## 주요 변경 사항


## 결과물
studyRoomId 있는 경우
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/81006587/229337824-284a9ce8-d3af-40df-a97a-18f0a96a0c9a.png">

studyRoomId 없는 경우
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/81006587/229337838-229da759-86d1-4397-bb3a-2da4032db04a.png">


## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #414