### PR TITLE
 merge: (#419) 학생 자습실 조회 학년, 성별 조건문 추가

### DIFF
--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/QueryStudyRoomPort.kt
@@ -1,5 +1,8 @@
 package team.aliens.dms.domain.studyroom.spi
 
+import java.time.LocalTime
+import java.util.UUID
+import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.studyroom.model.Seat
 import team.aliens.dms.domain.studyroom.model.SeatApplication
 import team.aliens.dms.domain.studyroom.model.StudyRoom
@@ -7,8 +10,6 @@ import team.aliens.dms.domain.studyroom.model.TimeSlot
 import team.aliens.dms.domain.studyroom.spi.vo.SeatApplicationVO
 import team.aliens.dms.domain.studyroom.spi.vo.StudentSeatApplicationVO
 import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
-import java.time.LocalTime
-import java.util.UUID
 
 interface QueryStudyRoomPort {
 
@@ -25,6 +26,8 @@ interface QueryStudyRoomPort {
     fun queryAllSeatApplicationVOsByStudyRoomIdAndTimeSlotId(studyRoomId: UUID, timeSlotId: UUID): List<SeatApplicationVO>
 
     fun queryAllStudyRoomsByTimeSlotId(timeSlotId: UUID): List<StudyRoomVO>
+
+    fun queryAllStudyRoomsByTimeSlotIdAndGradeAndSex(timeSlotId: UUID, grade: Int, sex: Sex): List<StudyRoomVO>
 
     fun queryTimeSlotsBySchoolId(schoolId: UUID): List<TimeSlot>
 

--- a/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
+++ b/dms-application/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCase.kt
@@ -1,26 +1,30 @@
 package team.aliens.dms.domain.studyroom.usecase
 
+import java.util.UUID
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.school.validateSameSchool
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse
 import team.aliens.dms.domain.studyroom.dto.StudentQueryStudyRoomsResponse.StudyRoomElement
 import team.aliens.dms.domain.studyroom.exception.TimeSlotNotFoundException
 import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryStudentPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
-import java.util.UUID
 
 @ReadOnlyUseCase
 class StudentQueryStudyRoomsUseCase(
     private val securityPort: StudyRoomSecurityPort,
     private val queryUserPort: StudyRoomQueryUserPort,
+    private val queryStudentPort: StudyRoomQueryStudentPort,
     private val queryStudyRoomPort: QueryStudyRoomPort
 ) {
 
     fun execute(timeSlotId: UUID): StudentQueryStudyRoomsResponse {
         val currentUserId = securityPort.getCurrentUserId()
         val user = queryUserPort.queryUserById(currentUserId) ?: throw UserNotFoundException
+        val student = queryStudentPort.queryStudentById(currentUserId) ?: throw StudentNotFoundException
         val timeSlot = queryStudyRoomPort.queryTimeSlotById(timeSlotId) ?: throw TimeSlotNotFoundException
 
         validateSameSchool(timeSlot.schoolId, user.schoolId)
@@ -28,7 +32,7 @@ class StudentQueryStudyRoomsUseCase(
         val seatApplications = queryStudyRoomPort.querySeatApplicationsByStudentId(currentUserId)
         val userStudyRoomIds = queryStudyRoomPort.queryAllSeatsById(seatApplications.map { it.seatId }).map { it.studyRoomId }
 
-        val studyRooms = queryStudyRoomPort.queryAllStudyRoomsByTimeSlotId(timeSlotId)
+        val studyRooms = queryStudyRoomPort.queryAllStudyRoomsByTimeSlotIdAndGradeAndSex(timeSlotId, student.grade, student.sex)
             .map {
                 StudyRoomElement(
                     id = it.id,

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
+import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.student.stub.createStudentStub
 import team.aliens.dms.domain.studyroom.exception.TimeSlotNotFoundException
@@ -112,6 +113,19 @@ class StudentQueryStudyRoomsUseCaseTests {
 
         // when & then
         assertThrows<UserNotFoundException> {
+            studentQueryRoomsUseCase.execute(timeSlotId)
+        }
+    }
+
+    @Test
+    fun `학생이 존재하지 않음`() {
+        // given
+        every { securityPort.getCurrentUserId() } returns userId
+        every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryStudentPort.queryStudentById(userId) } returns null
+
+        // when & then
+        assertThrows<StudentNotFoundException> {
             studentQueryRoomsUseCase.execute(timeSlotId)
         }
     }

--- a/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
+++ b/dms-application/src/test/kotlin/team/aliens/dms/domain/studyroom/usecase/StudentQueryStudyRoomsUseCaseTests.kt
@@ -2,31 +2,34 @@ package team.aliens.dms.domain.studyroom.usecase
 
 import io.mockk.every
 import io.mockk.mockk
+import java.time.LocalTime
+import java.util.UUID
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import team.aliens.dms.domain.school.exception.SchoolMismatchException
 import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.student.stub.createStudentStub
 import team.aliens.dms.domain.studyroom.exception.TimeSlotNotFoundException
 import team.aliens.dms.domain.studyroom.model.TimeSlot
 import team.aliens.dms.domain.studyroom.spi.QueryStudyRoomPort
+import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryStudentPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomQueryUserPort
 import team.aliens.dms.domain.studyroom.spi.StudyRoomSecurityPort
 import team.aliens.dms.domain.studyroom.spi.vo.StudyRoomVO
 import team.aliens.dms.domain.studyroom.stub.createTimeSlotStub
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import team.aliens.dms.domain.user.stub.createUserStub
-import java.time.LocalTime
-import java.util.UUID
 
 class StudentQueryStudyRoomsUseCaseTests {
 
     private val securityPort: StudyRoomSecurityPort = mockk(relaxed = true)
     private val queryUserPort: StudyRoomQueryUserPort = mockk(relaxed = true)
+    private val queryStudentPort: StudyRoomQueryStudentPort = mockk(relaxed = true)
     private val queryStudyRoomPort: QueryStudyRoomPort = mockk(relaxed = true)
 
     private val studentQueryRoomsUseCase = StudentQueryStudyRoomsUseCase(
-        securityPort, queryUserPort, queryStudyRoomPort
+        securityPort, queryUserPort, queryStudentPort, queryStudyRoomPort
     )
 
     private val userId = UUID.randomUUID()
@@ -37,6 +40,12 @@ class StudentQueryStudyRoomsUseCaseTests {
         createUserStub(
             id = userId,
             schoolId = schoolId
+        )
+    }
+
+    private val studentStub by lazy {
+        createStudentStub(
+            id = userId
         )
     }
 
@@ -63,8 +72,9 @@ class StudentQueryStudyRoomsUseCaseTests {
         // given
         every { securityPort.getCurrentUserId() } returns userId
         every { queryUserPort.queryUserById(userId) } returns userStub
+        every { queryStudentPort.queryStudentById(userId) } returns studentStub
         every { queryStudyRoomPort.queryTimeSlotById(timeSlotId) } returns timeSlotStub
-        every { queryStudyRoomPort.queryAllStudyRoomsByTimeSlotId(timeSlotId) } returns listOf(studyRoomStub)
+        every { queryStudyRoomPort.queryAllStudyRoomsByTimeSlotIdAndGradeAndSex(timeSlotId, studentStub.grade, studentStub.sex) } returns listOf(studyRoomStub)
 
         // when & then
         assertDoesNotThrow {


### PR DESCRIPTION
## 작업 내용 설명
- [x] 학생 자습실 조회시, 요청하는 학생의 학년, 성별에 해당하는 자습실만 보이도록 수정 

## 주요 변경 사항
- <!-- 변경 사항 작성 -->
- <!-- 변경 사항 작성 -->

## 결과물
<img width="877" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/81006587/229971105-a0bc2081-6a86-4afa-9389-5d521cc0a22a.png">

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #419