### PR TITLE
merge: (#438) 자습실 취소 시 모든 신청이 다 취소되는 오류

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/CommandStudyRoomPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/studyroom/spi/CommandStudyRoomPort.kt
@@ -29,6 +29,8 @@ interface CommandStudyRoomPort {
 
     fun deleteAllSeatApplications()
 
+    fun deleteSeatApplicationByStudentIdAndTimeSlotId(studentId: UUID, timeSlotId: UUID)
+
     fun deleteSeatApplicationBySeatIdAndStudentIdAndTimeSlotId(seatId: UUID, studentId: UUID, timeSlotId: UUID)
 
     fun deleteSeatApplicationByTimeSlotId(timeSlotId: UUID)

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ApplySeatUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/ApplySeatUseCase.kt
@@ -52,7 +52,7 @@ class ApplySeatUseCase(
             throw SeatAlreadyAppliedException
         }
 
-        commandStudyRoomPort.deleteSeatApplicationBySeatIdAndStudentIdAndTimeSlotId(seatId, currentUserId, timeSlotId)
+        commandStudyRoomPort.deleteSeatApplicationByStudentIdAndTimeSlotId(currentUserId, timeSlotId)
 
         commandStudyRoomPort.saveSeatApplication(
             SeatApplication(

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/StudyRoomPersistenceAdapter.kt
@@ -275,6 +275,10 @@ class StudyRoomPersistenceAdapter(
         seatApplicationRepository.deleteByStudentId(studentId)
     }
 
+    override fun deleteSeatApplicationByStudentIdAndTimeSlotId(studentId: UUID, timeSlotId: UUID) {
+        seatApplicationRepository.deleteByStudentIdAndTimeSlotId(studentId, timeSlotId)
+    }
+
     override fun deleteSeatApplicationBySeatIdAndStudentIdAndTimeSlotId(seatId: UUID, studentId: UUID, timeSlotId: UUID) {
         seatApplicationRepository.deleteBySeatIdAndStudentIdAndTimeSlotId(seatId, studentId, timeSlotId)
     }

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/SeatApplicationJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/repository/SeatApplicationJpaRepository.kt
@@ -17,6 +17,8 @@ interface SeatApplicationJpaRepository : CrudRepository<SeatApplicationJpaEntity
 
     fun deleteByTimeSlotId(timeSlotId: UUID)
 
+    fun deleteByStudentIdAndTimeSlotId(studentId: UUID, timeSlotId: UUID)
+
     fun deleteBySeatIdAndStudentIdAndTimeSlotId(seatId: UUID, studentId: UUID, timeSlotId: UUID)
 
     fun deleteBySeatStudyRoomId(studyRoomId: UUID)


### PR DESCRIPTION
## 작업 내용 설명
- [X] 자습실 자리 신청 취소할 때 자리 식별키도 같이 받아와서 처리

## 주요 변경 사항
- UnApplySeatUseCase

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #438 