### PR TITLE
merge: (#450) 탈퇴시 유저만 삭제

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/student/usecase/SignUpUseCase.kt
@@ -14,6 +14,7 @@ import team.aliens.dms.domain.school.model.School
 import team.aliens.dms.domain.school.spi.QuerySchoolPort
 import team.aliens.dms.domain.student.dto.SignUpRequest
 import team.aliens.dms.domain.student.dto.SignUpResponse
+import team.aliens.dms.domain.student.exception.StudentAlreadyExistsException
 import team.aliens.dms.domain.student.exception.StudentNotFoundException
 import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.student.spi.CommandStudentPort
@@ -68,6 +69,10 @@ class SignUpUseCase(
             classRoom = classRoom,
             number = number
         ) ?: throw StudentNotFoundException
+
+        if (student.userId != null) {
+            throw StudentAlreadyExistsException
+        }
 
         commandStudentPort.saveStudent(
             student.copy(

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentWithdrawalUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/student/usecase/StudentWithdrawalUseCase.kt
@@ -2,18 +2,12 @@ package team.aliens.dms.domain.student.usecase
 
 import java.time.LocalDateTime
 import team.aliens.dms.common.annotation.UseCase
-import team.aliens.dms.domain.remain.spi.CommandRemainStatusPort
-import team.aliens.dms.domain.student.spi.CommandStudentPort
-import team.aliens.dms.domain.studyroom.spi.CommandStudyRoomPort
 import team.aliens.dms.domain.user.exception.UserNotFoundException
 import team.aliens.dms.domain.user.service.UserService
 
 @UseCase
 class StudentWithdrawalUseCase(
-    private val userService: UserService,
-    private val commandRemainStatusPort: CommandRemainStatusPort,
-    private val commandStudyRoomPort: CommandStudyRoomPort,
-    private val commandStudentPort: CommandStudentPort
+    private val userService: UserService
 ) {
 
     fun execute() {
@@ -21,12 +15,6 @@ class StudentWithdrawalUseCase(
         val student = userService.getCurrentStudent()
         student.userId ?: throw UserNotFoundException
 
-        commandRemainStatusPort.deleteByStudentId(student.id)
-        commandStudyRoomPort.deleteSeatApplicationByStudentId(student.id)
-
-        commandStudentPort.saveStudent(
-            student.copy(deletedAt = LocalDateTime.now())
-        )
         userService.deleteUserById(student.userId)
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] 탈퇴시 학생 정보 삭제되지 않도록 수정
- [x] 이미 user가 등록되어있는 학생이 다시 회원가입할 수 없게 검증 로직 추가

## 주요 변경 사항

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #450