### PR TITLE
merge: (#483) entity 첫 저장시 merge로 인한 select query 방지

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/CreateStudyRoomUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/studyroom/usecase/CreateStudyRoomUseCase.kt
@@ -1,10 +1,10 @@
 package team.aliens.dms.domain.studyroom.usecase
 
+import java.util.UUID
 import team.aliens.dms.common.annotation.UseCase
 import team.aliens.dms.domain.studyroom.dto.CreateStudyRoomRequest
 import team.aliens.dms.domain.studyroom.service.StudyRoomService
 import team.aliens.dms.domain.user.service.UserService
-import java.util.UUID
 
 @UseCase
 class CreateStudyRoomUseCase(
@@ -18,15 +18,15 @@ class CreateStudyRoomUseCase(
 
         studyRoomService.checkStudyRoomExistsByFloorAndName(request.floor, request.name, user.schoolId)
         val studyRoom = studyRoomService.saveStudyRoom(
-            request.toStudyRoom(user.id)
+            request.toStudyRoom(schoolId = user.schoolId)
         )
 
         studyRoomService.saveAllStudyRoomTimeSlots(
-            request.toStudyRoomTimeSlots(studyRoom.id)
+            request.toStudyRoomTimeSlots(studyRoomId = studyRoom.id)
         )
 
         studyRoomService.saveAllSeats(
-            request.toSeats(studyRoom.id)
+            request.toSeats(studyRoomId = studyRoom.id)
         )
 
         return studyRoom.id

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/BaseUUIDEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/BaseUUIDEntity.kt
@@ -9,11 +9,11 @@ import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
 abstract class BaseUUIDEntity(
-
+    id: UUID?
+) {
     @Id
     @GeneratedValue(generator = "timeBasedUUID")
     @GenericGenerator(name = "timeBasedUUID", strategy = "team.aliens.dms.persistence.TimeBasedUUIDGenerator")
     @Column(columnDefinition = "BINARY(16)", nullable = false)
-    val id: UUID?
-
-)
+    val id: UUID? = if (id == UUID(0, 0)) null else id
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notice/entity/NoticeJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notice/entity/NoticeJpaEntity.kt
@@ -15,7 +15,7 @@ import javax.persistence.Table
 @Table(name = "tbl_notice")
 class NoticeJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PhraseJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PhraseJpaEntity.kt
@@ -13,7 +13,7 @@ import javax.persistence.Table
 @Table(name = "tbl_phrase")
 class PhraseJpaEntity(
 
-    override val id: UUID,
+    id: UUID?,
 
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
     val content: String,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointFilterJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointFilterJpaEntity.kt
@@ -23,7 +23,7 @@ import javax.persistence.UniqueConstraint
 )
 class PointFilterJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
@@ -18,7 +18,7 @@ import javax.persistence.Table
 @Table(name = "tbl_point_history")
 class PointHistoryJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
     val studentName: String,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointOptionJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointOptionJpaEntity.kt
@@ -17,7 +17,7 @@ import javax.persistence.Table
 @Table(name = "tbl_point_option")
 class PointOptionJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PhraseMapper.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PhraseMapper.kt
@@ -11,7 +11,7 @@ class PhraseMapper : GenericMapper<Phrase, PhraseJpaEntity> {
     override fun toDomain(entity: PhraseJpaEntity?): Phrase? {
         return entity?.let {
             Phrase(
-                id = entity.id,
+                id = entity.id!!,
                 content = entity.content,
                 type = entity.type,
                 standard = entity.standard

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/remain/entity/RemainOptionJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/remain/entity/RemainOptionJpaEntity.kt
@@ -14,7 +14,7 @@ import javax.persistence.Table
 @Table(name = "tbl_remain_option")
 class RemainOptionJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/room/entity/RoomJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/room/entity/RoomJpaEntity.kt
@@ -20,7 +20,7 @@ import javax.persistence.UniqueConstraint
 )
 class RoomJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/school/entity/SchoolJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/school/entity/SchoolJpaEntity.kt
@@ -17,7 +17,7 @@ import javax.persistence.UniqueConstraint
 )
 class SchoolJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val name: String,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/entity/StudentJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/entity/StudentJpaEntity.kt
@@ -23,7 +23,7 @@ import javax.persistence.Table
 @Where(clause = "deleted_at is null")
 class StudentJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)", nullable = true)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/SeatJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/SeatJpaEntity.kt
@@ -23,7 +23,7 @@ import javax.persistence.UniqueConstraint
 )
 class SeatJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_room_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/SeatTypeJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/SeatTypeJpaEntity.kt
@@ -14,7 +14,7 @@ import javax.persistence.Table
 @Table(name = "tbl_seat_type")
 class SeatTypeJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/StudyRoomJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/StudyRoomJpaEntity.kt
@@ -23,7 +23,7 @@ import javax.persistence.UniqueConstraint
 )
 class StudyRoomJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/TimeSlotJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/studyroom/entity/TimeSlotJpaEntity.kt
@@ -15,7 +15,7 @@ import javax.persistence.Table
 @Table(name = "tbl_time_slot")
 class TimeSlotJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @Column(columnDefinition = "TIME", nullable = false)
     val startTime: LocalTime,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/tag/entity/TagJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/tag/entity/TagJpaEntity.kt
@@ -22,7 +22,7 @@ import javax.persistence.UniqueConstraint
 )
 class TagJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val name: String,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/user/entity/UserJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/user/entity/UserJpaEntity.kt
@@ -20,7 +20,7 @@ import javax.persistence.Table
 @Where(clause = "deleted_at is null")
 class UserJpaEntity(
 
-    override val id: UUID?,
+    id: UUID?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)


### PR DESCRIPTION
## 작업 내용 설명
- [x] create시 persist가 아닌 merge가 실행됨으로 인한 select query 방지

## 주요 변경 사항

- persistable 상속 받지 않고 UUID가 UUID(0,0)인 경우 null로 들어가도록 해주었음
- persistable을 재정의 하는 방법을 고려해보았으나 알 수 없는 에러 발생

## 결과물

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #483