### PR TITLE
merge: 데이터 암호화 구현

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -43,6 +43,7 @@ object Dependencies {
     // aws
     const val SPRING_AWS = "org.springframework.cloud:spring-cloud-starter-aws:${DependencyVersions.AWS_VERSION}"
     const val AWS_SES = "com.amazonaws:aws-java-sdk-ses:${DependencyVersions.SES_VERSION}"
+    const val AWS_KMS = "com.amazonaws:aws-java-sdk-kms:${DependencyVersions.KMS_VERSION}"
 
     // test
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test:${PluginVersions.SPRING_BOOT_VERSION}"

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -3,6 +3,7 @@ object DependencyVersions {
     const val JWT_VERSION = "0.9.1"
     const val AWS_VERSION = "2.2.6.RELEASE"
     const val SES_VERSION = "1.11.852"
+    const val KMS_VERSION ="1.12.464"
     const val REDIS_VERSION = "2.7.2"
     const val SERVLET_VERSION = "4.0.1"
     const val UUID_TIME_VERSION = "3.1.4"

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/model/SchoolSecret.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/model/SchoolSecret.kt
@@ -1,9 +1,8 @@
 package team.aliens.dms.common.model
 
-import java.io.Serializable
 import java.util.UUID
 
 data class SchoolSecret(
     val schoolId: UUID,
     val secretKey: String
-) : Serializable
+)

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/model/SchoolSecret.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/model/SchoolSecret.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.common.model
+
+import java.io.Serializable
+import java.util.UUID
+
+data class SchoolSecret(
+    val schoolId: UUID,
+    val secretKey: String
+) : Serializable

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/service/security/SecurityService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/service/security/SecurityService.kt
@@ -9,4 +9,6 @@ interface SecurityService {
     fun getCurrentUserId(): UUID
 
     fun checkIsPasswordMatches(rawPassword: String, encodedPassword: String)
+
+    fun createSchoolSecretBySchoolId(schoolId: UUID)
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/service/security/SecurityServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/service/security/SecurityServiceImpl.kt
@@ -1,12 +1,17 @@
 package team.aliens.dms.common.service.security
 
+import java.util.UUID
 import team.aliens.dms.common.annotation.Service
+import team.aliens.dms.common.model.SchoolSecret
+import team.aliens.dms.common.spi.SchoolSecretPort
 import team.aliens.dms.common.spi.SecurityPort
+import team.aliens.dms.common.util.StringUtil
 import team.aliens.dms.domain.auth.exception.PasswordMismatchException
 
 @Service
 class SecurityServiceImpl(
-    private val securityPort: SecurityPort
+    private val securityPort: SecurityPort,
+    private val schoolSecretPort: SchoolSecretPort
 ) : SecurityService {
 
     override fun encodePassword(password: String) =
@@ -19,5 +24,14 @@ class SecurityServiceImpl(
         if (!securityPort.isPasswordMatch(rawPassword, encodedPassword)) {
             throw PasswordMismatchException
         }
+    }
+
+    override fun createSchoolSecretBySchoolId(schoolId: UUID) {
+        schoolSecretPort.saveSchoolSecret(
+            SchoolSecret(
+                schoolId = schoolId,
+                secretKey = StringUtil.randomKey()
+            )
+        )
     }
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/spi/EncryptPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/spi/EncryptPort.kt
@@ -1,0 +1,12 @@
+package team.aliens.dms.common.spi
+
+interface EncryptPort {
+
+    fun symmetricEncrypt(secretKey: String, plainText: String): String
+
+    fun symmetricDecrypt(secretKey: String, cipherText: String): String
+
+    fun asymmetricEncrypt(plainText: String): String
+
+    fun asymmetricDecrypt(cipherText: String): String
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/spi/SchoolSecretPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/spi/SchoolSecretPort.kt
@@ -1,0 +1,11 @@
+package team.aliens.dms.common.spi
+
+import java.util.UUID
+import team.aliens.dms.common.model.SchoolSecret
+
+interface SchoolSecretPort {
+
+    fun saveSchoolSecret(schoolSecret: SchoolSecret)
+
+    fun querySchoolSecretBySchoolId(schoolId: UUID): SchoolSecret?
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/spi/SchoolSecretPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/spi/SchoolSecretPort.kt
@@ -7,5 +7,5 @@ interface SchoolSecretPort {
 
     fun saveSchoolSecret(schoolSecret: SchoolSecret)
 
-    fun querySchoolSecretBySchoolId(schoolId: UUID): SchoolSecret?
+    fun querySchoolSecretBySchoolId(schoolId: UUID): String?
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/common/util/StringUtil.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/util/StringUtil.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.common.util
 
 import java.security.SecureRandom
+import java.util.Base64
 
 object StringUtil {
 
@@ -18,17 +19,23 @@ object StringUtil {
         return sb.toString()
     }
 
+    private val RANDOM = SecureRandom()
+
     fun randomNumber(number: Int): String {
-        val random = SecureRandom()
         val codeList: List<Char> = listOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
         val authCodeList: MutableList<String> = mutableListOf()
 
         for (i: Int in 0 until number) {
-            authCodeList.add(i, codeList[random.nextInt(codeList.size)].toString())
+            authCodeList.add(i, codeList[RANDOM.nextInt(codeList.size)].toString())
         }
 
         return authCodeList.toString().replace("[^0-9]".toRegex(), "")
     }
+
+    fun randomKey(byteSize: Int = 24): String =
+        Base64.getUrlEncoder().encodeToString(
+            ByteArray(byteSize).also { RANDOM.nextBytes(it) }
+        )
 
     fun <T> List<T>.toStringWithoutBracket() = toString().replace("[\\[\\]]".toRegex(), "")
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/manager/spi/vo/StudentWithTag.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/manager/spi/vo/StudentWithTag.kt
@@ -5,9 +5,9 @@ import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.tag.model.Tag
 import java.util.UUID
 
-data class StudentWithTag(
+open class StudentWithTag(
     val id: UUID,
-    val name: String,
+    open val name: String,
     val grade: Int,
     val classRoom: Int,
     val number: Int,

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/point/spi/vo/StudentWithPointVO.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/point/spi/vo/StudentWithPointVO.kt
@@ -3,8 +3,8 @@ package team.aliens.dms.domain.point.spi.vo
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.student.model.Student
 
-data class StudentWithPointVO(
-    val name: String,
+open class StudentWithPointVO(
+    open val name: String,
     val grade: Int,
     val classRoom: Int,
     val number: Int,

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/room/service/RoomService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/room/service/RoomService.kt
@@ -1,6 +1,6 @@
 package team.aliens.dms.domain.room.service
 
-import org.springframework.stereotype.Service
+import team.aliens.dms.common.annotation.Service
 
 @Service
 class RoomService(

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/school/dto/CreateSchoolRequest.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/school/dto/CreateSchoolRequest.kt
@@ -1,0 +1,37 @@
+package team.aliens.dms.domain.school.dto
+
+import java.time.LocalDate
+import java.util.UUID
+import team.aliens.dms.common.util.StringUtil
+import team.aliens.dms.domain.school.model.AvailableFeature
+import team.aliens.dms.domain.school.model.School
+
+class CreateSchoolRequest(
+    val schoolName: String,
+    val schoolAddress: String,
+    val mealService: Boolean,
+    val noticeService: Boolean,
+    val pointService: Boolean,
+    val studyRoomService: Boolean,
+    val remainService: Boolean
+) {
+    fun toSchool() =
+        School(
+            name = schoolName,
+            code = StringUtil.randomNumber(School.SCHOOL_CODE_SIZE),
+            question = "우리 학교 이름은?",
+            answer = schoolName,
+            address = schoolAddress,
+            contractStartedAt = LocalDate.now()
+        )
+
+    fun toAvailableFeature(schoolId: UUID) =
+        AvailableFeature(
+            schoolId = schoolId,
+            mealService = mealService,
+            noticeService = noticeService,
+            pointService = pointService,
+            studyRoomService = studyRoomService,
+            remainService = remainService
+        )
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/school/model/School.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/school/model/School.kt
@@ -22,7 +22,7 @@ data class School(
 
     val contractStartedAt: LocalDate,
 
-    val contractEndedAt: LocalDate?
+    val contractEndedAt: LocalDate? = null
 
 ) {
     companion object {

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/school/service/CommandSchoolService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/school/service/CommandSchoolService.kt
@@ -1,8 +1,11 @@
 package team.aliens.dms.domain.school.service
 
+import team.aliens.dms.domain.school.model.AvailableFeature
 import team.aliens.dms.domain.school.model.School
 
 interface CommandSchoolService {
 
     fun saveSchool(school: School): School
+
+    fun saveAvailableFeature(availableFeature: AvailableFeature): AvailableFeature
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/school/service/CommandSchoolServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/school/service/CommandSchoolServiceImpl.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.school.service
 
 import team.aliens.dms.common.annotation.Service
+import team.aliens.dms.domain.school.model.AvailableFeature
 import team.aliens.dms.domain.school.model.School
 import team.aliens.dms.domain.school.spi.CommandSchoolPort
 
@@ -11,4 +12,7 @@ class CommandSchoolServiceImpl(
 
     override fun saveSchool(school: School) =
         commandSchoolPort.saveSchool(school)
+
+    override fun saveAvailableFeature(availableFeature: AvailableFeature) =
+        commandSchoolPort.saveAvailableFeature(availableFeature)
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/school/spi/CommandSchoolPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/school/spi/CommandSchoolPort.kt
@@ -1,8 +1,11 @@
 package team.aliens.dms.domain.school.spi
 
+import team.aliens.dms.domain.school.model.AvailableFeature
 import team.aliens.dms.domain.school.model.School
 
 interface CommandSchoolPort {
 
     fun saveSchool(school: School): School
+
+    fun saveAvailableFeature(availableFeature: AvailableFeature): AvailableFeature
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/school/usecase/CreateSchoolUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/school/usecase/CreateSchoolUseCase.kt
@@ -1,0 +1,21 @@
+package team.aliens.dms.domain.school.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.service.security.SecurityService
+import team.aliens.dms.domain.school.dto.CreateSchoolRequest
+import team.aliens.dms.domain.school.service.SchoolService
+
+@UseCase
+class CreateSchoolUseCase(
+    private val schoolService: SchoolService,
+    private val securityService: SecurityService
+) {
+
+    fun execute(request: CreateSchoolRequest) {
+        val school = schoolService.saveSchool(
+            request.toSchool()
+        )
+        schoolService.saveAvailableFeature(request.toAvailableFeature(school.id))
+        securityService.createSchoolSecretBySchoolId(school.id)
+    }
+}

--- a/dms-infrastructure/build.gradle.kts
+++ b/dms-infrastructure/build.gradle.kts
@@ -24,8 +24,9 @@ dependencies {
     implementation(Dependencies.JWT)
 
     // aws
-    implementation(Dependencies.AWS_SES)
     implementation(Dependencies.SPRING_AWS)
+    implementation(Dependencies.AWS_SES)
+    implementation(Dependencies.AWS_KMS)
 
     // configuration
     kapt(Dependencies.CONFIGURATION_PROCESSOR)

--- a/dms-infrastructure/build.gradle.kts
+++ b/dms-infrastructure/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
 
     // logging
     implementation(Dependencies.SENTRY)
+
+    // redis
+    implementation(Dependencies.REDIS)
 }
 
 kapt {

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/AspectjConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/AspectjConfig.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+
+@Configuration
+@EnableAspectJAutoProxy(exposeProxy = true)
+class AspectjConfig

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.global.config
+
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableCaching
+class CacheConfig

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
@@ -1,8 +1,0 @@
-package team.aliens.dms.global.config
-
-import org.springframework.cache.annotation.EnableCaching
-import org.springframework.context.annotation.Configuration
-
-@Configuration
-@EnableCaching
-class CacheConfig

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/RedisCacheConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/config/RedisCacheConfig.kt
@@ -1,0 +1,46 @@
+package team.aliens.dms.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.time.Duration
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig {
+
+    @Bean
+    fun redisCacheManager(
+        connectionFactory: RedisConnectionFactory,
+        objectMapper: ObjectMapper,
+    ): CacheManager {
+
+        val redisCacheConfiguration = RedisCacheConfiguration
+            .defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer())
+            )
+            .entryTtl(CACHE_DURATION)
+
+        return RedisCacheManagerBuilder
+            .fromConnectionFactory(connectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
+    }
+
+    companion object {
+        private val CACHE_DURATION = Duration.ofMinutes(30L)
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/error/GlobalErrorCode.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/error/GlobalErrorCode.kt
@@ -14,6 +14,7 @@ enum class GlobalErrorCode(
     BAD_REQUEST(ErrorStatus.BAD_REQUEST, "Bad Request", 3),
     INVALID_FILE(ErrorStatus.BAD_REQUEST, "Invalid File", 4),
     BAD_EXCEL_FORMAT(ErrorStatus.BAD_REQUEST, "%s행 등 %s개 행의 데이터 형식이 잘못되었습니다.", 5),
+    KEY_MANAGEMENT_SERVICE(ErrorStatus.BAD_REQUEST, "Key processing failed", 6),
 
     EXTENSION_MISMATCH(401, "File Extension Mismatch", 1),
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSAdapter.kt
@@ -8,7 +8,6 @@ import java.nio.ByteBuffer
 import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import team.aliens.dms.common.spi.EncryptPort
 import team.aliens.dms.thirdparty.encrypt.exception.KMSException
@@ -40,7 +39,6 @@ class AwsKMSAdapter(
         )
     }
 
-    @Cacheable("cipher", cacheManager = "redisCacheManager")
     protected fun getCipher(opmode: Int, key: String): Cipher =
         Cipher.getInstance(encryptProperties.transformation).apply {
             init(opmode, SecretKeySpec(key.toByteArray(), encryptProperties.algorithm))

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSAdapter.kt
@@ -4,14 +4,14 @@ import com.amazonaws.services.kms.AWSKMSAsync
 import com.amazonaws.services.kms.model.DecryptRequest
 import com.amazonaws.services.kms.model.EncryptRequest
 import com.amazonaws.services.kms.model.EncryptionAlgorithmSpec
-import org.springframework.cache.annotation.Cacheable
-import org.springframework.stereotype.Component
-import team.aliens.dms.common.spi.EncryptPort
-import team.aliens.dms.thirdparty.encrypt.exception.KMSException
 import java.nio.ByteBuffer
 import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Component
+import team.aliens.dms.common.spi.EncryptPort
+import team.aliens.dms.thirdparty.encrypt.exception.KMSException
 
 @Component
 class AwsKMSAdapter(
@@ -40,7 +40,7 @@ class AwsKMSAdapter(
         )
     }
 
-    @Cacheable("cipher")
+    @Cacheable("cipher", cacheManager = "redisCacheManager")
     protected fun getCipher(opmode: Int, key: String): Cipher =
         Cipher.getInstance(encryptProperties.transformation).apply {
             init(opmode, SecretKeySpec(key.toByteArray(), encryptProperties.algorithm))
@@ -65,7 +65,6 @@ class AwsKMSAdapter(
         )
     }
 
-    @Cacheable("decryptedText")
     override fun asymmetricDecrypt(cipherText: String): String {
 
         val request = DecryptRequest()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSAdapter.kt
@@ -1,0 +1,90 @@
+package team.aliens.dms.thirdparty.encrypt
+
+import com.amazonaws.services.kms.AWSKMSAsync
+import com.amazonaws.services.kms.model.DecryptRequest
+import com.amazonaws.services.kms.model.EncryptRequest
+import com.amazonaws.services.kms.model.EncryptionAlgorithmSpec
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Component
+import team.aliens.dms.common.spi.EncryptPort
+import team.aliens.dms.thirdparty.encrypt.exception.KMSException
+import java.nio.ByteBuffer
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class AwsKMSAdapter(
+    private val awskmsAsync: AWSKMSAsync,
+    private val awsKMSProperties: AwsKMSProperties,
+    private val encryptProperties: EncryptProperties
+) : EncryptPort {
+
+    override fun symmetricEncrypt(
+        secretKey: String,
+        plainText: String,
+    ): String {
+        val cipher = getCipher(Cipher.ENCRYPT_MODE, secretKey)
+        return String(
+            cipher.doFinal(plainText.toByteArray()).encodeBase64()
+        )
+    }
+
+    override fun symmetricDecrypt(
+        secretKey: String,
+        cipherText: String,
+    ): String {
+        val cipher = getCipher(Cipher.DECRYPT_MODE, secretKey)
+        return String(
+            cipher.doFinal(cipherText.decodeBase64())
+        )
+    }
+
+    @Cacheable("cipher")
+    protected fun getCipher(opmode: Int, key: String): Cipher =
+        Cipher.getInstance(encryptProperties.transformation).apply {
+            init(opmode, SecretKeySpec(key.toByteArray(), encryptProperties.algorithm))
+        }
+
+    override fun asymmetricEncrypt(plainText: String): String {
+
+        val request = EncryptRequest()
+            .withKeyId(awsKMSProperties.key)
+            .withPlaintext(ByteBuffer.wrap(plainText.toByteArray()))
+            .withEncryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
+
+        val encryptedByte = runCatching {
+            awskmsAsync.encrypt(request).ciphertextBlob.array()
+        }.onFailure { e ->
+            e.printStackTrace()
+            throw KMSException
+        }.getOrThrow()
+
+        return String(
+            encryptedByte.encodeBase64()
+        )
+    }
+
+    @Cacheable("decryptedText")
+    override fun asymmetricDecrypt(cipherText: String): String {
+
+        val request = DecryptRequest()
+            .withKeyId(awsKMSProperties.key)
+            .withCiphertextBlob(ByteBuffer.wrap(cipherText.decodeBase64()))
+            .withEncryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
+
+        val decryptedByte = runCatching {
+            awskmsAsync.decrypt(request).plaintext.array()
+        }.onFailure { e ->
+            e.printStackTrace()
+            throw KMSException
+        }.getOrThrow()
+
+        return String(decryptedByte)
+    }
+
+    // byteArray를 String으로 바로 변환하면 padding이 깨지는 문제가 발생하기 때문에
+    // encoding 결과를 Base64로 암호화하여 저장한다.
+    private fun ByteArray.encodeBase64() = Base64.getEncoder().encode(this)
+    private fun String.decodeBase64() = Base64.getDecoder().decode(this)
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSConfiguration.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSConfiguration.kt
@@ -1,0 +1,25 @@
+package team.aliens.dms.thirdparty.encrypt
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.kms.AWSKMSAsync
+import com.amazonaws.services.kms.AWSKMSAsyncClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import team.aliens.dms.thirdparty.AwsProperties
+
+@Configuration
+class AwsKMSConfiguration(
+    private val awsProperties: AwsProperties
+) {
+    @Bean
+    fun awsKMSAsync(): AWSKMSAsync {
+        val basicAWSCredentials = BasicAWSCredentials(awsProperties.accessKey, awsProperties.secretKey)
+
+        return AWSKMSAsyncClient.asyncBuilder()
+            .withCredentials(AWSStaticCredentialsProvider(basicAWSCredentials))
+            .withRegion(Regions.AP_NORTHEAST_2)
+            .build()
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSProperties.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/AwsKMSProperties.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.thirdparty.encrypt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties("cloud.aws.kms")
+@ConstructorBinding
+class AwsKMSProperties(
+    val key: String
+)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/EncryptProperties.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/EncryptProperties.kt
@@ -1,0 +1,11 @@
+package team.aliens.dms.thirdparty.encrypt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties("encrypt")
+@ConstructorBinding
+class EncryptProperties(
+    val transformation: String,
+    val algorithm: String
+)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/aop/EntityEncryptAspect.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/aop/EntityEncryptAspect.kt
@@ -1,5 +1,8 @@
 package team.aliens.dms.thirdparty.encrypt.aop
 
+import java.lang.reflect.Field
+import java.util.function.Consumer
+import java.util.function.Function
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.AfterReturning
@@ -14,9 +17,6 @@ import team.aliens.dms.common.spi.EncryptPort
 import team.aliens.dms.common.spi.SchoolSecretPort
 import team.aliens.dms.common.spi.SecurityPort
 import team.aliens.dms.domain.school.exception.SchoolNotFoundException
-import java.lang.reflect.Field
-import java.util.function.Consumer
-import java.util.function.Function
 
 @UseCase
 @Aspect
@@ -117,6 +117,6 @@ class EntityEncryptAspect(
     private fun getSchoolKey(): String {
         val schoolId = securityPort.getCurrentUserSchoolId()
         val schoolSecret = schoolSecretPort.querySchoolSecretBySchoolId(schoolId) ?: throw SchoolNotFoundException
-        return encryptPort.asymmetricDecrypt(schoolSecret.secretKey)
+        return encryptPort.asymmetricDecrypt(schoolSecret)
     }
 }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/aop/EntityEncryptAspect.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/aop/EntityEncryptAspect.kt
@@ -83,10 +83,10 @@ class EntityEncryptAspect(
             when (f.getAnnotation(EncryptedColumn::class.java).type) {
                 EncryptType.SYMMETRIC -> encryptPort.symmetricEncrypt(
                     secretKey = getSchoolKey(),
-                    plainText = f.get(obj) as String
+                    plainText = f[obj] as String
                 )
                 EncryptType.ASYMMETRIC -> encryptPort.asymmetricEncrypt(
-                    plainText = f.get(obj) as String
+                    plainText = f[obj] as String
                 )
             }
         }
@@ -97,10 +97,10 @@ class EntityEncryptAspect(
             when (f.getAnnotation(EncryptedColumn::class.java).type) {
                 EncryptType.SYMMETRIC -> encryptPort.symmetricDecrypt(
                     secretKey = getSchoolKey(),
-                    cipherText = f.get(obj) as String
+                    cipherText = f[obj] as String
                 )
                 EncryptType.ASYMMETRIC -> encryptPort.asymmetricDecrypt(
-                    cipherText = f.get(obj) as String
+                    cipherText = f[obj] as String
                 )
             }
         }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/aop/EntityEncryptAspect.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/aop/EntityEncryptAspect.kt
@@ -1,0 +1,122 @@
+package team.aliens.dms.thirdparty.encrypt.aop
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import team.aliens.dms.common.annotation.Decrypted
+import team.aliens.dms.common.annotation.EncryptType
+import team.aliens.dms.common.annotation.EncryptedColumn
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.spi.EncryptPort
+import team.aliens.dms.common.spi.SchoolSecretPort
+import team.aliens.dms.common.spi.SecurityPort
+import team.aliens.dms.domain.school.exception.SchoolNotFoundException
+import java.lang.reflect.Field
+import java.util.function.Consumer
+import java.util.function.Function
+
+@UseCase
+@Aspect
+class EntityEncryptAspect(
+    private val securityPort: SecurityPort,
+    private val schoolSecretPort: SchoolSecretPort,
+    private val encryptPort: EncryptPort
+) {
+
+    @AfterReturning(
+        "@annotation(team.aliens.dms.common.annotation.Encrypt)",
+        returning = "ret"
+    )
+    fun encryptReturnValue(joinPoint: JoinPoint, ret: Any) {
+        if (ret is List<*>) ret.map { obj ->
+            doOnEncryptedColumn(obj!!) { field ->
+                setEncryptedValue(obj, field)
+            }
+        } else {
+            doOnEncryptedColumn(ret) { field ->
+                setEncryptedValue(ret, field)
+            }
+        }
+    }
+
+    @AfterReturning(
+        "@annotation(team.aliens.dms.common.annotation.Decrypt)",
+        returning = "ret"
+    )
+    fun decryptReturnValue(joinPoint: JoinPoint, ret: Any) {
+        if (ret is List<*>) ret.map { obj ->
+            doOnEncryptedColumn(obj!!) { field ->
+                setDecryptedValue(obj, field)
+            }
+        } else {
+            doOnEncryptedColumn(ret) { field ->
+                setDecryptedValue(ret, field)
+            }
+        }
+    }
+
+    @Around("execution(* *(.., @team.aliens.dms.common.annotation.Decrypted() *, ..))+")
+    fun decryptParameterValue(joinPoint: ProceedingJoinPoint) {
+        (joinPoint.signature as MethodSignature).method.parameters
+            .forEachIndexed { idx, param ->
+                if (param.annotations.contains(Decrypted::class as Annotation)) {
+                    doOnEncryptedColumn(joinPoint.args[idx]) { field ->
+                        setDecryptedValue(joinPoint.args[idx], field)
+                    }
+                }
+            }
+    }
+
+    private fun doOnEncryptedColumn(obj: Any, behavior: Consumer<Field>) {
+        obj::class.java.declaredFields.map { field: Field ->
+            if (field.isAnnotationPresent(EncryptedColumn::class.java)) {
+                behavior.accept(field)
+            }
+        }
+    }
+
+    private fun setEncryptedValue(obj: Any, field: Field) {
+        getAnnotationAndSet(obj, field) { f ->
+            when (f.getAnnotation(EncryptedColumn::class.java).type) {
+                EncryptType.SYMMETRIC -> encryptPort.symmetricEncrypt(
+                    secretKey = getSchoolKey(),
+                    plainText = f.get(obj) as String
+                )
+                EncryptType.ASYMMETRIC -> encryptPort.asymmetricEncrypt(
+                    plainText = f.get(obj) as String
+                )
+            }
+        }
+    }
+
+    private fun setDecryptedValue(obj: Any, field: Field) {
+        getAnnotationAndSet(obj, field) { f ->
+            when (f.getAnnotation(EncryptedColumn::class.java).type) {
+                EncryptType.SYMMETRIC -> encryptPort.symmetricDecrypt(
+                    secretKey = getSchoolKey(),
+                    cipherText = f.get(obj) as String
+                )
+                EncryptType.ASYMMETRIC -> encryptPort.asymmetricDecrypt(
+                    cipherText = f.get(obj) as String
+                )
+            }
+        }
+    }
+
+    private fun getAnnotationAndSet(obj: Any, field: Field, function: Function<Field, String>) {
+        field.run {
+            check(type == String::class.java)
+            isAccessible = true
+            set(obj, function.apply(this))
+        }
+    }
+
+    private fun getSchoolKey(): String {
+        val schoolId = securityPort.getCurrentUserSchoolId()
+        val schoolSecret = schoolSecretPort.querySchoolSecretBySchoolId(schoolId) ?: throw SchoolNotFoundException
+        return encryptPort.asymmetricDecrypt(schoolSecret.secretKey)
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/exception/KMSException.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/encrypt/exception/KMSException.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.thirdparty.encrypt.exception
+
+import team.aliens.dms.common.error.DmsException
+import team.aliens.dms.global.error.GlobalErrorCode
+
+object KMSException : DmsException(
+    GlobalErrorCode.KEY_MANAGEMENT_SERVICE
+)

--- a/dms-infrastructure/src/main/resources/application.yml
+++ b/dms-infrastructure/src/main/resources/application.yml
@@ -61,6 +61,8 @@ cloud:
       bucket: ${BUCKET_NAME:dms}
     ses:
       source: ${SES_SENDER:asdf}
+    kms:
+      key: ${KMS_ARN:asdf}
 
 sentry:
   dsn: ${SENTRY_DSN:asdf}

--- a/dms-infrastructure/src/main/resources/application.yml
+++ b/dms-infrastructure/src/main/resources/application.yml
@@ -39,6 +39,9 @@ spring:
       max-file-size: 20MB
       max-request-size: 20MB
 
+  cache:
+    type: redis
+
 secret:
   secret-key: ${SECRET_KEY:asdfghgfds}
   access-exp: ${ACCESS_EXP:1800}

--- a/dms-infrastructure/src/main/resources/application.yml
+++ b/dms-infrastructure/src/main/resources/application.yml
@@ -67,6 +67,10 @@ cloud:
     kms:
       key: ${KMS_ARN:asdf}
 
+encrypt:
+  transformation: ${ENCRYPT_TRANSFORMATION}
+  algorithm: ${ENCRYPT_ALGORITHM}
+
 sentry:
   dsn: ${SENTRY_DSN:asdf}
   traces-sample-rate: 1.0

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/common/annotation/EncryptAnnotations.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/common/annotation/EncryptAnnotations.kt
@@ -17,7 +17,7 @@ enum class EncryptType {
 }
 
 /**
- * 메서드의 반환값에서 EncryptedColmn이 붙은 필드을 암호화하는 어노테이션
+ * 메서드의 반환값에서 EncryptedColumn이 붙은 필드을 암호화하는 어노테이션
  * @see EncryptedColumn
  * @see team.aliens.dms.persistence.EncryptableGenericMapper
  */
@@ -27,7 +27,7 @@ enum class EncryptType {
 annotation class Encrypt
 
 /**
- * 메서드의 반환값에서 EncryptedColmn이 붙은 필드을 복호화하는 어노테이션
+ * 메서드의 반환값에서 EncryptedColumn이 붙은 필드을 복호화하는 어노테이션
  * @see EncryptedColumn
  */
 @Inherited

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/common/annotation/EncryptAnnotations.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/common/annotation/EncryptAnnotations.kt
@@ -1,0 +1,47 @@
+package team.aliens.dms.common.annotation
+
+import java.lang.annotation.Inherited
+
+/**
+ * 저장시 암호화되는 컬럼을 명시해주기 위한 어노테이션
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class EncryptedColumn(
+    val type: EncryptType
+)
+
+enum class EncryptType {
+    SYMMETRIC,
+    ASYMMETRIC
+}
+
+/**
+ * 메서드의 반환값에서 EncryptedColmn이 붙은 필드을 암호화하는 어노테이션
+ * @see EncryptedColumn
+ * @see team.aliens.dms.persistence.EncryptableGenericMapper
+ */
+@Inherited
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Encrypt
+
+/**
+ * 메서드의 반환값에서 EncryptedColmn이 붙은 필드을 복호화하는 어노테이션
+ * @see EncryptedColumn
+ */
+@Inherited
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Decrypt
+
+/**
+ * 파라미터 전달시에 암호화된 엔티티를 복호화하는 어노테이션
+ * @see team.aliens.dms.persistence.EncryptableGenericMapper
+ */
+@Inherited
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class Decrypted(
+    val value: String = ""
+)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/EncryptableGenericMapper.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/EncryptableGenericMapper.kt
@@ -1,0 +1,12 @@
+package team.aliens.dms.persistence
+
+import team.aliens.dms.common.annotation.Decrypted
+import team.aliens.dms.common.annotation.Encrypt
+
+interface EncryptableGenericMapper<D, E> : GenericMapper<D, E> {
+
+    override fun toDomain(@Decrypted entity: E?): D?
+
+    @Encrypt
+    override fun toEntity(domain: D): E
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notice/entity/NoticeJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notice/entity/NoticeJpaEntity.kt
@@ -24,7 +24,7 @@ class NoticeJpaEntity(
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     val title: String,
 
-    @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     val content: String,
 
     override val createdAt: LocalDateTime,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/entity/PointHistoryJpaEntity.kt
@@ -1,8 +1,5 @@
 package team.aliens.dms.persistence.point.entity
 
-import team.aliens.dms.domain.point.model.PointType
-import team.aliens.dms.persistence.BaseEntity
-import team.aliens.dms.persistence.school.entity.SchoolJpaEntity
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.Column
@@ -13,6 +10,11 @@ import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
+import team.aliens.dms.common.annotation.EncryptType
+import team.aliens.dms.common.annotation.EncryptedColumn
+import team.aliens.dms.domain.point.model.PointType
+import team.aliens.dms.persistence.BaseEntity
+import team.aliens.dms.persistence.school.entity.SchoolJpaEntity
 
 @Entity
 @Table(name = "tbl_point_history")
@@ -20,10 +22,12 @@ class PointHistoryJpaEntity(
 
     id: UUID?,
 
+    @EncryptedColumn(type = EncryptType.SYMMETRIC)
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
     val studentName: String,
 
-    @Column(columnDefinition = "VARCHAR(5)", nullable = false)
+    @EncryptedColumn(type = EncryptType.SYMMETRIC)
+    @Column(columnDefinition = "TEXT", nullable = false)
     val studentGcn: String,
 
     @Column(columnDefinition = "INT", nullable = false)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PointHistoryMapper.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/mapper/PointHistoryMapper.kt
@@ -3,14 +3,14 @@ package team.aliens.dms.persistence.point.mapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.point.model.PointHistory
-import team.aliens.dms.persistence.GenericMapper
+import team.aliens.dms.persistence.EncryptableGenericMapper
 import team.aliens.dms.persistence.point.entity.PointHistoryJpaEntity
 import team.aliens.dms.persistence.school.repository.SchoolJpaRepository
 
 @Component
 class PointHistoryMapper(
     private val schoolRepository: SchoolJpaRepository
-) : GenericMapper<PointHistory, PointHistoryJpaEntity> {
+) : EncryptableGenericMapper<PointHistory, PointHistoryJpaEntity> {
 
     override fun toDomain(entity: PointHistoryJpaEntity?): PointHistory? {
         return entity?.let {

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/school/SchoolPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/school/SchoolPersistenceAdapter.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.persistence.school
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import team.aliens.dms.domain.school.model.AvailableFeature
 import team.aliens.dms.domain.school.model.School
 import team.aliens.dms.domain.school.spi.SchoolPort
 import team.aliens.dms.persistence.school.mapper.AvailableFeatureMapper
@@ -25,6 +26,12 @@ class SchoolPersistenceAdapter(
     override fun saveSchool(school: School) = schoolMapper.toDomain(
         schoolRepository.save(
             schoolMapper.toEntity(school)
+        )
+    )!!
+
+    override fun saveAvailableFeature(availableFeature: AvailableFeature) = availableFeatureMapper.toDomain(
+        availableFeatureRepository.save(
+            availableFeatureMapper.toEntity(availableFeature)
         )
     )!!
 

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/SchoolSecretPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/SchoolSecretPersistenceAdapter.kt
@@ -15,10 +15,10 @@ class SchoolSecretPersistenceAdapter(
     private val schoolSecretMapper: SchoolSecretMapper
 ) : SchoolSecretPort {
 
-    @Cacheable("schoolSecret")
+    @Cacheable("schoolSecret", cacheManager = "redisCacheManager")
     override fun querySchoolSecretBySchoolId(schoolId: UUID) =
         schoolSecretRepository.findByIdOrNull(schoolId)
-            ?.let { schoolSecretMapper.toDomain(it) }
+            ?.let { schoolSecretMapper.toDomain(it)?.secretKey }
 
     override fun saveSchoolSecret(schoolSecret: SchoolSecret) {
         schoolSecretRepository.save(

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/SchoolSecretPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/SchoolSecretPersistenceAdapter.kt
@@ -1,0 +1,28 @@
+package team.aliens.dms.persistence.security
+
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import team.aliens.dms.common.model.SchoolSecret
+import team.aliens.dms.common.spi.SchoolSecretPort
+import team.aliens.dms.persistence.security.mapper.SchoolSecretMapper
+import team.aliens.dms.persistence.security.repository.SchoolSecretJpaRepository
+import java.util.UUID
+
+@Component
+class SchoolSecretPersistenceAdapter(
+    private val schoolSecretRepository: SchoolSecretJpaRepository,
+    private val schoolSecretMapper: SchoolSecretMapper
+) : SchoolSecretPort {
+
+    @Cacheable("schoolSecret")
+    override fun querySchoolSecretBySchoolId(schoolId: UUID) =
+        schoolSecretRepository.findByIdOrNull(schoolId)
+            ?.let { schoolSecretMapper.toDomain(it) }
+
+    override fun saveSchoolSecret(schoolSecret: SchoolSecret) {
+        schoolSecretRepository.save(
+            schoolSecretMapper.toEntity(schoolSecret)
+        )
+    }
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/entity/SchoolSecretJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/entity/SchoolSecretJpaEntity.kt
@@ -1,0 +1,32 @@
+package team.aliens.dms.persistence.security.entity
+
+import team.aliens.dms.common.annotation.EncryptType
+import team.aliens.dms.common.annotation.EncryptedColumn
+import team.aliens.dms.persistence.school.entity.SchoolJpaEntity
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.MapsId
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "tbl_school_secret")
+class SchoolSecretJpaEntity(
+
+    @Id
+    val schoolId: UUID,
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", columnDefinition = "BINARY(16)", nullable = false)
+    val school: SchoolJpaEntity?,
+
+    @EncryptedColumn(type = EncryptType.ASYMMETRIC)
+    @Column(columnDefinition = "TEXT", nullable = false)
+    val secretKey: String
+
+)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/mapper/SchoolSecretMapper.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/mapper/SchoolSecretMapper.kt
@@ -1,0 +1,33 @@
+package team.aliens.dms.persistence.security.mapper
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import team.aliens.dms.common.model.SchoolSecret
+import team.aliens.dms.domain.school.exception.SchoolNotFoundException
+import team.aliens.dms.persistence.EncryptableGenericMapper
+import team.aliens.dms.persistence.school.repository.SchoolJpaRepository
+import team.aliens.dms.persistence.security.entity.SchoolSecretJpaEntity
+
+@Component
+class SchoolSecretMapper(
+    private val schoolRepository: SchoolJpaRepository
+) : EncryptableGenericMapper<SchoolSecret, SchoolSecretJpaEntity> {
+
+    override fun toDomain(entity: SchoolSecretJpaEntity?): SchoolSecret? {
+        return entity?.let {
+            SchoolSecret(
+                schoolId = it.schoolId,
+                secretKey = it.secretKey
+            )
+        }
+    }
+
+    override fun toEntity(domain: SchoolSecret): SchoolSecretJpaEntity {
+        val school = schoolRepository.findByIdOrNull(domain.schoolId) ?: throw SchoolNotFoundException
+        return SchoolSecretJpaEntity(
+            schoolId = domain.schoolId,
+            school = school,
+            secretKey = domain.secretKey
+        )
+    }
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/repository/SchoolSecretJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/security/repository/SchoolSecretJpaRepository.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.persistence.security.repository
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import team.aliens.dms.persistence.security.entity.SchoolSecretJpaEntity
+import java.util.UUID
+
+@Repository
+interface SchoolSecretJpaRepository : CrudRepository<SchoolSecretJpaEntity, UUID>

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/entity/StudentJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/entity/StudentJpaEntity.kt
@@ -1,10 +1,5 @@
 package team.aliens.dms.persistence.student.entity
 
-import org.hibernate.annotations.Where
-import team.aliens.dms.domain.student.model.Sex
-import team.aliens.dms.persistence.BaseUUIDEntity
-import team.aliens.dms.persistence.room.entity.RoomJpaEntity
-import team.aliens.dms.persistence.user.entity.UserJpaEntity
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.CascadeType
@@ -17,6 +12,13 @@ import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.OneToOne
 import javax.persistence.Table
+import org.hibernate.annotations.Where
+import team.aliens.dms.common.annotation.EncryptType
+import team.aliens.dms.common.annotation.EncryptedColumn
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.persistence.BaseUUIDEntity
+import team.aliens.dms.persistence.room.entity.RoomJpaEntity
+import team.aliens.dms.persistence.user.entity.UserJpaEntity
 
 @Entity
 @Table(name = "tbl_student")
@@ -45,7 +47,8 @@ class StudentJpaEntity(
     @Column(columnDefinition = "TINYINT UNSIGNED", nullable = false)
     val number: Int,
 
-    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    @EncryptedColumn(type = EncryptType.SYMMETRIC)
+    @Column(columnDefinition = "TEXT", nullable = false)
     val name: String,
 
     @Column(columnDefinition = "VARCHAR(500)", nullable = false)
@@ -57,4 +60,5 @@ class StudentJpaEntity(
 
     @Column(columnDefinition = "DATETIME")
     val deletedAt: LocalDateTime?
+
 ) : BaseUUIDEntity(id)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/mapper/StudentMapper.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/mapper/StudentMapper.kt
@@ -3,7 +3,7 @@ package team.aliens.dms.persistence.student.mapper
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.student.model.Student
-import team.aliens.dms.persistence.GenericMapper
+import team.aliens.dms.persistence.EncryptableGenericMapper
 import team.aliens.dms.persistence.room.repository.RoomJpaRepository
 import team.aliens.dms.persistence.student.entity.StudentJpaEntity
 import team.aliens.dms.persistence.user.repository.UserJpaRepository
@@ -12,7 +12,7 @@ import team.aliens.dms.persistence.user.repository.UserJpaRepository
 class StudentMapper(
     private val roomRepository: RoomJpaRepository,
     private val userRepository: UserJpaRepository
-) : GenericMapper<Student, StudentJpaEntity> {
+) : EncryptableGenericMapper<Student, StudentJpaEntity> {
 
     override fun toDomain(entity: StudentJpaEntity?): Student? {
         return entity?.let {
@@ -47,7 +47,7 @@ class StudentMapper(
             classRoom = domain.classRoom,
             number = domain.number,
             name = domain.name,
-            profileImageUrl = domain.profileImageUrl!!,
+            profileImageUrl = domain.profileImageUrl,
             sex = domain.sex,
             deletedAt = domain.deletedAt
         )

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/vo/QueryStudentWithPointVO.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/vo/QueryStudentWithPointVO.kt
@@ -1,12 +1,23 @@
 package team.aliens.dms.persistence.student.repository.vo
 
 import com.querydsl.core.annotations.QueryProjection
+import team.aliens.dms.common.annotation.EncryptType
+import team.aliens.dms.common.annotation.EncryptedColumn
+import team.aliens.dms.domain.point.spi.vo.StudentWithPointVO
 
-data class QueryStudentWithPointVO @QueryProjection constructor(
-    val name: String,
-    val grade: Int,
-    val classRoom: Int,
-    val number: Int,
-    val bonusTotal: Int?,
-    val minusTotal: Int?
+class QueryStudentWithPointVO @QueryProjection constructor(
+    @EncryptedColumn(type = EncryptType.SYMMETRIC)
+    override val name: String,
+    grade: Int,
+    classRoom: Int,
+    number: Int,
+    bonusTotal: Int?,
+    minusTotal: Int?,
+) : StudentWithPointVO(
+    name = name,
+    grade = grade,
+    classRoom = classRoom,
+    number = number,
+    bonusTotal = bonusTotal ?: 0,
+    minusTotal = minusTotal ?: 0
 )

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/vo/QueryStudentsWithTagVO.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/vo/QueryStudentsWithTagVO.kt
@@ -1,18 +1,40 @@
 package team.aliens.dms.persistence.student.repository.vo
 
 import com.querydsl.core.annotations.QueryProjection
+import team.aliens.dms.common.annotation.EncryptType
+import team.aliens.dms.common.annotation.EncryptedColumn
+import team.aliens.dms.domain.manager.spi.vo.StudentWithTag
 import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.tag.model.Tag
 import team.aliens.dms.persistence.tag.entity.TagJpaEntity
 import java.util.UUID
 
-data class QueryStudentsWithTagVO @QueryProjection constructor(
-    val id: UUID,
-    val name: String,
-    val grade: Int,
-    val classRoom: Int,
-    val number: Int,
-    val roomNumber: String,
-    val profileImageUrl: String,
-    val sex: Sex,
-    val tags: List<TagJpaEntity>
+class QueryStudentsWithTagVO @QueryProjection constructor(
+    id: UUID,
+    @EncryptedColumn(type = EncryptType.SYMMETRIC)
+    override val name: String,
+    grade: Int,
+    classRoom: Int,
+    number: Int,
+    roomNumber: String,
+    profileImageUrl: String,
+    sex: Sex,
+    tags: List<TagJpaEntity>
+) : StudentWithTag(
+    id = id,
+    name = name,
+    grade = grade,
+    classRoom = classRoom,
+    number = number,
+    roomNumber = roomNumber,
+    profileImageUrl = profileImageUrl,
+    sex = sex,
+    tags = tags.map {
+        Tag(
+            id = it.id!!,
+            name = it.name,
+            color = it.color,
+            schoolId = it.school!!.id!!
+        )
+    }
 )

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/school/SchoolWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/school/SchoolWebAdapter.kt
@@ -1,34 +1,38 @@
 package team.aliens.dms.domain.school
 
+import java.util.UUID
+import javax.validation.Valid
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import team.aliens.dms.domain.school.dto.CreateSchoolRequest
 import team.aliens.dms.domain.school.dto.QueryAvailableFeaturesResponse
 import team.aliens.dms.domain.school.dto.SchoolsResponse
 import team.aliens.dms.domain.school.dto.UpdateQuestionRequest
+import team.aliens.dms.domain.school.dto.request.CreateSchoolWebRequest
 import team.aliens.dms.domain.school.dto.request.UpdateQuestionWebRequest
 import team.aliens.dms.domain.school.dto.response.ReissueSchoolCodeResponse
 import team.aliens.dms.domain.school.dto.response.SchoolIdResponse
 import team.aliens.dms.domain.school.dto.response.SchoolQuestionResponse
 import team.aliens.dms.domain.school.usecase.CheckSchoolAnswerUseCase
 import team.aliens.dms.domain.school.usecase.CheckSchoolCodeUseCase
+import team.aliens.dms.domain.school.usecase.CreateSchoolUseCase
 import team.aliens.dms.domain.school.usecase.QueryAvailableFeaturesUseCase
 import team.aliens.dms.domain.school.usecase.QuerySchoolQuestionUseCase
 import team.aliens.dms.domain.school.usecase.QuerySchoolsUseCase
 import team.aliens.dms.domain.school.usecase.ReissueSchoolCodeUseCase
 import team.aliens.dms.domain.school.usecase.UpdateQuestionUseCase
-import java.util.UUID
-import javax.validation.Valid
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotNull
-import javax.validation.constraints.Size
 
 @Validated
 @RequestMapping("/schools")
@@ -40,7 +44,8 @@ class SchoolWebAdapter(
     private val checkSchoolCodeUseCase: CheckSchoolCodeUseCase,
     private val updateQuestionUseCase: UpdateQuestionUseCase,
     private val reissueSchoolCodeUseCase: ReissueSchoolCodeUseCase,
-    private val queryAvailableFeaturesUseCase: QueryAvailableFeaturesUseCase
+    private val queryAvailableFeaturesUseCase: QueryAvailableFeaturesUseCase,
+    private val createSchoolUseCase: CreateSchoolUseCase
 ) {
 
     @GetMapping
@@ -96,5 +101,23 @@ class SchoolWebAdapter(
         )
 
         updateQuestionUseCase.execute(request)
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping
+    fun createSchool(@RequestBody @Valid request: CreateSchoolWebRequest) {
+        createSchoolUseCase.execute(
+            request.run {
+                CreateSchoolRequest(
+                    schoolName = schoolName,
+                    schoolAddress = schoolAddress,
+                    mealService = mealService,
+                    noticeService = noticeService,
+                    pointService = pointService,
+                    studyRoomService = studyRoomService,
+                    remainService = remainService
+                )
+            }
+        )
     }
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/school/dto/request/CreateSchoolWebRequest.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/school/dto/request/CreateSchoolWebRequest.kt
@@ -1,0 +1,11 @@
+package team.aliens.dms.domain.school.dto.request
+
+class CreateSchoolWebRequest(
+    val schoolName: String,
+    val schoolAddress: String,
+    val mealService: Boolean,
+    val noticeService: Boolean,
+    val pointService: Boolean,
+    val studyRoomService: Boolean,
+    val remainService: Boolean
+)


### PR DESCRIPTION
## 작업 내용 설명
- [x] kms를 이용한 데이터 암호화 구현

## 주요 변경 사항
- kms Encrypt 구현 ([참고](https://www.notion.so/teamaliens/DB-04858ee917e94bd7be516a4e3f41d2b5?pvs=4))
- 아직 일부 컬럼에만 적용해놓았고, 정렬 및 검색에 대한 대응방안은 마련하지 않았습니다
    - 어차피 paging이 적용되지 않았으니 조회해온 후에 정렬하는 방식을 생각중입니다.. 
    - 추후 추가 작업 예정입니다

## 결과물

첫 요청인 경우
- encrypt X : 약 256ms
- encrypt O : 약 1374ms

schoolSecret 캐시되어있는 경우
- encrypt X : 약 86~105ms
- encrypt O : 약 79~114ms

secret이 캐시되어있지 않은 경우 조회쿼리 + kms 요청으로 인해 반환에 1초 이상이 더 소요되지만, 캐시 된 경우에는 큰 차이 없는 것으로 보입니다

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #490