### PR TITLE
chore: pointHistory response 필드명

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/point/dto/PointResponse.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/point/dto/PointResponse.kt
@@ -1,14 +1,15 @@
 package team.aliens.dms.domain.point.dto
 
+import java.util.UUID
 import team.aliens.dms.domain.point.model.PointOption
 import team.aliens.dms.domain.point.model.PointType
 import team.aliens.dms.domain.point.spi.vo.AllPointHistoryVO
 import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
-import java.util.UUID
 
 data class PointHistoryResponse(
     val totalPoint: Int? = null,
-    val pointHistories: List<PointHistoryVO>
+    val pointHistories: List<PointHistoryVO>,
+    val points: List<PointHistoryVO> = pointHistories // TODO: 상벌점 내역 조회 api에 사용, 앱과 협의 후 삭제
 )
 
 data class AllPointHistoryResponse(

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/point/dto/PointResponse.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/point/dto/PointResponse.kt
@@ -9,7 +9,8 @@ import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 data class PointHistoryResponse(
     val totalPoint: Int? = null,
     val pointHistories: List<PointHistoryVO>,
-    val points: List<PointHistoryVO> = pointHistories // TODO: 상벌점 내역 조회 api에 사용, 앱과 협의 후 삭제
+    @Deprecated("상벌점 내역 조회 api에 사용, 앱과 협의 후 삭제")
+    val points: List<PointHistoryVO> = pointHistories
 )
 
 data class AllPointHistoryResponse(


### PR DESCRIPTION
## 작업 내용 설명
- class를 합치는건 리팩토링 목적에 크게 벗어나는 것 같아서 두 이름으로 모두 반환하도록 설정해놓았습니다
- 나중에 꼭 지워야합니다.
- 구버전 지원하기 위해 필드명, url 바뀌는건 항상 이런식으로 해놨다가 나중에 수정해야할 것 같아용..

## 주요 변경 사항
- <!-- 변경 사항 작성 -->
- <!-- 변경 사항 작성 -->

## 결과물
<img width="712" alt="image" src="https://github.com/team-aliens/DMS-Backend/assets/81006587/61b91981-0acb-4c0c-90f8-1f35ea6d4926">
<img width="585" alt="image" src="https://github.com/team-aliens/DMS-Backend/assets/81006587/1603dc35-7e9b-40f0-9532-55d6944b523b">


## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved # <!-- 이슈번호 -->