### PR TITLE
merge: (#525) 알림 저장 및 조회 api 

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/common/spi/EventPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/common/spi/EventPort.kt
@@ -1,9 +1,10 @@
 package team.aliens.dms.common.spi
 
+import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.Notification
 
 interface NotificationEventPort {
-    fun publishNotification(deviceToken: String, notification: Notification)
+    fun publishNotification(deviceToken: DeviceToken, notification: Notification)
     fun publishNotificationToAllByTopic(notification: Notification)
 }
 

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notice/service/CommandNoticeServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notice/service/CommandNoticeServiceImpl.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.domain.notice.service
 
 import team.aliens.dms.common.annotation.Service
 import team.aliens.dms.common.spi.NotificationEventPort
+import team.aliens.dms.common.spi.SecurityPort
 import team.aliens.dms.domain.notice.model.Notice
 import team.aliens.dms.domain.notice.spi.CommandNoticePort
 import team.aliens.dms.domain.notification.model.Notification
@@ -9,16 +10,19 @@ import team.aliens.dms.domain.notification.model.Notification
 @Service
 class CommandNoticeServiceImpl(
     private val commandNoticePort: CommandNoticePort,
-    private val notificationEventPort: NotificationEventPort
+    private val notificationEventPort: NotificationEventPort,
+    private val securityPort: SecurityPort
 ) : CommandNoticeService {
 
-    override fun saveNotice(notice: Notice) =
-        commandNoticePort.saveNotice(notice)
+    override fun saveNotice(notice: Notice): Notice {
+        val schoolId = securityPort.getCurrentUserSchoolId()
+        return commandNoticePort.saveNotice(notice)
             .also {
                 notificationEventPort.publishNotificationToAllByTopic(
-                    Notification.NoticeNotification(notice)
+                    Notification.NoticeNotification(schoolId, it)
                 )
             }
+    }
 
     override fun deleteNotice(notice: Notice) {
         commandNoticePort.deleteNotice(notice)

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/dto/NotificationResponse.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/dto/NotificationResponse.kt
@@ -1,0 +1,48 @@
+package team.aliens.dms.domain.notification.dto
+
+import java.time.LocalDateTime
+import java.util.UUID
+import team.aliens.dms.domain.notification.model.Topic
+import team.aliens.dms.domain.notification.model.UserNotification
+
+data class NotificationsResponse(
+    val notifications: List<NotificationResponse>
+) {
+    companion object {
+        fun of(userNotifications: List<UserNotification>) =
+            NotificationsResponse(
+                userNotifications.map { NotificationResponse.of(it) }
+            )
+    }
+}
+
+data class NotificationResponse(
+    val id: UUID,
+    val topic: Topic,
+    val identifier: String?,
+    val title: String,
+    val content: String,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun of(userNotification: UserNotification) = userNotification.run {
+            NotificationResponse(
+                id = id,
+                topic = topic,
+                identifier = identifier,
+                title = title,
+                content = content,
+                createdAt = createdAt
+            )
+        }
+    }
+}
+
+data class TopicSubscribesResponse(
+    val topicSubscribes: List<TopicSubscribeResponse>
+)
+
+data class TopicSubscribeResponse(
+    val topic: Topic,
+    val isSubscribed: Boolean
+)

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/model/Notification.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/model/Notification.kt
@@ -1,21 +1,52 @@
 package team.aliens.dms.domain.notification.model
 
+import java.time.LocalDateTime
+import java.util.UUID
 import team.aliens.dms.domain.notice.model.Notice
 
 sealed class Notification(
+
+    val schoolId: UUID,
+
     val topic: Topic,
+
     val identifier: String?,
+
     val title: String,
+
     val content: String,
-    val threadId: String
+
+    val threadId: String,
+
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    private val isSaveRequired: Boolean
+
 ) {
+    fun toUserNotification(userId: UUID): UserNotification =
+        UserNotification(
+            userId = userId,
+            topic = topic,
+            identifier = identifier,
+            title = title,
+            content = content,
+            createdAt = createdAt
+        )
+
+    fun runIfSaveRequired(function: () -> Unit) {
+        if (isSaveRequired) function.invoke()
+    }
+
     class NoticeNotification(
+        schoolId: UUID,
         notice: Notice
     ) : Notification(
+        schoolId = schoolId,
         topic = Topic.NOTICE,
         identifier = notice.id.toString(),
         title = "${notice.title}",
         content = "기숙사 공지가 등록되었습니다.",
-        threadId = notice.id.toString()
+        threadId = notice.id.toString(),
+        isSaveRequired = true
     )
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/model/UserNotification.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/model/UserNotification.kt
@@ -1,0 +1,22 @@
+package team.aliens.dms.domain.notification.model
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+class UserNotification(
+
+    val id: UUID = UUID(0, 0),
+
+    val userId: UUID,
+
+    val topic: Topic,
+
+    val identifier: String?,
+
+    val title: String,
+
+    val content: String,
+
+    val createdAt: LocalDateTime
+
+)

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationService.kt
@@ -1,8 +1,10 @@
 package team.aliens.dms.domain.notification.service
 
+import java.util.UUID
 import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.Notification
 import team.aliens.dms.domain.notification.model.Topic
+import team.aliens.dms.domain.notification.model.UserNotification
 
 interface NotificationService {
 
@@ -15,13 +17,15 @@ interface NotificationService {
     fun updateSubscribes(deviceToken: String, topicsToSubscribe: List<Pair<Topic, Boolean>>)
 
     fun sendMessage(
-        deviceToken: String,
+        deviceToken: DeviceToken,
         notification: Notification
     )
 
-    fun sendMessages(deviceTokens: List<String>, notification: Notification)
+    fun sendMessages(deviceTokens: List<DeviceToken>, notification: Notification)
 
     fun sendMessagesByTopic(
         notification: Notification
     )
+
+    fun getUserNotificationsByUserId(userId: UUID): List<UserNotification>
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/spi/UserNotificationPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/spi/UserNotificationPort.kt
@@ -1,0 +1,13 @@
+package team.aliens.dms.domain.notification.spi
+
+import java.util.UUID
+import team.aliens.dms.domain.notification.model.UserNotification
+
+interface UserNotificationPort {
+
+    fun saveUserNotification(userNotification: UserNotification): UserNotification
+
+    fun saveUserNotifications(userNotifications: List<UserNotification>)
+
+    fun queryUserNotificationByUserId(userId: UUID): List<UserNotification>
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/QueryMyNotificationsUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/QueryMyNotificationsUseCase.kt
@@ -1,0 +1,20 @@
+package team.aliens.dms.domain.notification.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.notification.dto.NotificationsResponse
+import team.aliens.dms.domain.notification.service.NotificationService
+import team.aliens.dms.domain.user.service.UserService
+
+@ReadOnlyUseCase
+class QueryMyNotificationsUseCase(
+    private val userService: UserService,
+    private val notificationService: NotificationService
+) {
+
+    fun execute(): NotificationsResponse {
+        val user = userService.getCurrentUser()
+        return NotificationsResponse.of(
+            notificationService.getUserNotificationsByUserId(user.id)
+        )
+    }
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/user/spi/QueryUserPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/user/spi/QueryUserPort.kt
@@ -14,6 +14,8 @@ interface QueryUserPort {
 
     fun queryUserBySchoolIdAndAuthority(schoolId: UUID, authority: Authority): User?
 
+    fun queryUsersBySchoolId(schoolId: UUID): List<User>
+
     fun existsUserByEmail(email: String): Boolean
 
     fun existsUserByAccountId(accountId: String): Boolean

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/event/EventAdapter.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/event/EventAdapter.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.event
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import team.aliens.dms.common.spi.EventPort
+import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.Notification
 
 @Component
@@ -10,10 +11,7 @@ class EventAdapter(
     private val eventPublisher: ApplicationEventPublisher
 ) : EventPort {
 
-    override fun publishNotification(
-        deviceToken: String,
-        notification: Notification
-    ) {
+    override fun publishNotification(deviceToken: DeviceToken, notification: Notification) {
         eventPublisher.publishEvent(
             SingleNotificationEvent(
                 deviceToken = deviceToken,

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/event/EventHandler.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/event/EventHandler.kt
@@ -1,6 +1,8 @@
 package team.aliens.dms.event
 
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 import team.aliens.dms.domain.notification.service.NotificationService
@@ -10,26 +12,28 @@ class NotificationEventHandler(
     private val notificationService: NotificationService
 ) {
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onNotificationEvent(event: TopicNotificationEvent) {
-
-        when (event) {
-            is SingleNotificationEvent -> {
-                notificationService.sendMessage(
-                    deviceToken = event.deviceToken,
-                    notification = event.notification
-                )
-            }
-            is GroupNotificationEvent -> {
-                notificationService.sendMessages(
-                    deviceTokens = event.deviceTokens,
-                    notification = event.notification
-                )
-            }
-            else -> {
-                notificationService.sendMessagesByTopic(
-                    notification = event.notification
-                )
+        event.run {
+            when (this) {
+                is SingleNotificationEvent -> {
+                    notificationService.sendMessage(
+                        deviceToken = deviceToken,
+                        notification = notification
+                    )
+                }
+                is GroupNotificationEvent -> {
+                    notificationService.sendMessages(
+                        deviceTokens = deviceTokens,
+                        notification = notification
+                    )
+                }
+                else -> {
+                    notificationService.sendMessagesByTopic(
+                        notification = event.notification
+                    )
+                }
             }
         }
     }

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/event/Events.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/event/Events.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.event
 
 import org.springframework.context.ApplicationEvent
+import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.Notification
 
 open class TopicNotificationEvent(
@@ -8,11 +9,11 @@ open class TopicNotificationEvent(
 ) : ApplicationEvent(notification)
 
 open class GroupNotificationEvent(
-    val deviceTokens: List<String>,
+    val deviceTokens: List<DeviceToken>,
     notification: Notification
 ) : TopicNotificationEvent(notification)
 
 class SingleNotificationEvent(
-    val deviceToken: String,
+    val deviceToken: DeviceToken,
     notification: Notification
 ) : TopicNotificationEvent(notification)

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -34,6 +34,7 @@ class SecurityConfig(
             .authorizeRequests()
             // healthcheck
             .antMatchers(HttpMethod.GET, "/").permitAll()
+
             // /auth
             .antMatchers(HttpMethod.GET, "/auth/account-id").permitAll()
             .antMatchers(HttpMethod.GET, "/auth/email").permitAll()
@@ -41,9 +42,11 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/auth/code").permitAll()
             .antMatchers(HttpMethod.POST, "/auth/tokens").permitAll()
             .antMatchers(HttpMethod.PUT, "/auth/reissue").permitAll()
+
             // /users
             .antMatchers(HttpMethod.GET, "/users/password").hasAnyAuthority(STUDENT.name, MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/users/password").hasAnyAuthority(STUDENT.name, MANAGER.name)
+            
             // /students
             .antMatchers(HttpMethod.GET, "/students/email/duplication").permitAll()
             .antMatchers(HttpMethod.GET, "/students/account-id/duplication").permitAll()
@@ -54,6 +57,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.PATCH, "/students/password/initialization").permitAll()
             .antMatchers(HttpMethod.PATCH, "/students/profile").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.DELETE, "/students").hasAuthority(STUDENT.name)
+            
             // /managers
             .antMatchers(HttpMethod.GET, "/managers/account-id/{school-id}").permitAll()
             .antMatchers(HttpMethod.GET, "/managers/students").hasAuthority(MANAGER.name)
@@ -64,6 +68,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/managers/students/file").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.POST, "/managers/students/file/room").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.POST, "/managers/students/file/gcn").hasAuthority(MANAGER.name)
+            
             // /schools
             .antMatchers(HttpMethod.GET, "/schools").permitAll()
             .antMatchers(HttpMethod.GET, "/schools/question/{school-id}").permitAll()
@@ -72,6 +77,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.PATCH, "/schools/question").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/schools/code").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/schools/available-features").hasAnyAuthority(MANAGER.name, STUDENT.name)
+            
             // /notices
             .antMatchers(HttpMethod.GET, "/notices/status").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.GET, "/notices").hasAnyAuthority(STUDENT.name, MANAGER.name)
@@ -79,12 +85,15 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/notices").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/notices/{notice-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/notices/{notice-id}").hasAuthority(MANAGER.name)
+            
             // /files
             .antMatchers(HttpMethod.POST, "/files").permitAll()
             .antMatchers(HttpMethod.POST, "/files/verified-student").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/files/url").permitAll()
+            
             // /meals
             .antMatchers(HttpMethod.GET, "/meals/{date}").hasAuthority(STUDENT.name)
+            
             // /points
             .antMatchers(HttpMethod.GET, "/points").hasAuthority(STUDENT.name)
             .antMatchers(HttpMethod.POST, "/points/options").hasAuthority(MANAGER.name)
@@ -97,11 +106,13 @@ class SecurityConfig(
             .antMatchers(HttpMethod.PUT, "/points/history/{point-history-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/points/options").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/points/options/{point-option-id}").hasAuthority(MANAGER.name)
+            
             // /templates
             .antMatchers(HttpMethod.GET, "/templates").permitAll()
             .antMatchers(HttpMethod.POST, "/templates").permitAll()
             .antMatchers(HttpMethod.PATCH, "/templates").permitAll()
             .antMatchers(HttpMethod.DELETE, "/templates").permitAll()
+            
             // /tags
             .antMatchers(HttpMethod.GET, "/tags").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/tags/{tag-id}").hasAuthority(MANAGER.name)
@@ -109,6 +120,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/tags/students").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/tags/students").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PATCH, "/tags/{tag-id}").hasAuthority(MANAGER.name)
+            
             // /study-rooms
             .antMatchers(HttpMethod.GET, "/study-rooms/available-time").hasAnyAuthority(STUDENT.name, MANAGER.name)
             .antMatchers(HttpMethod.PUT, "/study-rooms/available-time").hasAuthority(MANAGER.name)
@@ -131,6 +143,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.PATCH, "/study-rooms/time-slots/{time-slot-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/study-rooms/time-slots/{time-slot-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.POST, "/study-rooms/students/file").hasAuthority(MANAGER.name)
+            
             // /remains
             .antMatchers(HttpMethod.PUT, "/remains/available-time").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.PUT, "/remains/{remain-option-id}").hasAuthority(STUDENT.name)
@@ -141,7 +154,10 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/remains/available-time").hasAnyAuthority(STUDENT.name, MANAGER.name)
             .antMatchers(HttpMethod.DELETE, "/remains/options/{remain-option-id}").hasAuthority(MANAGER.name)
             .antMatchers(HttpMethod.GET, "/remains/status/file").hasAuthority(MANAGER.name)
-            .antMatchers(HttpMethod.GET, "/notifications/token").authenticated()
+            
+            // /notifications
+            .antMatchers(HttpMethod.POST, "/notifications/token").authenticated()
+            .antMatchers(HttpMethod.GET, "/notifications").authenticated()
             .antMatchers(HttpMethod.POST, "/notifications/topic").authenticated()
             .antMatchers(HttpMethod.DELETE, "/notifications/token").authenticated()
             .antMatchers(HttpMethod.PATCH, "/notifications/token").authenticated()

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/UserNotificationPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/UserNotificationPersistenceAdapter.kt
@@ -1,0 +1,34 @@
+package team.aliens.dms.persistence.notification
+
+import java.util.UUID
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.notification.model.UserNotification
+import team.aliens.dms.domain.notification.spi.UserNotificationPort
+import team.aliens.dms.persistence.notification.mapper.UserNotificationMapper
+import team.aliens.dms.persistence.notification.repository.UserNotificationJpaRepository
+
+@Component
+class UserNotificationPersistenceAdapter(
+    private val userNotificationMapper: UserNotificationMapper,
+    private val userNotificationRepository: UserNotificationJpaRepository
+) : UserNotificationPort {
+
+    override fun saveUserNotification(userNotification: UserNotification) =
+        userNotificationMapper.toDomain(
+            userNotificationRepository.save(
+                userNotificationMapper.toEntity(userNotification)
+            )
+        )!!
+
+    override fun saveUserNotifications(userNotifications: List<UserNotification>) {
+        userNotificationRepository.saveAll(
+            userNotifications.map {
+                userNotificationMapper.toEntity(it)
+            }
+        )
+    }
+
+    override fun queryUserNotificationByUserId(userId: UUID) =
+        userNotificationRepository.findByUserId(userId)
+            .map { userNotificationMapper.toDomain(it)!! }
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/entity/UserNotificationJpaEntity.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/entity/UserNotificationJpaEntity.kt
@@ -1,0 +1,43 @@
+package team.aliens.dms.persistence.notification.entity
+
+import java.time.LocalDateTime
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+import team.aliens.dms.domain.notification.model.Topic
+import team.aliens.dms.persistence.BaseUUIDEntity
+import team.aliens.dms.persistence.user.entity.UserJpaEntity
+
+@Entity
+@Table(name = "tbl_user_notification")
+class UserNotificationJpaEntity(
+
+    id: UUID?,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)", nullable = false)
+    val user: UserJpaEntity?,
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)", nullable = false)
+    val topic: Topic,
+
+    @Column(columnDefinition = "VARCHAR(500)")
+    val identifier: String?,
+
+    @Column(columnDefinition = "VARCHAR(500)", nullable = false)
+    val title: String,
+
+    @Column(columnDefinition = "VARCHAR(500)", nullable = false)
+    val content: String,
+
+    @Column(columnDefinition = "DATETIME(6)", nullable = false)
+    val createdAt: LocalDateTime
+
+) : BaseUUIDEntity(id)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/mapper/UserNotificationMapper.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/mapper/UserNotificationMapper.kt
@@ -1,0 +1,43 @@
+package team.aliens.dms.persistence.notification.mapper
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.notification.model.UserNotification
+import team.aliens.dms.domain.user.exception.UserNotFoundException
+import team.aliens.dms.persistence.GenericMapper
+import team.aliens.dms.persistence.notification.entity.UserNotificationJpaEntity
+import team.aliens.dms.persistence.user.repository.UserJpaRepository
+
+@Component
+class UserNotificationMapper(
+    private val userRepository: UserJpaRepository
+) : GenericMapper<UserNotification, UserNotificationJpaEntity> {
+
+    override fun toDomain(entity: UserNotificationJpaEntity?): UserNotification? {
+        return entity?.let {
+            UserNotification(
+                id = it.id!!,
+                userId = it.user!!.id!!,
+                topic = it.topic,
+                identifier = it.identifier,
+                title = it.title,
+                content = it.content,
+                createdAt = it.createdAt
+            )
+        }
+    }
+
+    override fun toEntity(domain: UserNotification): UserNotificationJpaEntity {
+        val user = userRepository.findByIdOrNull(domain.userId) ?: throw UserNotFoundException
+
+        return UserNotificationJpaEntity(
+            id = domain.id,
+            user = user,
+            topic = domain.topic,
+            identifier = domain.identifier,
+            title = domain.title,
+            content = domain.content,
+            createdAt = domain.createdAt
+        )
+    }
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/repository/UserNotificationJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/repository/UserNotificationJpaRepository.kt
@@ -1,0 +1,9 @@
+package team.aliens.dms.persistence.notification.repository
+
+import java.util.UUID
+import org.springframework.data.repository.CrudRepository
+import team.aliens.dms.persistence.notification.entity.UserNotificationJpaEntity
+
+interface UserNotificationJpaRepository : CrudRepository<UserNotificationJpaEntity, UUID> {
+    fun findByUserId(userId: UUID): List<UserNotificationJpaEntity>
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/user/UserPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/user/UserPersistenceAdapter.kt
@@ -37,6 +37,10 @@ class UserPersistenceAdapter(
         userRepository.findBySchoolIdAndAuthority(schoolId, authority)
     )
 
+    override fun queryUsersBySchoolId(schoolId: UUID) =
+        userRepository.findBySchoolId(schoolId)
+            .map { userMapper.toDomain(it)!! }
+
     override fun queryUserByEmail(email: String) = userMapper.toDomain(
         userRepository.findByEmail(email)
     )

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/user/repository/UserJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/user/repository/UserJpaRepository.kt
@@ -19,6 +19,8 @@ interface UserJpaRepository : CrudRepository<UserJpaEntity, UUID> {
 
     fun findBySchoolIdAndAuthority(schoolId: UUID, authority: Authority): UserJpaEntity?
 
+    fun findBySchoolId(schoolId: UUID): List<UserJpaEntity>
+
     fun findByEmail(email: String): UserJpaEntity?
 
     fun findByAccountId(accountId: String): UserJpaEntity?

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/notification/NotificationWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/notification/NotificationWebAdapter.kt
@@ -1,27 +1,31 @@
 package team.aliens.dms.domain.notification
 
+import javax.validation.Valid
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.aliens.dms.domain.notification.dto.NotificationsResponse
 import team.aliens.dms.domain.notification.dto.SetDeviceTokenRequest
 import team.aliens.dms.domain.notification.dto.request.DeviceTokenRequest
 import team.aliens.dms.domain.notification.dto.request.TopicRequest
 import team.aliens.dms.domain.notification.dto.request.UpdateTopicSubscribesWebRequest
+import team.aliens.dms.domain.notification.usecase.QueryMyNotificationsUseCase
 import team.aliens.dms.domain.notification.usecase.SetDeviceTokenUseCase
 import team.aliens.dms.domain.notification.usecase.SubscribeTopicUseCase
 import team.aliens.dms.domain.notification.usecase.UnsubscribeTopicUseCase
 import team.aliens.dms.domain.notification.usecase.UpdateTopicSubscribesUseCase
-import javax.validation.Valid
 
 @Validated
 @RequestMapping("/notifications")
 @RestController
 class NotificationWebAdapter(
     private val setDeviceTokenUseCase: SetDeviceTokenUseCase,
+    private val queryMyNotificationsUseCase: QueryMyNotificationsUseCase,
     private val subscribeTopicUseCase: SubscribeTopicUseCase,
     private val unsubscribeTopicUseCase: UnsubscribeTopicUseCase,
     private val updateTopicSubscribesUseCase: UpdateTopicSubscribesUseCase
@@ -32,6 +36,11 @@ class NotificationWebAdapter(
         setDeviceTokenUseCase.execute(
             SetDeviceTokenRequest(deviceToken = request.deviceToken)
         )
+    }
+
+    @GetMapping
+    fun queryMyNotifications(): NotificationsResponse {
+        return queryMyNotificationsUseCase.execute()
     }
 
     @PostMapping("/topic")


### PR DESCRIPTION
## 작업 내용 설명
- [x] 유저별 알림 저장 구현
- [x] 내 알림 조회 api (GET /notifications)

## 주요 변경 사항
erd
- identifier는 앱에서 알림을 클릭했을때의 동작을 위한 구분 정보입니다 (ex 공지 눌렀을때 identifier에 있는 공지 id를 통해 이동)
<img width="537" alt="image" src="https://github.com/team-aliens/DMS-Backend/assets/81006587/1177be61-9716-4275-a55c-bdb3ba15d4ca">

## 결과물
<img width="638" alt="image" src="https://github.com/team-aliens/DMS-Backend/assets/81006587/06e542f0-f807-4651-ae88-b9fb92327eb0">

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #525