### PR TITLE
chore: (#605) 외출 취소 확인 로직 변경

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/outing/model/OutingApplication.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/outing/model/OutingApplication.kt
@@ -36,7 +36,7 @@ data class OutingApplication(
 ) : SchoolIdDomain {
 
     fun checkCancelable(status: OutingStatus) {
-        if (status != OutingStatus.REQUESTED) {
+        if (status != OutingStatus.APPROVED) {
             throw OutingTypeMismatchException
         }
     }

--- a/dms-core/src/test/kotlin/team/aliens/dms/domain/outing/model/OutingApplicationTest.kt
+++ b/dms-core/src/test/kotlin/team/aliens/dms/domain/outing/model/OutingApplicationTest.kt
@@ -10,17 +10,17 @@ class OutingApplicationTest : DescribeSpec({
 
     describe("checkCancelable") {
         context("외출 신청 상태가 REQUESTED이면") {
-            val outingApplication = createOutingApplicationStub(outingStatus = OutingStatus.REQUESTED)
+            val outingApplication = createOutingApplicationStub(outingStatus = OutingStatus.APPROVED)
 
             it("외출 취소가 가능하다") {
                 shouldNotThrowAny {
-                    outingApplication.checkCancelable(OutingStatus.REQUESTED)
+                    outingApplication.checkCancelable(OutingStatus.APPROVED)
                 }
             }
         }
 
         context("외출 신청 상태가 REQUESTED가 아니면") {
-            val outingApplication = createOutingApplicationStub(outingStatus = OutingStatus.REQUESTED)
+            val outingApplication = createOutingApplicationStub(outingStatus = OutingStatus.APPROVED)
 
             it("외출 취소가 불가능하다") {
                 shouldThrow<OutingTypeMismatchException> {


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 기존 OutingStatus가 REQUEST일때만 취소됬었던 상황 -> 외출 신청시 OutingStatus의 기본값이 APPROVED로 바뀌면서 APPROVED일때만 외출 취소 가능하게 변경
- [ ] <!-- 작업 내용 작성 -->

## 주요 변경 사항
- <!-- 변경 사항 작성 -->
- <!-- 변경 사항 작성 -->

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #605 