### PR TITLE
merge: (#671) 엑셀 API 메서드 분리

### DIFF
--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
@@ -67,42 +67,6 @@ class ExcelPort {
         }
     }
 
-    fun formatOutingWorkSheet(
-        worksheet: Sheet,
-    ) {
-        val lastCellNum = worksheet.getRow(0).lastCellNum.toInt()
-        worksheet.apply {
-            // 정렬 필터 적용
-            setAutoFilter(CellRangeAddress(0, 0, 0, lastCellNum - 1))
-            createFreezePane(0, 1)
-            // 데이터에 맞춰 폭 조정
-            (0 until lastCellNum)
-                .map {
-                    autoSizeColumn(it)
-                    val width = getColumnWidth(it)
-                    setColumnWidth(it, ((width * 1.3) - 50).toInt())
-                }
-        }
-    }
-
-    fun formatWorkSheet(
-        worksheet: Sheet,
-    ) {
-        val lastCellNum = worksheet.getRow(0).lastCellNum.toInt()
-        worksheet.apply {
-            // 정렬 필터 적용
-            setAutoFilter(CellRangeAddress(0, 0, 0, lastCellNum - 1))
-            createFreezePane(0, 1)
-            // 데이터에 맞춰 폭 조정
-            (0 until lastCellNum)
-                .map {
-                    autoSizeColumn(it)
-                    val width = getColumnWidth(it)
-                    setColumnWidth(it, width + 900)
-                }
-        }
-    }
-
     fun createExcelSheet(
         attributes: List<String>,
         dataList: List<List<String?>>
@@ -155,6 +119,40 @@ class ExcelPort {
         ByteArrayOutputStream().use { stream ->
             workbook.write(stream)
             return stream.toByteArray()
+        }
+    }
+
+    fun formatOutingWorkSheet(
+        worksheet: Sheet,
+    ) {
+        val lastCellNum = worksheet.getRow(0).lastCellNum.toInt()
+        worksheet.apply {
+            // 정렬 필터 적용
+            setAutoFilter(CellRangeAddress(0, 0, 0, lastCellNum - 1))
+            createFreezePane(0, 1)
+            // 데이터에 맞춰 폭 조정
+            (0 until lastCellNum)
+                .map {
+                    autoSizeColumn(it)
+                    val width = getColumnWidth(it)
+        }
+    }
+
+    fun formatWorkSheet(
+        worksheet: Sheet,
+    ) {
+        val lastCellNum = worksheet.getRow(0).lastCellNum.toInt()
+        worksheet.apply {
+            // 정렬 필터 적용
+            setAutoFilter(CellRangeAddress(0, 0, 0, lastCellNum - 1))
+            createFreezePane(0, 1)
+            // 데이터에 맞춰 폭 조정
+            (0 until lastCellNum)
+                .map {
+                    autoSizeColumn(it)
+                    val width = getColumnWidth(it)
+                    setColumnWidth(it, width + 900)
+                }
         }
     }
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
@@ -22,8 +22,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.function.Function
 
-@Component
-class ExcelPort {
+abstract class ExcelPort {
     fun <T> getExcelInfo(worksheet: Sheet, function: Function<Row, T>): List<T?> {
 
         val invalidRowIdxes = mutableListOf<Int>()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
@@ -1,0 +1,223 @@
+package team.aliens.dms.thirdparty.parser.port
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook
+import org.apache.poi.ss.usermodel.Cell
+import org.apache.poi.ss.usermodel.CellStyle
+import org.apache.poi.ss.usermodel.HorizontalAlignment
+import org.apache.poi.ss.usermodel.IndexedColors
+import org.apache.poi.ss.usermodel.Row
+import org.apache.poi.ss.usermodel.Sheet
+import org.apache.poi.ss.usermodel.VerticalAlignment
+import org.apache.poi.ss.usermodel.Workbook
+import org.apache.poi.ss.util.CellRangeAddress
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.springframework.stereotype.Component
+import team.aliens.dms.domain.file.FileExtension.XLS
+import team.aliens.dms.domain.file.FileExtension.XLSX
+import team.aliens.dms.thirdparty.parser.exception.BadExcelFormatException
+import team.aliens.dms.thirdparty.parser.exception.ExcelExtensionMismatchException
+import team.aliens.dms.thirdparty.parser.exception.ExcelInvalidFileException
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.function.Function
+
+@Component
+class ExcelPort {
+    fun <T> getExcelInfo(worksheet: Sheet, function: Function<Row, T>): List<T?> {
+
+        val invalidRowIdxes = mutableListOf<Int>()
+
+        val results = (1..worksheet.lastRowNum).map { i ->
+            val row = worksheet.getRow(i)
+            if (row.isFirstCellBlank()) return@map null
+
+            try {
+                function.apply(row)
+            } catch (e: Exception) {
+                invalidRowIdxes.add(i + 1) // poi idx 0부터 시작, 엑셀 행은 1부터 시작
+                null
+            }
+        }
+
+        if (invalidRowIdxes.isNotEmpty()) {
+            throw BadExcelFormatException(invalidRowIdxes = invalidRowIdxes)
+        }
+
+        return results
+    }
+
+    private fun Row.isFirstCellBlank() = cellIterator().next().cellType == Cell.CELL_TYPE_BLANK
+
+    fun transferToExcel(file: File): Workbook {
+        val inputStream = file.inputStream()
+
+        return inputStream.use {
+            runCatching {
+                when (file.extension.lowercase()) {
+                    XLS -> HSSFWorkbook(inputStream)
+                    XLSX -> XSSFWorkbook(inputStream)
+                    else -> throw ExcelExtensionMismatchException
+                }
+            }.also {
+                file.delete()
+            }.onFailure {
+                it.printStackTrace()
+                throw ExcelInvalidFileException
+            }.getOrThrow()
+        }
+    }
+
+    fun formatOutingWorkSheet(
+        worksheet: Sheet,
+    ) {
+        val lastCellNum = worksheet.getRow(0).lastCellNum.toInt()
+        worksheet.apply {
+            // 정렬 필터 적용
+            setAutoFilter(CellRangeAddress(0, 0, 0, lastCellNum - 1))
+            createFreezePane(0, 1)
+            // 데이터에 맞춰 폭 조정
+            (0 until lastCellNum)
+                .map {
+                    autoSizeColumn(it)
+                    val width = getColumnWidth(it)
+                    setColumnWidth(it, ((width * 1.3) - 50).toInt())
+                }
+        }
+    }
+
+    fun formatWorkSheet(
+        worksheet: Sheet,
+    ) {
+        val lastCellNum = worksheet.getRow(0).lastCellNum.toInt()
+        worksheet.apply {
+            // 정렬 필터 적용
+            setAutoFilter(CellRangeAddress(0, 0, 0, lastCellNum - 1))
+            createFreezePane(0, 1)
+            // 데이터에 맞춰 폭 조정
+            (0 until lastCellNum)
+                .map {
+                    autoSizeColumn(it)
+                    val width = getColumnWidth(it)
+                    setColumnWidth(it, width + 900)
+                }
+        }
+    }
+
+    fun createExcelSheet(
+        attributes: List<String>,
+        dataList: List<List<String?>>
+    ): ByteArray {
+        val workbook = XSSFWorkbook()
+        val sheet = workbook.createSheet()
+
+        val headerRow = sheet.createRow(0)
+        insertDataAtRow(headerRow, attributes, getHeaderCellStyle(workbook))
+
+        dataList.forEachIndexed { idx, data ->
+            val row = sheet.createRow(idx + 1)
+            insertDataAtRow(row, data, getDefaultCellStyle(workbook))
+        }
+        formatWorkSheet(sheet)
+
+        ByteArrayOutputStream().use { stream ->
+            workbook.write(stream)
+            return stream.toByteArray()
+        }
+    }
+
+    fun createGroupExcelSheet(
+        attributes: List<String>,
+        dataListSet: List<List<List<String?>>>,
+        colors: List<IndexedColors> = listOf(IndexedColors.AUTOMATIC)
+    ): ByteArray {
+        val workbook = XSSFWorkbook()
+        val sheet = workbook.createSheet()
+
+        val headerRow = sheet.createRow(0)
+        insertDataAtRow(headerRow, attributes, getHeaderCellStyle(workbook))
+
+        var idx = 1;
+        dataListSet.forEachIndexed { setIdx, dataList -> // 각 그룹마다 지정된 색을 받음.
+            val color = colors[setIdx % colors.size]
+
+            dataList.forEach { data ->
+                val row = sheet.createRow(idx++)
+                insertDataAtRow(
+                    row = row,
+                    data = data,
+                    style = getDefaultCellStyle(workbook),
+                    color = color
+                )
+            }
+        }
+        formatOutingWorkSheet(sheet)
+
+        ByteArrayOutputStream().use { stream ->
+            workbook.write(stream)
+            return stream.toByteArray()
+        }
+    }
+
+    fun insertDataAtRow(
+        row: Row,
+        data: List<String?>,
+        style: CellStyle,
+        color: IndexedColors = IndexedColors.WHITE,
+        startIdx: Int = 0
+    ) {
+        style.fillPattern = CellStyle.SOLID_FOREGROUND
+        if (style.fillForegroundColor == IndexedColors.AUTOMATIC.index) style.fillForegroundColor = color.index
+
+        style.setBorder()
+
+        data.forEachIndexed { i, item ->
+            val cell = row.createCell(i + startIdx)
+            item?.toDoubleOrNull()?.let {
+                cell.setCellValue(it)
+            } ?: cell.setCellValue(item)
+            cell.cellStyle = style
+        }
+    }
+
+    fun getHeaderCellStyle(workbook: Workbook): CellStyle {
+        val borderStyle = CellStyle.BORDER_THIN
+        val borderColor = IndexedColors.BLACK.index
+
+        return workbook.createCellStyle()
+            .apply {
+                fillForegroundColor = IndexedColors.YELLOW.index
+                fillPattern = CellStyle.SOLID_FOREGROUND
+                alignment = HorizontalAlignment.LEFT.ordinal.toShort()
+                verticalAlignment = VerticalAlignment.CENTER.ordinal.toShort()
+                borderLeft = borderStyle
+                borderTop = borderStyle
+                borderRight = borderStyle
+                borderBottom = borderStyle
+                leftBorderColor = borderColor
+                topBorderColor = borderColor
+                rightBorderColor = borderColor
+                bottomBorderColor = borderColor
+            }
+    }
+
+    fun getDefaultCellStyle(workbook: Workbook): CellStyle =
+        workbook.createCellStyle()
+            .apply {
+                alignment = HorizontalAlignment.LEFT.ordinal.toShort()
+                verticalAlignment = VerticalAlignment.CENTER.ordinal.toShort()
+            }
+
+    fun CellStyle.setBorder() {
+        val borderStyle = CellStyle.BORDER_THIN
+        val borderColor = IndexedColors.BLACK.index
+
+        borderLeft = borderStyle
+        borderTop = borderStyle
+        borderRight = borderStyle
+        borderBottom = borderStyle
+        leftBorderColor = borderColor
+        topBorderColor = borderColor
+        rightBorderColor = borderColor
+        bottomBorderColor = borderColor
+    }
+}

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
@@ -12,7 +12,6 @@ import org.apache.poi.ss.usermodel.VerticalAlignment
 import org.apache.poi.ss.usermodel.Workbook
 import org.apache.poi.ss.util.CellRangeAddress
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
-import org.springframework.stereotype.Component
 import team.aliens.dms.domain.file.FileExtension.XLS
 import team.aliens.dms.domain.file.FileExtension.XLSX
 import team.aliens.dms.thirdparty.parser.exception.BadExcelFormatException
@@ -22,7 +21,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.function.Function
 
-abstract class ExcelPort {
+open class ExcelPort {
     fun <T> getExcelInfo(worksheet: Sheet, function: Function<Row, T>): List<T?> {
 
         val invalidRowIdxes = mutableListOf<Int>()

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/parser/port/ExcelPort.kt
@@ -6,6 +6,7 @@ import org.apache.poi.ss.usermodel.CellStyle
 import org.apache.poi.ss.usermodel.HorizontalAlignment
 import org.apache.poi.ss.usermodel.IndexedColors
 import org.apache.poi.ss.usermodel.Row
+import org.apache.poi.ss.usermodel.Row.RETURN_BLANK_AS_NULL
 import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.ss.usermodel.VerticalAlignment
 import org.apache.poi.ss.usermodel.Workbook
@@ -46,7 +47,11 @@ class ExcelPort {
         return results
     }
 
-    private fun Row.isFirstCellBlank() = cellIterator().next().cellType == Cell.CELL_TYPE_BLANK
+    fun Row.isFirstCellBlank() = cellIterator().next().cellType == Cell.CELL_TYPE_BLANK
+
+    fun Row.getStringValue(idx: Int) = getCell(idx, RETURN_BLANK_AS_NULL).stringCellValue
+
+    fun Row.getIntValue(idx: Int) = getCell(idx, RETURN_BLANK_AS_NULL).numericCellValue.toInt()
 
     fun transferToExcel(file: File): Workbook {
         val inputStream = file.inputStream()
@@ -100,7 +105,8 @@ class ExcelPort {
         val headerRow = sheet.createRow(0)
         insertDataAtRow(headerRow, attributes, getHeaderCellStyle(workbook))
 
-        var idx = 1;
+        var idx = 1
+
         dataListSet.forEachIndexed { setIdx, dataList -> // 각 그룹마다 지정된 색을 받음.
             val color = colors[setIdx % colors.size]
 
@@ -135,6 +141,8 @@ class ExcelPort {
                 .map {
                     autoSizeColumn(it)
                     val width = getColumnWidth(it)
+                    setColumnWidth(it, ((width * 1.3) - 50).toInt())
+                }
         }
     }
 


### PR DESCRIPTION
## 작업 내용 설명
- [ ] ExcelAdapter의 메서드들을 의존도 별 분리

## 주요 변경 사항
- ExcelAdapter에서 분리할 메서드를 ExcelPort 로 분리
- ExcelPort를 ExcelAdapter에 상속하도록 변경

## 결과물
![image](https://github.com/user-attachments/assets/5ed03a0b-95c3-4ed3-a30c-158b5e9926d8)


## 체크리스트
- [X] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #671 