### PR TITLE
merge: (#719) 알림 구독/해제 API 병합

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationService.kt
@@ -25,4 +25,6 @@ interface NotificationService :
     fun sendMessagesByTopic(
         notification: Notification
     )
+
+    fun toggleSubscription(token: String, topic: Topic)
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImpl.kt
@@ -123,23 +123,17 @@ class NotificationServiceImpl(
 
     override fun toggleSubscription(token: String, topic: Topic) {
         val deviceToken = this.getDeviceTokenByToken(token)
-        val currentSubscription = queryTopicSubscriptionPort.queryDeviceTokenIdAndTopic(
-            deviceToken.id,
-            topic
-        )
-
-        if (currentSubscription != null) {
-            val shouldSubscribe = !currentSubscription.isSubscribed
-            if (shouldSubscribe) {
-                notificationPort.subscribeTopic(token, topic)
-            } else {
+        queryTopicSubscriptionPort.queryDeviceTokenIdAndTopic(deviceToken.id, topic)?.let { currentSubscription ->
+            if (currentSubscription.isSubscribed) {
                 notificationPort.unsubscribeTopic(token, topic)
+            } else {
+                notificationPort.subscribeTopic(token, topic)
             }
             commandTopicSubscriptionPort.saveTopicSubscription(
                 TopicSubscription(
                     deviceTokenId = deviceToken.id,
                     topic = topic,
-                    isSubscribed = shouldSubscribe
+                    isSubscribed = !currentSubscription.isSubscribed
                 )
             )
         }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImpl.kt
@@ -123,17 +123,20 @@ class NotificationServiceImpl(
 
     override fun toggleSubscription(token: String, topic: Topic) {
         val deviceToken = this.getDeviceTokenByToken(token)
-        queryTopicSubscriptionPort.queryDeviceTokenIdAndTopic(deviceToken.id, topic)?.let { currentSubscription ->
-            if (currentSubscription.isSubscribed) {
+        val currentSubscribe = queryTopicSubscriptionPort.queryDeviceTokenIdAndTopic(deviceToken.id, topic)
+
+        currentSubscribe?.let {
+            if (it.isSubscribed) {
                 notificationPort.unsubscribeTopic(token, topic)
             } else {
                 notificationPort.subscribeTopic(token, topic)
             }
+
             commandTopicSubscriptionPort.saveTopicSubscription(
                 TopicSubscription(
                     deviceTokenId = deviceToken.id,
                     topic = topic,
-                    isSubscribed = !currentSubscription.isSubscribed
+                    isSubscribed = !it.isSubscribed
                 )
             )
         }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/spi/QueryTopicSubscriptionPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/spi/QueryTopicSubscriptionPort.kt
@@ -1,9 +1,12 @@
 package team.aliens.dms.domain.notification.spi
 
+import team.aliens.dms.domain.notification.model.Topic
 import team.aliens.dms.domain.notification.model.TopicSubscription
 import java.util.UUID
 
 interface QueryTopicSubscriptionPort {
 
     fun queryTopicSubscriptionsByDeviceTokenId(deviceTokenId: UUID): List<TopicSubscription>
+
+    fun queryDeviceTokenIdAndTopic(deviceTokenId: UUID, topic: Topic): TopicSubscription?
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/ToggleSubscriptionUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/ToggleSubscriptionUseCase.kt
@@ -1,0 +1,18 @@
+package team.aliens.dms.domain.notification.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.notification.model.Topic
+import team.aliens.dms.domain.notification.service.NotificationService
+
+@UseCase
+class ToggleSubscriptionUseCase(
+    private val notificationService: NotificationService
+) {
+
+    fun execute(deviceToken: String, topic: Topic) {
+        notificationService.toggleSubscription(
+            token = deviceToken,
+            topic = topic
+        )
+    }
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/student/service/GetStudentServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/student/service/GetStudentServiceImpl.kt
@@ -6,7 +6,6 @@ import team.aliens.dms.domain.file.spi.vo.ExcelStudentVO
 import team.aliens.dms.domain.manager.dto.PointFilter
 import team.aliens.dms.domain.manager.dto.Sort
 import team.aliens.dms.domain.outing.spi.QueryOutingApplicationPort
-import team.aliens.dms.domain.point.spi.QueryPointHistoryPort
 import team.aliens.dms.domain.room.exception.RoomNotFoundException
 import team.aliens.dms.domain.room.model.Room
 import team.aliens.dms.domain.student.exception.StudentNotFoundException

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -167,6 +167,7 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.GET, "/notifications/topic").authenticated()
                 .requestMatchers(HttpMethod.PATCH, "/notifications/topic").authenticated()
                 .requestMatchers(HttpMethod.GET, "/notifications").authenticated()
+                .requestMatchers(HttpMethod.PATCH, "/notifications/topic/toggle").authenticated()
 
                 // /outings
                 .requestMatchers(HttpMethod.POST, "/outings").hasAuthority(STUDENT.name)

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/TopicSubscriptionPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/TopicSubscriptionPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.persistence.notification
 
 import org.springframework.stereotype.Component
+import team.aliens.dms.domain.notification.model.Topic
 import team.aliens.dms.domain.notification.model.TopicSubscription
 import team.aliens.dms.domain.notification.spi.TopicSubscriptionPort
 import team.aliens.dms.persistence.notification.mapper.TopicSubscriptionMapper
@@ -31,7 +32,13 @@ class TopicSubscriptionPersistenceAdapter(
         topicSubscriptionRepository.deleteAllByDeviceTokenId(deviceTokenId)
     }
 
-    override fun queryTopicSubscriptionsByDeviceTokenId(deviceTokenId: UUID) =
-        topicSubscriptionRepository.findByDeviceTokenId(deviceTokenId)
+    override fun queryTopicSubscriptionsByDeviceTokenId(deviceTokenId: UUID): List<TopicSubscription> {
+        return topicSubscriptionRepository.findByDeviceTokenId(deviceTokenId)
             .map { topicSubscriptionMapper.toDomain(it)!! }
+    }
+
+    override fun queryDeviceTokenIdAndTopic(deviceTokenId: UUID, topic: Topic): TopicSubscription? {
+        return topicSubscriptionRepository.findById_DeviceTokenIdAndId_Topic(deviceTokenId, topic)
+            ?.let { topicSubscriptionMapper.toDomain(it) }
+    }
 }

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/repository/TopicSubscriptionJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/notification/repository/TopicSubscriptionJpaRepository.kt
@@ -2,13 +2,17 @@ package team.aliens.dms.persistence.notification.repository
 
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
+import team.aliens.dms.domain.notification.model.Topic
 import team.aliens.dms.persistence.notification.entity.TopicSubscriptionJpaEntity
 import team.aliens.dms.persistence.notification.entity.TopicSubscriptionJpaEntityId
 import java.util.UUID
 
 @Repository
 interface TopicSubscriptionJpaRepository : CrudRepository<TopicSubscriptionJpaEntity, TopicSubscriptionJpaEntityId> {
-    fun findByDeviceTokenId(deviceTokenId: UUID): List<TopicSubscriptionJpaEntity>
 
     fun deleteAllByDeviceTokenId(deviceTokenId: UUID)
+
+    fun findById_DeviceTokenIdAndId_Topic(deviceTokenId: UUID, topic: Topic): TopicSubscriptionJpaEntity?
+
+    fun findByDeviceTokenId(deviceTokenId: UUID): List<TopicSubscriptionJpaEntity>
 }

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/notification/NotificationWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/notification/NotificationWebAdapter.kt
@@ -25,6 +25,7 @@ import team.aliens.dms.domain.notification.usecase.RemoveMyAllNotificationUseCas
 import team.aliens.dms.domain.notification.usecase.RemoveNotificationUseCase
 import team.aliens.dms.domain.notification.usecase.SetDeviceTokenUseCase
 import team.aliens.dms.domain.notification.usecase.SubscribeTopicUseCase
+import team.aliens.dms.domain.notification.usecase.ToggleSubscriptionUseCase
 import team.aliens.dms.domain.notification.usecase.UnsubscribeTopicUseCase
 import team.aliens.dms.domain.notification.usecase.UpdateTopicSubscriptionsUseCase
 import java.util.UUID
@@ -41,6 +42,7 @@ class NotificationWebAdapter(
     private val queryTopicSubscriptionUseCase: QueryTopicSubscriptionUseCase,
     private val removeNotificationUseCase: RemoveNotificationUseCase,
     private val removeMyAllNotificationUseCase: RemoveMyAllNotificationUseCase,
+    private val toggleSubscriptionUseCase: ToggleSubscriptionUseCase,
 ) {
 
     @PostMapping("/token")
@@ -66,6 +68,15 @@ class NotificationWebAdapter(
     @DeleteMapping("/topic")
     fun unsubscribeTopic(@RequestBody @Valid request: TopicRequest) {
         unsubscribeTopicUseCase.execute(
+            deviceToken = request.deviceToken,
+            topic = request.topic
+        )
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/topic/toggle")
+    fun toggleSubscription(@RequestBody @Valid request: TopicRequest) {
+        toggleSubscriptionUseCase.execute(
             deviceToken = request.deviceToken,
             topic = request.topic
         )


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 알림 구독, 알림 해제를 토글 형태로 하나의 API로 병함
- [ ] <!-- 작업 내용 작성 -->

## 주요 변경 사항
- <!-- 변경 사항 작성 -->
- <!-- 변경 사항 작성 -->

## 결과물
![image](https://github.com/user-attachments/assets/b1dfbc51-5da1-411f-beb1-4d6c9bc8a4c5)

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #719