### PR TITLE
feat: (#737) 캐싱 적용

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -86,4 +86,5 @@ object Dependencies {
     // slack
     const val SLACK = "com.slack.api:slack-api-client:${DependencyVersions.SLACK_VERSION}"
 
+    const val CACHE = "org.springframework.boot:spring-boot-starter-cache"
 }

--- a/dms-infrastructure/build.gradle.kts
+++ b/dms-infrastructure/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
 
     // notification
     implementation(Dependencies.FCM)
+
+    //cache
+    implementation(Dependencies.CACHE)
 }
 
 tasks.getByName<Jar>("jar") {

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
@@ -11,7 +11,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
-import team.aliens.dms.global.config.CacheName.STUDENT2
 import java.time.Duration
 
 @Configuration
@@ -20,26 +19,28 @@ class CacheConfig {
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
         val redisCacheConfiguration: RedisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(30))
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofMinutes(30))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
 
         return RedisCacheManager.RedisCacheManagerBuilder
-                .fromConnectionFactory(redisConnectionFactory)
-                .cacheDefaults(redisCacheConfiguration)
-                .build()
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
     }
 
-    //캐시를 구분하기 위해 존재함
+    // 캐시를 구분하기 위해 존재함
     @Bean
     fun redisCacheManagerBuilderCustomizer(): RedisCacheManagerBuilderCustomizer {
         return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManager.RedisCacheManagerBuilder ->
             builder
-                    .withCacheConfiguration(STUDENT2, RedisCacheConfiguration.defaultCacheConfig()
-                            .entryTtl(Duration.ofMinutes(10))
-                            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
-                            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
-                    )
+                .withCacheConfiguration(
+                    "student",
+                    RedisCacheConfiguration.defaultCacheConfig()
+                        .entryTtl(Duration.ofMinutes(10))
+                        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+                        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
+                )
         }
     }
 }

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheConfig.kt
@@ -1,0 +1,45 @@
+package team.aliens.dms.global.config
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import team.aliens.dms.global.config.CacheName.STUDENT2
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val redisCacheConfiguration: RedisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build()
+    }
+
+    //캐시를 구분하기 위해 존재함
+    @Bean
+    fun redisCacheManagerBuilderCustomizer(): RedisCacheManagerBuilderCustomizer {
+        return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManager.RedisCacheManagerBuilder ->
+            builder
+                    .withCacheConfiguration(STUDENT2, RedisCacheConfiguration.defaultCacheConfig()
+                            .entryTtl(Duration.ofMinutes(10))
+                            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+                            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
+                    )
+        }
+    }
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheName.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheName.kt
@@ -1,5 +1,0 @@
-package team.aliens.dms.global.config
-
-object CacheName {
-    const val STUDENT2 = "student"
-}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheName.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CacheName.kt
@@ -1,0 +1,5 @@
+package team.aliens.dms.global.config
+
+object CacheName {
+    const val STUDENT2 = "student"
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CustomKeyGenerator.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CustomKeyGenerator.kt
@@ -9,7 +9,7 @@ import java.lang.reflect.Method
 @Configuration
 class CustomKeyGenerator : KeyGenerator {
 
-    //메서드 명을 사용해 key를 만들어준다.
+    // 메서드 명을 사용해 key를 만들어준다.
     override fun generate(target: Any, method: Method, vararg params: Any): Any {
         return method.name + SimpleKeyGenerator.generateKey(*params)
     }

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CustomKeyGenerator.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/global/config/CustomKeyGenerator.kt
@@ -1,0 +1,21 @@
+package team.aliens.dms.global.config
+
+import org.springframework.cache.interceptor.KeyGenerator
+import org.springframework.cache.interceptor.SimpleKeyGenerator
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.lang.reflect.Method
+
+@Configuration
+class CustomKeyGenerator : KeyGenerator {
+
+    //메서드 명을 사용해 key를 만들어준다.
+    override fun generate(target: Any, method: Method, vararg params: Any): Any {
+        return method.name + SimpleKeyGenerator.generateKey(*params)
+    }
+
+    @Bean
+    fun keyGenerator(): KeyGenerator {
+        return CustomKeyGenerator()
+    }
+}

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/VolunteerApplicationJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/VolunteerApplicationJpaRepository.kt
@@ -6,6 +6,4 @@ import team.aliens.dms.persistence.volunteer.entity.VolunteerApplicationJpaEntit
 import java.util.UUID
 
 @Repository
-interface VolunteerApplicationJpaRepository : CrudRepository<VolunteerApplicationJpaEntity, UUID> {
-
-}
+interface VolunteerApplicationJpaRepository : CrudRepository<VolunteerApplicationJpaEntity, UUID>

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/VolunteerJpaRepository.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/VolunteerJpaRepository.kt
@@ -6,6 +6,4 @@ import team.aliens.dms.persistence.volunteer.entity.VolunteerJpaEntity
 import java.util.UUID
 
 @Repository
-interface VolunteerJpaRepository : CrudRepository<VolunteerJpaEntity, UUID> {
-
-}
+interface VolunteerJpaRepository : CrudRepository<VolunteerJpaEntity, UUID>

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/student/StudentWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/student/StudentWebAdapter.kt
@@ -5,6 +5,9 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -56,6 +59,7 @@ import team.aliens.dms.domain.student.usecase.UpdateStudentProfileUseCase
 import team.aliens.dms.domain.student.usecase.UpdateStudentRoomByFileUseCase
 import java.util.UUID
 
+@CacheConfig(cacheNames = ["student"])
 @Validated
 @RequestMapping("/students")
 @RestController
@@ -157,6 +161,7 @@ class StudentWebAdapter(
         return checkStudentGcnUseCase.execute(request)
     }
 
+    @CacheEvict(allEntries = true)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/profile")
     fun updateProfile(@RequestBody @Valid webRequest: UpdateStudentProfileWebRequest) {
@@ -168,6 +173,7 @@ class StudentWebAdapter(
         return studentMyPageUseCase.execute()
     }
 
+    @CacheEvict(allEntries = true)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping
     fun withdrawal() {
@@ -181,6 +187,7 @@ class StudentWebAdapter(
         return response.file
     }
 
+    @Cacheable
     @GetMapping("/manager")
     fun managerGetAllStudents(
         @RequestParam(required = false) name: String?,
@@ -202,29 +209,34 @@ class StudentWebAdapter(
         )
     }
 
+    @Cacheable
     @GetMapping("/{student-id}")
     fun getStudentDetails(@PathVariable("student-id") @NotNull studentId: UUID): StudentDetailsResponse {
         return queryStudentDetailsUseCase.execute(studentId)
     }
 
+    @CacheEvict(allEntries = true)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{student-id}")
     fun deleteStudent(@PathVariable("student-id") @NotNull studentId: UUID) {
         removeStudentUseCase.execute(studentId)
     }
 
+    @CacheEvict(allEntries = true)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/file/room")
     fun updateStudentRoomByFile(@RequestPart @NotNull file: MultipartFile?) {
         updateStudentRoomByFileUseCase.execute(file!!.toFile())
     }
 
+    @CacheEvict(allEntries = true)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/file/gcn")
     fun updateStudentGcnByFile(@RequestPart @NotNull file: MultipartFile?) {
         updateStudentGcnByFileUseCase.execute(file!!.toFile())
     }
 
+    @CacheEvict(allEntries = true)
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/verified-student")
     fun importVerifiedStudentFromExcel(@RequestPart @NotNull file: MultipartFile?) {
@@ -233,6 +245,7 @@ class StudentWebAdapter(
         )
     }
 
+    @Cacheable
     @GetMapping
     fun studentGetAllStudents(@RequestParam(required = false) name: String?): StudentsResponse {
         return studentGetAllStudentsUseCase.execute(name)


### PR DESCRIPTION
## 작업 내용 설명
- [x] studentWebAdapter 에 캐싱 적용했습니다
- [x] 캐시 저장소로 redis를 사용했습니다

## 주요 변경 사항
- CacheConfig
-- 캐시 설정을 모아뒀습니다
- CustomKeyGenerator 
-- key를 메서드 명으로 생성해줌으로써 구분해줄 수 있도록 하였습니다

## 추가적으로
- 원래 CacheConfig에 상수를 넣어주려했는데 persistence에도 필요하고 presentation 계층에도 필요해서 하드코딩 했습니다
- redis관련 dependencis가 persistence에 있어서 persistence에 cacheConfig 등을 뒀습니다
- 캐싱 처리가 필요해보이는 도메인을 말해주시면 추가해서 올리겠습니다

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?

## 관련 이슈
- resolved #737 