### PR TITLE
merge: (#774) 봉사 활동 목록 조회 Response 에 CurrentApplicants 추가

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/dto/response/VolunteerResponse.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/dto/response/VolunteerResponse.kt
@@ -6,6 +6,7 @@ import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.model.VolunteerApplication
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerApplicantVO
+import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
 import java.util.UUID
 
 data class QueryMyVolunteerApplicationResponse(
@@ -48,21 +49,23 @@ data class VolunteerResponse(
     val content: String,
     val score: Int,
     val optionalScore: Int,
+    val currentApplicants: Int,
     val maxApplicants: Int,
     val availableSex: Sex,
     val availableGrade: AvailableGrade
 ) {
     companion object {
-        fun of(volunteer: Volunteer): VolunteerResponse {
+        fun of(volunteerWithCurrentApplicantVO: VolunteerWithCurrentApplicantVO): VolunteerResponse {
             return VolunteerResponse(
-                id = volunteer.id,
-                name = volunteer.name,
-                content = volunteer.content,
-                score = volunteer.score,
-                optionalScore = volunteer.optionalScore,
-                maxApplicants = volunteer.maxApplicants,
-                availableSex = volunteer.availableSex,
-                availableGrade = volunteer.availableGrade
+                id = volunteerWithCurrentApplicantVO.id,
+                name = volunteerWithCurrentApplicantVO.name,
+                content = volunteerWithCurrentApplicantVO.content,
+                score = volunteerWithCurrentApplicantVO.score,
+                optionalScore = volunteerWithCurrentApplicantVO.optionalScore,
+                currentApplicants = volunteerWithCurrentApplicantVO.currentApplicants,
+                maxApplicants = volunteerWithCurrentApplicantVO.maxApplicants,
+                availableSex = volunteerWithCurrentApplicantVO.availableSex,
+                availableGrade = volunteerWithCurrentApplicantVO.availableGrade
             )
         }
     }
@@ -94,6 +97,8 @@ data class CurrentVolunteerApplicantResponse(
     val volunteerName: String,
     val availableSex: Sex,
     val availableGrade: AvailableGrade,
+    val currentApplicants: Int,
+    val maxApplicants: Int,
     val applicants: List<VolunteerApplicantResponse>
 ) {
     companion object {
@@ -101,6 +106,8 @@ data class CurrentVolunteerApplicantResponse(
             volunteerName = currentVolunteerApplicant.volunteerName,
             availableSex = currentVolunteerApplicant.availableSex,
             availableGrade = currentVolunteerApplicant.availableGrade,
+            currentApplicants = currentVolunteerApplicant.currentApplicants,
+            maxApplicants = currentVolunteerApplicant.maxApplicants,
             applicants = currentVolunteerApplicant.applicants
                 .map { VolunteerApplicantResponse.of(it) }
         )
@@ -117,17 +124,19 @@ data class AvailableVolunteerResponse(
     val content: String,
     val score: Int,
     val optionalScore: Int,
+    val currentApplicants: Int,
     val maxApplicants: Int
 ) {
     companion object {
-        fun of(volunteer: Volunteer): AvailableVolunteerResponse {
+        fun of(volunteerWithCurrentApplicantVO: VolunteerWithCurrentApplicantVO): AvailableVolunteerResponse {
             return AvailableVolunteerResponse(
-                id = volunteer.id,
-                name = volunteer.name,
-                content = volunteer.content,
-                score = volunteer.score,
-                optionalScore = volunteer.optionalScore,
-                maxApplicants = volunteer.maxApplicants
+                id = volunteerWithCurrentApplicantVO.id,
+                name = volunteerWithCurrentApplicantVO.name,
+                content = volunteerWithCurrentApplicantVO.content,
+                score = volunteerWithCurrentApplicantVO.score,
+                optionalScore = volunteerWithCurrentApplicantVO.optionalScore,
+                currentApplicants = volunteerWithCurrentApplicantVO.currentApplicants,
+                maxApplicants = volunteerWithCurrentApplicantVO.maxApplicants
             )
         }
     }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/dto/response/VolunteerResponse.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/dto/response/VolunteerResponse.kt
@@ -4,6 +4,7 @@ import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.volunteer.model.AvailableGrade
 import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.model.VolunteerApplication
+import team.aliens.dms.domain.volunteer.model.VolunteerApplicationStatus
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
@@ -14,11 +15,11 @@ data class QueryMyVolunteerApplicationResponse(
 ) {
     companion object {
         fun of(
-            applicationsWithVolunteers: List<Pair<VolunteerApplication, Volunteer>>
+            applicationsWithVolunteers: List<Triple<VolunteerApplication, Volunteer, VolunteerApplicationStatus>>
         ): QueryMyVolunteerApplicationResponse {
             return QueryMyVolunteerApplicationResponse(
-                volunteerApplications = applicationsWithVolunteers.map { (application, volunteer) ->
-                    VolunteerApplicationResponse.of(application, volunteer)
+                volunteerApplications = applicationsWithVolunteers.map { (application, volunteer, status) ->
+                    VolunteerApplicationResponse.of(application, volunteer, status)
                 }
             )
         }
@@ -28,15 +29,19 @@ data class QueryMyVolunteerApplicationResponse(
 data class VolunteerApplicationResponse(
     val id: UUID,
     val volunteerId: UUID,
-    val approved: Boolean,
-    val name: String,
+    val status: VolunteerApplicationStatus,
+    val name: String
 ) {
     companion object {
-        fun of(volunteerApplication: VolunteerApplication, volunteer: Volunteer): VolunteerApplicationResponse {
+        fun of(
+            volunteerApplication: VolunteerApplication,
+            volunteer: Volunteer,
+            status: VolunteerApplicationStatus
+        ): VolunteerApplicationResponse {
             return VolunteerApplicationResponse(
                 id = volunteerApplication.id,
                 volunteerId = volunteerApplication.volunteerId,
-                approved = volunteerApplication.approved,
+                status = status,
                 name = volunteer.name
             )
         }
@@ -125,7 +130,8 @@ data class AvailableVolunteerResponse(
     val score: Int,
     val optionalScore: Int,
     val currentApplicants: Int,
-    val maxApplicants: Int
+    val maxApplicants: Int,
+    val status: VolunteerApplicationStatus
 ) {
     companion object {
         fun of(volunteerWithCurrentApplicantVO: VolunteerWithCurrentApplicantVO): AvailableVolunteerResponse {
@@ -136,7 +142,8 @@ data class AvailableVolunteerResponse(
                 score = volunteerWithCurrentApplicantVO.score,
                 optionalScore = volunteerWithCurrentApplicantVO.optionalScore,
                 currentApplicants = volunteerWithCurrentApplicantVO.currentApplicants,
-                maxApplicants = volunteerWithCurrentApplicantVO.maxApplicants
+                maxApplicants = volunteerWithCurrentApplicantVO.maxApplicants,
+                status = volunteerWithCurrentApplicantVO.status
             )
         }
     }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/model/VolunteerApplicationStatus.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/model/VolunteerApplicationStatus.kt
@@ -1,0 +1,17 @@
+package team.aliens.dms.domain.volunteer.model
+
+enum class VolunteerApplicationStatus {
+    NOT_APPLIED,
+    APPLYING,
+    APPLIED;
+
+    companion object {
+
+        fun of(isApproved: Boolean?): VolunteerApplicationStatus =
+            when (isApproved) {
+                true -> APPLIED
+                false -> APPLYING
+                null -> NOT_APPLIED
+            }
+    }
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerService.kt
@@ -5,6 +5,7 @@ import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.model.VolunteerApplication
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerApplicantVO
+import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
 import java.util.UUID
 
 interface GetVolunteerService {
@@ -13,9 +14,9 @@ interface GetVolunteerService {
 
     fun getVolunteerById(volunteerId: UUID): Volunteer
 
-    fun getVolunteerByStudent(student: Student): List<Volunteer>
+    fun getAllVolunteersWithCurrentApplicantsByStudent(student: Student): List<VolunteerWithCurrentApplicantVO>
 
-    fun getAllVolunteersBySchoolId(schoolId: UUID): List<Volunteer>
+    fun getAllVolunteersWithCurrentApplicantsBySchoolId(schoolId: UUID): List<VolunteerWithCurrentApplicantVO>
 
     fun getAllApplicantsByVolunteerId(volunteerId: UUID): List<VolunteerApplicantVO>
 

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerService.kt
@@ -12,6 +12,8 @@ interface GetVolunteerService {
 
     fun getVolunteerApplicationById(volunteerApplicationId: UUID): VolunteerApplication
 
+    fun getVolunteerApplicationByVolunteerIdAndStudentId(volunteerId: UUID, studentId: UUID): VolunteerApplication
+
     fun getVolunteerById(volunteerId: UUID): Volunteer
 
     fun getAllVolunteersWithCurrentApplicantsByStudent(student: Student): List<VolunteerWithCurrentApplicantVO>

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerService.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.domain.volunteer.service
 import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.model.VolunteerApplication
+import team.aliens.dms.domain.volunteer.model.VolunteerApplicationStatus
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
@@ -24,5 +25,5 @@ interface GetVolunteerService {
 
     fun getAllApplicantsBySchoolIdGroupByVolunteer(schoolId: UUID): List<CurrentVolunteerApplicantVO>
 
-    fun getVolunteerApplicationsWithVolunteersByStudentId(studentId: UUID): List<Pair<VolunteerApplication, Volunteer>>
+    fun getVolunteerApplicationsWithVolunteersByStudentId(studentId: UUID): List<Triple<VolunteerApplication, Volunteer, VolunteerApplicationStatus>>
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerServiceImpl.kt
@@ -6,6 +6,7 @@ import team.aliens.dms.domain.volunteer.exception.VolunteerApplicationNotFoundEx
 import team.aliens.dms.domain.volunteer.exception.VolunteerNotFoundException
 import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.model.VolunteerApplication
+import team.aliens.dms.domain.volunteer.model.VolunteerApplicationStatus
 import team.aliens.dms.domain.volunteer.spi.QueryVolunteerApplicationPort
 import team.aliens.dms.domain.volunteer.spi.QueryVolunteerPort
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
@@ -53,7 +54,7 @@ class GetVolunteerServiceImpl(
     override fun getAllApplicantsBySchoolIdGroupByVolunteer(schoolId: UUID): List<CurrentVolunteerApplicantVO> =
         queryVolunteerApplicationPort.queryAllApplicantsBySchoolIdGroupByVolunteer(schoolId)
 
-    override fun getVolunteerApplicationsWithVolunteersByStudentId(studentId: UUID): List<Pair<VolunteerApplication, Volunteer>> {
+    override fun getVolunteerApplicationsWithVolunteersByStudentId(studentId: UUID): List<Triple<VolunteerApplication, Volunteer, VolunteerApplicationStatus>> {
         return queryVolunteerApplicationPort.getVolunteerApplicationsWithVolunteersByStudentId(studentId)
     }
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerServiceImpl.kt
@@ -23,6 +23,15 @@ class GetVolunteerServiceImpl(
         queryVolunteerApplicationPort.queryVolunteerApplicationById(volunteerApplicationId)
             ?: throw VolunteerApplicationNotFoundException
 
+    override fun getVolunteerApplicationByVolunteerIdAndStudentId(
+        volunteerId: UUID,
+        studentId: UUID
+    ): VolunteerApplication =
+        queryVolunteerApplicationPort.queryVolunteerApplicationByStudentIdAndVolunteerId(
+            volunteerId = volunteerId,
+            studentId = studentId
+        ) ?: throw VolunteerApplicationNotFoundException
+
     override fun getVolunteerById(volunteerId: UUID): Volunteer =
         queryVolunteerPort.queryVolunteerById(volunteerId)
             ?: throw VolunteerNotFoundException

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/service/GetVolunteerServiceImpl.kt
@@ -10,6 +10,7 @@ import team.aliens.dms.domain.volunteer.spi.QueryVolunteerApplicationPort
 import team.aliens.dms.domain.volunteer.spi.QueryVolunteerPort
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerApplicantVO
+import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
 import java.util.UUID
 
 @Service
@@ -26,16 +27,16 @@ class GetVolunteerServiceImpl(
         queryVolunteerPort.queryVolunteerById(volunteerId)
             ?: throw VolunteerNotFoundException
 
-    override fun getVolunteerByStudent(student: Student): List<Volunteer> {
-        val volunteers = queryVolunteerPort.queryAllVolunteersBySchoolId(student.schoolId)
+    override fun getAllVolunteersWithCurrentApplicantsByStudent(student: Student): List<VolunteerWithCurrentApplicantVO> {
+        val volunteers = queryVolunteerPort.queryAllVolunteersWithCurrentApplicantsBySchoolId(student.schoolId)
 
         return volunteers.filter { volunteer ->
-            volunteer.isAvailable(student)
+            volunteer.toVolunteer().isAvailable(student)
         }
     }
 
-    override fun getAllVolunteersBySchoolId(schoolId: UUID): List<Volunteer> =
-        queryVolunteerPort.queryAllVolunteersBySchoolId(schoolId)
+    override fun getAllVolunteersWithCurrentApplicantsBySchoolId(schoolId: UUID): List<VolunteerWithCurrentApplicantVO> =
+        queryVolunteerPort.queryAllVolunteersWithCurrentApplicantsBySchoolId(schoolId)
 
     override fun getAllApplicantsByVolunteerId(volunteerId: UUID): List<VolunteerApplicantVO> =
         queryVolunteerApplicationPort.queryAllApplicantsByVolunteerId(volunteerId)

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/QueryVolunteerApplicationPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/QueryVolunteerApplicationPort.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.domain.volunteer.spi
 
 import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.model.VolunteerApplication
+import team.aliens.dms.domain.volunteer.model.VolunteerApplicationStatus
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerApplicantVO
 import java.util.UUID
@@ -16,5 +17,5 @@ interface QueryVolunteerApplicationPort {
 
     fun queryVolunteerApplicationByStudentIdAndVolunteerId(studentId: UUID, volunteerId: UUID): VolunteerApplication?
 
-    fun getVolunteerApplicationsWithVolunteersByStudentId(studentId: UUID): List<Pair<VolunteerApplication, Volunteer>>
+    fun getVolunteerApplicationsWithVolunteersByStudentId(studentId: UUID): List<Triple<VolunteerApplication, Volunteer, VolunteerApplicationStatus>>
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/QueryVolunteerPort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/QueryVolunteerPort.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.volunteer.spi
 
 import team.aliens.dms.domain.volunteer.model.Volunteer
+import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
 import java.util.UUID
 
 interface QueryVolunteerPort {
@@ -8,4 +9,6 @@ interface QueryVolunteerPort {
     fun queryVolunteerById(volunteerId: UUID): Volunteer?
 
     fun queryAllVolunteersBySchoolId(schoolId: UUID): List<Volunteer>
+
+    fun queryAllVolunteersWithCurrentApplicantsBySchoolId(schoolId: UUID): List<VolunteerWithCurrentApplicantVO>
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/vo/CurrentVolunteerApplicantVO.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/vo/CurrentVolunteerApplicantVO.kt
@@ -7,5 +7,7 @@ open class CurrentVolunteerApplicantVO(
     val volunteerName: String,
     val availableSex: Sex,
     val availableGrade: AvailableGrade,
+    val currentApplicants: Int,
+    val maxApplicants: Int,
     val applicants: List<VolunteerApplicantVO>
 )

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/vo/VolunteerWithCurrentApplicantVO.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/vo/VolunteerWithCurrentApplicantVO.kt
@@ -1,0 +1,32 @@
+package team.aliens.dms.domain.volunteer.spi.vo
+
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.volunteer.model.AvailableGrade
+import team.aliens.dms.domain.volunteer.model.Volunteer
+import java.util.UUID
+
+open class VolunteerWithCurrentApplicantVO(
+    val id: UUID,
+    val name: String,
+    val content: String,
+    val score: Int,
+    val optionalScore: Int,
+    val currentApplicants: Int,
+    val maxApplicants: Int,
+    val availableSex: Sex,
+    val availableGrade: AvailableGrade,
+    val schoolId: UUID
+) {
+
+    fun toVolunteer() = Volunteer(
+        id = id,
+        name = name,
+        content = content,
+        score = score,
+        optionalScore = optionalScore,
+        maxApplicants = maxApplicants,
+        availableSex = availableSex,
+        availableGrade = availableGrade,
+        schoolId = schoolId
+    )
+}

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/vo/VolunteerWithCurrentApplicantVO.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/spi/vo/VolunteerWithCurrentApplicantVO.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.domain.volunteer.spi.vo
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.volunteer.model.AvailableGrade
 import team.aliens.dms.domain.volunteer.model.Volunteer
+import team.aliens.dms.domain.volunteer.model.VolunteerApplicationStatus
 import java.util.UUID
 
 open class VolunteerWithCurrentApplicantVO(
@@ -15,7 +16,8 @@ open class VolunteerWithCurrentApplicantVO(
     val maxApplicants: Int,
     val availableSex: Sex,
     val availableGrade: AvailableGrade,
-    val schoolId: UUID
+    val schoolId: UUID,
+    val status: VolunteerApplicationStatus
 ) {
 
     fun toVolunteer() = Volunteer(

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/usecase/ManagerGetAllVolunteersUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/usecase/ManagerGetAllVolunteersUseCase.kt
@@ -15,7 +15,7 @@ class ManagerGetAllVolunteersUseCase(
     fun execute(): VolunteersResponse {
         val schoolId = securityService.getCurrentSchoolId()
 
-        val volunteers = volunteerService.getAllVolunteersBySchoolId(schoolId)
+        val volunteers = volunteerService.getAllVolunteersWithCurrentApplicantsBySchoolId(schoolId)
             .map { VolunteerResponse.of(it) }
 
         return VolunteersResponse(volunteers)

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/usecase/QueryAvailableVolunteersUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/usecase/QueryAvailableVolunteersUseCase.kt
@@ -15,7 +15,7 @@ class QueryAvailableVolunteersUseCase(
     fun execute(): AvailableVolunteersResponse {
         val student = studentService.getCurrentStudent()
 
-        val availableVolunteers = volunteerService.getVolunteerByStudent(student)
+        val availableVolunteers = volunteerService.getAllVolunteersWithCurrentApplicantsByStudent(student)
 
         return AvailableVolunteersResponse(
             availableVolunteers

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/usecase/UnapplyVolunteerUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/volunteer/usecase/UnapplyVolunteerUseCase.kt
@@ -1,16 +1,23 @@
 package team.aliens.dms.domain.volunteer.usecase
 
 import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.student.service.StudentService
 import team.aliens.dms.domain.volunteer.service.VolunteerService
 import java.util.UUID
 
 @UseCase
 class UnapplyVolunteerUseCase(
-    private val volunteerService: VolunteerService
+    private val volunteerService: VolunteerService,
+    private val studentService: StudentService
 ) {
 
-    fun execute(volunteerApplicationId: UUID) {
-        val volunteer = volunteerService.getVolunteerApplicationById(volunteerApplicationId)
+    fun execute(volunteerId: UUID) {
+        val student = studentService.getCurrentStudent()
+
+        val volunteer = volunteerService.getVolunteerApplicationByVolunteerIdAndStudentId(
+            volunteerId = volunteerId,
+            studentId = student.id
+        )
 
         volunteer.checkIsNotApproved()
 

--- a/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -200,7 +200,7 @@ class SecurityConfig(
                 .requestMatchers(HttpMethod.DELETE, "/volunteers/exception/{volunteer-application-id}").hasAuthority(MANAGER.name)
                 .requestMatchers(HttpMethod.GET, "/volunteers/current").hasAuthority(MANAGER.name)
                 .requestMatchers(HttpMethod.POST, "/volunteers/application/{volunteer-id}").hasAuthority(STUDENT.name)
-                .requestMatchers(HttpMethod.DELETE, "/volunteers/cancellation/{volunteer-application-id}").hasAuthority(STUDENT.name)
+                .requestMatchers(HttpMethod.DELETE, "/volunteers/cancellation/{volunteer-id}").hasAuthority(STUDENT.name)
                 .requestMatchers(HttpMethod.GET, "/volunteers").hasAuthority(STUDENT.name)
                 .requestMatchers(HttpMethod.GET, "/volunteers/my/application").hasAuthority(STUDENT.name)
 

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/VolunteerApplicationPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/VolunteerApplicationPersistenceAdapter.kt
@@ -76,7 +76,7 @@ class VolunteerApplicationPersistenceAdapter(
             .leftJoin(volunteerApplicationJpaEntity)
             .on(
                 volunteerApplicationJpaEntity.volunteer.id.eq(volunteerJpaEntity.id)
-                    .and(volunteerApplicationJpaEntity.approved.isFalse.not())
+                    .and(volunteerApplicationJpaEntity.approved.isTrue)
             )
             .leftJoin(studentJpaEntity)
             .on(studentJpaEntity.id.eq(volunteerApplicationJpaEntity.student.id))
@@ -90,6 +90,8 @@ class VolunteerApplicationPersistenceAdapter(
                             volunteerJpaEntity.name,
                             volunteerJpaEntity.availableSex,
                             volunteerJpaEntity.availableGrade,
+                            list(volunteerApplicationJpaEntity.id),
+                            volunteerJpaEntity.maxApplicants,
                             list(
                                 QQueryVolunteerApplicantVO(
                                     volunteerApplicationJpaEntity.id,

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/VolunteerPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/VolunteerPersistenceAdapter.kt
@@ -1,17 +1,25 @@
 package team.aliens.dms.persistence.volunteer
 
+import com.querydsl.core.group.GroupBy.groupBy
+import com.querydsl.core.group.GroupBy.list
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.aliens.dms.domain.volunteer.model.Volunteer
 import team.aliens.dms.domain.volunteer.spi.VolunteerPort
+import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
+import team.aliens.dms.persistence.volunteer.entity.QVolunteerApplicationJpaEntity.volunteerApplicationJpaEntity
+import team.aliens.dms.persistence.volunteer.entity.QVolunteerJpaEntity.volunteerJpaEntity
 import team.aliens.dms.persistence.volunteer.mapper.VolunteerMapper
 import team.aliens.dms.persistence.volunteer.repository.VolunteerJpaRepository
+import team.aliens.dms.persistence.volunteer.repository.vo.QQueryVolunteerWithCurrentApplicantVO
 import java.util.UUID
 
 @Component
 class VolunteerPersistenceAdapter(
     private val volunteerMapper: VolunteerMapper,
-    private val volunteerJpaRepository: VolunteerJpaRepository
+    private val volunteerJpaRepository: VolunteerJpaRepository,
+    private val queryFactory: JPAQueryFactory
 ) : VolunteerPort {
 
     override fun saveVolunteer(volunteer: Volunteer): Volunteer = volunteerMapper.toDomain(
@@ -33,5 +41,31 @@ class VolunteerPersistenceAdapter(
     override fun queryAllVolunteersBySchoolId(schoolId: UUID): List<Volunteer> {
         return volunteerJpaRepository.findAllBySchoolId(schoolId)
             .map { volunteerMapper.toDomain(it)!! }
+    }
+
+    override fun queryAllVolunteersWithCurrentApplicantsBySchoolId(schoolId: UUID): List<VolunteerWithCurrentApplicantVO> {
+        return queryFactory.selectFrom(volunteerJpaEntity)
+            .leftJoin(volunteerApplicationJpaEntity)
+            .on(
+                volunteerApplicationJpaEntity.volunteer.id.eq(volunteerJpaEntity.id),
+                volunteerApplicationJpaEntity.approved.isTrue
+            )
+            .transform(
+                groupBy(volunteerJpaEntity.id)
+                    .list(
+                        QQueryVolunteerWithCurrentApplicantVO(
+                            volunteerJpaEntity.id,
+                            volunteerJpaEntity.name,
+                            volunteerJpaEntity.content,
+                            volunteerJpaEntity.score,
+                            volunteerJpaEntity.optionalScore,
+                            list(volunteerApplicationJpaEntity.id),
+                            volunteerJpaEntity.maxApplicants,
+                            volunteerJpaEntity.availableSex,
+                            volunteerJpaEntity.availableGrade,
+                            volunteerJpaEntity.school.id
+                        )
+                    )
+            )
     }
 }

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/vo/QueryCurrentVolunteerApplicantVO.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/vo/QueryCurrentVolunteerApplicantVO.kt
@@ -4,15 +4,20 @@ import com.querydsl.core.annotations.QueryProjection
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.volunteer.model.AvailableGrade
 import team.aliens.dms.domain.volunteer.spi.vo.CurrentVolunteerApplicantVO
+import java.util.UUID
 
 class QueryCurrentVolunteerApplicantVO @QueryProjection constructor(
     volunteerName: String,
     availableSex: Sex,
     availableGrade: AvailableGrade,
+    currentApplicants: List<UUID>,
+    maxApplicants: Int,
     applicants: List<QueryVolunteerApplicantVO>
 ) : CurrentVolunteerApplicantVO(
     volunteerName = volunteerName,
     availableSex = availableSex,
     availableGrade = availableGrade,
+    currentApplicants = currentApplicants.size,
+    maxApplicants = maxApplicants,
     applicants = applicants
 )

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/vo/QueryVolunteerWithCurrentApplicantVO.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/vo/QueryVolunteerWithCurrentApplicantVO.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.persistence.volunteer.repository.vo
 import com.querydsl.core.annotations.QueryProjection
 import team.aliens.dms.domain.student.model.Sex
 import team.aliens.dms.domain.volunteer.model.AvailableGrade
+import team.aliens.dms.domain.volunteer.model.VolunteerApplicationStatus
 import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
 import java.util.UUID
 
@@ -16,7 +17,8 @@ class QueryVolunteerWithCurrentApplicantVO @QueryProjection constructor(
     maxApplicants: Int,
     availableSex: Sex,
     availableGrade: AvailableGrade,
-    schoolId: UUID
+    schoolId: UUID,
+    status: Boolean?
 ) : VolunteerWithCurrentApplicantVO(
     id = id,
     name = name,
@@ -27,5 +29,6 @@ class QueryVolunteerWithCurrentApplicantVO @QueryProjection constructor(
     maxApplicants = maxApplicants,
     availableSex = availableSex,
     availableGrade = availableGrade,
-    schoolId = schoolId
+    schoolId = schoolId,
+    status = VolunteerApplicationStatus.of(status)
 )

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/vo/QueryVolunteerWithCurrentApplicantVO.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/repository/vo/QueryVolunteerWithCurrentApplicantVO.kt
@@ -1,0 +1,31 @@
+package team.aliens.dms.persistence.volunteer.repository.vo
+
+import com.querydsl.core.annotations.QueryProjection
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.volunteer.model.AvailableGrade
+import team.aliens.dms.domain.volunteer.spi.vo.VolunteerWithCurrentApplicantVO
+import java.util.UUID
+
+class QueryVolunteerWithCurrentApplicantVO @QueryProjection constructor(
+    id: UUID,
+    name: String,
+    content: String,
+    score: Int,
+    optionalScore: Int,
+    currentApplicants: List<UUID>,
+    maxApplicants: Int,
+    availableSex: Sex,
+    availableGrade: AvailableGrade,
+    schoolId: UUID
+) : VolunteerWithCurrentApplicantVO(
+    id = id,
+    name = name,
+    content = content,
+    score = score,
+    optionalScore = optionalScore,
+    currentApplicants = currentApplicants.size,
+    maxApplicants = maxApplicants,
+    availableSex = availableSex,
+    availableGrade = availableGrade,
+    schoolId = schoolId
+)

--- a/dms-presentation/src/main/kotlin/team/aliens/dms/domain/volunteer/VolunteerWebAdapter.kt
+++ b/dms-presentation/src/main/kotlin/team/aliens/dms/domain/volunteer/VolunteerWebAdapter.kt
@@ -63,9 +63,9 @@ class VolunteerWebAdapter(
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/cancellation/{volunteer-application-id}")
-    fun unapplyVolunteer(@PathVariable("volunteer-application-id") @NotNull volunteerApplicationId: UUID) {
-        unapplyVolunteerUseCase.execute(volunteerApplicationId)
+    @DeleteMapping("/cancellation/{volunteer-id}")
+    fun unapplyVolunteer(@PathVariable("volunteer-id") @NotNull volunteerId: UUID) {
+        unapplyVolunteerUseCase.execute(volunteerId)
     }
 
     @ResponseStatus(HttpStatus.OK)


### PR DESCRIPTION
## 작업 내용 설명
- [x] response에 currentApplicants 필드 추가
- [x] 학생 조회 response에 status 필드 추가

## 주요 변경 사항
- VO 추가
- Response of 메서드의 매개 변수 클래스를 VO 로 변경

- status ENUM 추가 (노션에 명세 해놨습니다)
- response 에 status가 추가됨에 따라 approved 필드를 제거
- 쿼리의 반환값을 List<Pair<>> 에서 List<Triple<>> 로 변경

- 현재 봉사자에 따른 신청제약은 서버에서 처리하지 않습니다.

## 결과물
![image](https://github.com/user-attachments/assets/a7be86ff-b548-4154-9b08-1858c58e226a)
![image](https://github.com/user-attachments/assets/bbc348bc-2463-4c7f-8e45-4d4db5219764)


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #774 