### PR TITLE
merge: (#814) 워크플로우 버전 업그레이드

### DIFF
--- a/.github/workflows/xquare-cd-prod.yml
+++ b/.github/workflows/xquare-cd-prod.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'


### PR DESCRIPTION
## 작업 내용 설명
![Image](https://github.com/user-attachments/assets/9543a053-0141-4df5-a3c9-a56cfa43e056)

2025년 2월 1일부터 actions/cache 의 v1-v2를 종료합니다 (이 [변경 로그 발표](https://app.github.media/e/er?s=88570519&lid=6815&elqTrackId=08a5e2ee0de44b669cfee44c72a218f2&elq=a03ae9e6b46c431a96ca345bbad99b2c&elqaid=4282&elqat=1&elqak=8AF5E7AAA12E3C7C230E5849DC6FF5707A506F974B68867C08DD3502A54AFC88073A) 에서 자세히 읽어보세요)  actions/toolkit 의 @actions/cache 패키지 의 모든 이전 버전도 종료 합니다. 발표된 사용 중단 날짜 이후에 @actions/cache 패키지 또는 actions/cache 버전을 사용하려고 하면 워크플로 오류가 발생합니다. 캐시 작업의 특정 버전이나 SHA에 고정된 경우 2월 1일 이후에도 워크플로가 실패합니다.

필요한 작업:
지원되는 버전의 actions/cache를 사용하도록 워크플로를 업데이트하고 @actions/cache 패키지를 기반으로 하는 작업이나 다른 제품을 4.0.0 이상으로 업그레이드하는 것이 좋습니다.

| **actions/cache 버전 올리면서 구 버전인 다른 요소들도 버전업 해줬습니다**

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #814 