### PR TITLE
merge: (#840) 상벌점 토탈 조회 쿼리 리팩토링

### DIFF
--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -186,7 +186,7 @@ class PointHistoryPersistenceAdapter(
                 )
             )
             .from(studentJpaEntity)
-            .leftJoin(pointHistoryJpaEntity).on(
+            .join(pointHistoryJpaEntity).on(
                 pointHistoryJpaEntity.id.`in`(history)
             )
             .fetch()

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -160,11 +160,10 @@ class PointHistoryPersistenceAdapter(
         pointHistoryRepository.findByStudentGcnIn(gcns)
             .map { pointHistoryMapper.toDomain(it)!! }
 
-
     override fun queryPointTotalsGroupByStudent(): List<StudentTotalVO> {
         val latestPointHistory = QPointHistoryJpaEntity("latestPointHistory")
 
-        val subQuery = JPAExpressions
+        val history = JPAExpressions
             .select(latestPointHistory.id)
             .from(latestPointHistory)
             .where(
@@ -188,7 +187,7 @@ class PointHistoryPersistenceAdapter(
             )
             .from(studentJpaEntity)
             .leftJoin(pointHistoryJpaEntity).on(
-                pointHistoryJpaEntity.id.`in`(subQuery)
+                pointHistoryJpaEntity.id.`in`(history)
             )
             .fetch()
     }

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -171,7 +171,7 @@ class PointHistoryPersistenceAdapter(
                 latestPointHistory.studentGcn.startsWith(
                     studentJpaEntity.grade.stringValue().toString() +
                         studentJpaEntity.classRoom.stringValue() +
-                        studentJpaEntity.number.stringValue()
+                        studentJpaEntity.number.stringValue().toString().padStart(2, '0')
                 ),
                 latestPointHistory.studentName.eq(studentJpaEntity.name)
             )

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -167,7 +167,7 @@ class PointHistoryPersistenceAdapter(
             .select(latestPointHistory.id)
             .from(latestPointHistory)
             .where(
-                latestPointHistory.studentGcn.startsWith(
+                latestPointHistory.studentGcn.eq(
                     studentJpaEntity.grade.stringValue().toString() +
                         studentJpaEntity.classRoom.stringValue() +
                         studentJpaEntity.number.stringValue().toString().padStart(2, '0')


### PR DESCRIPTION
## 작업 내용 설명
select(pointHistoryJpaEntity.createdAt.max()) 서브 쿼리 <-  join으로 대체
substring를 gcn에 사용하여 인덱스가 무시당하는 이슈 <- eq로 대체 
 ‭ ‭ ‭
- 지금 조인 형태가 student - pointhistory 의 LeftJoin 형식인데 
join 형식으로 변경하여 벌점을 받은 학생만 조회 하도록 변경하였습니다
 ‭ ‭ ‭
- padStart 사용해서 학생 번호 처리해주었습니다
https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/pad-start.html
 ‭ ‭ ‭
 ‭ ‭ ‭
## 결과물
<!-- 결과 화면 캡처 -->


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #840 