### PR TITLE
merge: (#844) 투표 결과 조회 쿼리 모범학생, 학생 분리 및 관련된 기능 전체 수정

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/service/GetVoteService.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/service/GetVoteService.kt
@@ -18,6 +18,8 @@ interface GetVoteService {
 
     fun getVotesInStudentVotingByVotingTopicId(votingTopicId: UUID, grade: Int): List<StudentVotingResultVO>
 
+    fun getVotesInModelStudentVotingByVotingTopicId(votingTopicId: UUID, grade: Int): List<StudentVotingResultVO>
+
     fun getVotesInOptionVotingByVotingTopicId(votingTopicId: UUID): List<OptionVotingResultVO>
 
     fun getVotingOptionById(votingOptionId: UUID): VotingOption

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/service/GetVoteServiceImpl.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/service/GetVoteServiceImpl.kt
@@ -39,6 +39,10 @@ class GetVoteServiceImpl(
         return queryVotePort.queryStudentVotingByVotingTopicIdAndGrade(votingTopicId, grade)
     }
 
+    override fun getVotesInModelStudentVotingByVotingTopicId(votingTopicId: UUID, grade: Int): List<StudentVotingResultVO> {
+        return queryVotePort.queryModelStudentVotingByVotingTopicIdAndGrade(votingTopicId, grade)
+    }
+
     override fun getVotesInOptionVotingByVotingTopicId(votingTopicId: UUID): List<OptionVotingResultVO> {
         return queryVotePort.queryOptionVotingByVotingTopicId(votingTopicId)
     }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/spi/QueryVotePort.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/spi/QueryVotePort.kt
@@ -14,4 +14,6 @@ interface QueryVotePort {
     fun queryOptionVotingByVotingTopicId(votingTopicId: UUID): List<OptionVotingResultVO>
 
     fun queryVoteByStudentId(studentId: UUID): List<Vote>
+
+    fun queryModelStudentVotingByVotingTopicIdAndGrade(votingTopicId: UUID, grade: Int): List<StudentVotingResultVO>
 }

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/usecase/QueryVotesUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/usecase/QueryVotesUseCase.kt
@@ -21,7 +21,8 @@ class QueryVotesUseCase(
         val votingTopic = voteService.getVotingTopicById(votingTopicId)
 
         return when (votingTopic.voteType) {
-            VoteType.STUDENT_VOTE, VoteType.MODEL_STUDENT_VOTE -> queryStudentVotingVotes(votingTopicId)
+            VoteType.STUDENT_VOTE -> queryStudentVotingVotes(votingTopicId, false)
+            VoteType.MODEL_STUDENT_VOTE -> queryStudentVotingVotes(votingTopicId, true)
             VoteType.OPTION_VOTE, VoteType.APPROVAL_VOTE -> queryOptionVotingVotes(votingTopicId)
         }
     }
@@ -40,10 +41,14 @@ class QueryVotesUseCase(
         )
     }
 
-    private fun queryStudentVotingVotes(votingTopicId: UUID): VotesResponse {
+    private fun queryStudentVotingVotes(votingTopicId: UUID, isModelStudent: Boolean): VotesResponse {
         return VotesResponse.of(
             listOf(1, 2, 3).flatMap { grade ->
-                val result: List<StudentVotingResultVO> = voteService.getVotesInStudentVotingByVotingTopicId(votingTopicId, grade)
+
+                val result: List<StudentVotingResultVO> =
+                    if (isModelStudent) voteService.getVotesInModelStudentVotingByVotingTopicId(votingTopicId, grade)
+                    else voteService.getVotesInStudentVotingByVotingTopicId(votingTopicId, grade)
+
                 result.map { votingResult ->
                     val student = studentService.getStudentById(votingResult.id)
                     val classNumber = Student.processGcn(

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/usecase/QueryVotesUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/usecase/QueryVotesUseCase.kt
@@ -1,6 +1,6 @@
 package team.aliens.dms.domain.vote.usecase
 
-import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.student.service.StudentService
 import team.aliens.dms.domain.vote.dto.response.VoteResponse
@@ -11,7 +11,7 @@ import team.aliens.dms.domain.vote.spi.vo.OptionVotingResultVO
 import team.aliens.dms.domain.vote.spi.vo.StudentVotingResultVO
 import java.util.UUID
 
-@UseCase
+@ReadOnlyUseCase
 class QueryVotesUseCase(
     private val voteService: VoteService,
     private val studentService: StudentService

--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/usecase/UpdateVotingTopicUseCase.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/usecase/UpdateVotingTopicUseCase.kt
@@ -16,7 +16,7 @@ class UpdateVotingTopicUseCase(
 ) {
 
     fun execute(request: UpdateVotingTopicRequest) {
-        if (request.startTime.isAfter(request.endTime)) {
+        if (request.startTime.isAfter(request.endTime) || request.endTime.isBefore(LocalDateTime.now())) {
             throw InvalidPeriodException
         }
 

--- a/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/vote/VotePersistenceAdapter.kt
+++ b/dms-persistence/src/main/kotlin/team/aliens/dms/persistence/vote/VotePersistenceAdapter.kt
@@ -1,5 +1,9 @@
 package team.aliens.dms.persistence.vote
 
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.NumberTemplate
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -7,6 +11,7 @@ import team.aliens.dms.domain.vote.model.Vote
 import team.aliens.dms.domain.vote.spi.VotePort
 import team.aliens.dms.domain.vote.spi.vo.OptionVotingResultVO
 import team.aliens.dms.domain.vote.spi.vo.StudentVotingResultVO
+import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity
 import team.aliens.dms.persistence.student.entity.QStudentJpaEntity.studentJpaEntity
 import team.aliens.dms.persistence.vote.entity.QVoteJpaEntity.voteJpaEntity
 import team.aliens.dms.persistence.vote.entity.QVotingOptionJpaEntity.votingOptionJpaEntity
@@ -15,6 +20,7 @@ import team.aliens.dms.persistence.vote.mapper.VoteMapper
 import team.aliens.dms.persistence.vote.repository.VoteJpaRepository
 import team.aliens.dms.persistence.vote.repository.vo.QQueryOptionVotingResultVO
 import team.aliens.dms.persistence.vote.repository.vo.QQueryStudentVotingResultVO
+import team.aliens.dms.persistence.vote.repository.vo.QueryStudentVotingResultVO
 import java.util.UUID
 
 @Component
@@ -73,8 +79,68 @@ class VotePersistenceAdapter(
     }
 
     override fun queryVoteByStudentId(studentId: UUID): List<Vote> =
-        voteJpaRepository.findByStudentId(studentId).map {
-                entity ->
+        voteJpaRepository.findByStudentId(studentId).map { entity ->
             voteMapper.toDomain(entity)!!
         }
+
+    override fun queryModelStudentVotingByVotingTopicIdAndGrade(
+        votingTopicId: UUID,
+        grade: Int
+    ): List<StudentVotingResultVO> {
+        val subPointHistoryJpaEntity = QPointHistoryJpaEntity("subPointHistory")
+
+        val selectedStudentGcnExpr =
+            voteJpaEntity.selectedStudent.grade.multiply(1000)
+                .add(voteJpaEntity.selectedStudent.classRoom.multiply(100))
+                .add(voteJpaEntity.selectedStudent.number).stringValue()
+
+        val bonusTotalSubQuery: Expression<Int> = JPAExpressions
+            .select(subPointHistoryJpaEntity.bonusTotal)
+            .from(subPointHistoryJpaEntity)
+            .where(
+                subPointHistoryJpaEntity.studentGcn.eq(selectedStudentGcnExpr),
+                subPointHistoryJpaEntity.createdAt.eq(
+                    JPAExpressions.select(subPointHistoryJpaEntity.createdAt.max())
+                        .from(subPointHistoryJpaEntity)
+                        .where(
+                            subPointHistoryJpaEntity.studentGcn.eq(selectedStudentGcnExpr)
+                        )
+                )
+            )
+
+        val bonusTotalOrderExpr: NumberTemplate<Int> = Expressions.numberTemplate(
+            Int::class.java,
+            "({0})",
+            bonusTotalSubQuery
+        )
+
+        val results = queryFactory
+            .select(
+                studentJpaEntity.id,
+                studentJpaEntity.name,
+                voteJpaEntity.id.count().intValue().coalesce(0),
+                bonusTotalOrderExpr
+            )
+            .from(voteJpaEntity)
+            .join(voteJpaEntity.selectedStudent, studentJpaEntity)
+            .join(voteJpaEntity.votingTopic, votingTopicJpaEntity)
+            .where(
+                votingTopicJpaEntity.id.eq(votingTopicId),
+                studentJpaEntity.grade.eq(grade)
+            )
+            .groupBy(studentJpaEntity.id, studentJpaEntity.name)
+            .orderBy(
+                voteJpaEntity.id.count().intValue().desc(),
+                bonusTotalOrderExpr.intValue().asc()
+            )
+            .fetch()
+
+        return results.map {
+            QueryStudentVotingResultVO(
+                id = it.get(studentJpaEntity.id)!!,
+                name = it.get(studentJpaEntity.name)!!,
+                votes = it.get(voteJpaEntity.id.count().intValue().coalesce(0))!!
+            )
+        }
+    }
 }


### PR DESCRIPTION
## 작업 내용 설명
* 투표결과 조회 쿼리 모범학생, 학생투표로 분리함
* 기존에 "임시" 로 되어있던 투표 결과 공지로 보내는 기능을 실제 투표 결과로 보내게 수정
* QueryVotesUseCase 에서 보내는 투표결과를 모범학생, 학생으로 분리해서 결과 가져오게 함.
* votePersistenceAdapter 에서 JPA 표현식을 사용하여 최대한 queryDSL 코드를 분리함

## 주요 변경 사항
* QueryVoteUseCase
* VotePersistenceAdapter
* CommandNoticeServiceImpl

## 결과물

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #844 