### PR TITLE
merge: (#881) 투표 결과 조회 시 투표 주제 이름도 같이 보여주게 변경

### DIFF
--- a/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/dto/response/VoteResponse.kt
+++ b/dms-core/src/main/kotlin/team/aliens/dms/domain/vote/dto/response/VoteResponse.kt
@@ -86,13 +86,16 @@ data class VoteResponse(
 }
 
 data class VotesResponse(
+    val votingTopicName: String,
     val votes: List<VoteResponse>
 ) {
     companion object {
         fun of(
-            votes: List<VoteResponse>
+            votes: List<VoteResponse>,
+            votingTopicName: String
         ) = VotesResponse(
-            votes = votes
+            votes = votes,
+            votingTopicName = votingTopicName
         )
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- 기존 투표 주제 이름 확인 불가능하던 api에서 확인 가능하게 변경
## 주요 변경 사항
## 결과물
![image](https://github.com/user-attachments/assets/f1cf9eab-3309-4e38-964f-d90a62c47c6a)
## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #881 