### PR TITLE
merge: (#922) MealScheduler cron 실행일 20 -> 28일으로 수정

### DIFF
--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/scheduler/MealScheduler.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/scheduler/MealScheduler.kt
@@ -10,8 +10,8 @@ class MealScheduler(
 ) {
 
     /**
-     * 매달 20일에 cron job 실행
+     * 매달 28일에 cron job 실행
      */
-    @Scheduled(cron = "0 0 0 20 * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 28 * *", zone = "Asia/Seoul")
     fun saveAllMeals() = saveAllMealsUseCase.execute()
 }


### PR DESCRIPTION
## 작업 내용 설명
- 기존 20일에 실행되던 MealScheduler가 작동하지 않아 실행일을 28일로 수정했습니다.

## 주요 변경 사항

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #922 