### PR TITLE
merge: (#949) 알림 읽기 작업 API 분리

### DIFF
--- a/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/GetNotificationService.kt
+++ b/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/GetNotificationService.kt
@@ -9,6 +9,8 @@ interface GetNotificationService {
 
     fun getNotificationOfUsersByUserId(userId: UUID): List<NotificationOfUser>
 
+    fun getNotificationOfUserById(notificationOfUserId: UUID): NotificationOfUser
+
     fun getTopicSubscriptionsByToken(token: String): List<TopicSubscription>
 
     fun getDeviceTokenByToken(token: String): DeviceToken

--- a/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/GetNotificationServiceImpl.kt
+++ b/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/GetNotificationServiceImpl.kt
@@ -2,8 +2,8 @@ package team.aliens.dms.domain.notification.service
 
 import team.aliens.dms.common.annotation.Service
 import team.aliens.dms.domain.notification.exception.DeviceTokenNotFoundException
+import team.aliens.dms.domain.notification.exception.NotificationOfUserNotFoundException
 import team.aliens.dms.domain.notification.model.DeviceToken
-import team.aliens.dms.domain.notification.model.TopicSubscription
 import team.aliens.dms.domain.notification.spi.QueryDeviceTokenPort
 import team.aliens.dms.domain.notification.spi.QueryNotificationOfUserPort
 import team.aliens.dms.domain.notification.spi.QueryTopicSubscriptionPort
@@ -19,10 +19,12 @@ class GetNotificationServiceImpl(
     override fun getNotificationOfUsersByUserId(userId: UUID) =
         notificationOfUserPort.queryNotificationOfUserByUserId(userId)
 
-    override fun getTopicSubscriptionsByToken(token: String): List<TopicSubscription> {
-        val savedToken = getDeviceTokenByToken(token)
-        return topicSubscriptionPort.queryTopicSubscriptionsByDeviceTokenId(savedToken.id)
-    }
+    override fun getNotificationOfUserById(notificationOfUserId: UUID) =
+        notificationOfUserPort.queryNotificationOfUserById(notificationOfUserId)
+            ?: throw NotificationOfUserNotFoundException
+
+    override fun getTopicSubscriptionsByToken(token: String) =
+        topicSubscriptionPort.queryTopicSubscriptionsByDeviceTokenId(getDeviceTokenByToken(token).id)
 
     override fun getDeviceTokenByToken(token: String) =
         deviceTokenPort.queryDeviceTokenByToken(token) ?: throw DeviceTokenNotFoundException

--- a/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/QueryMyNotificationsUseCase.kt
+++ b/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/QueryMyNotificationsUseCase.kt
@@ -6,7 +6,7 @@ import team.aliens.dms.domain.notification.dto.NotificationsResponse
 import team.aliens.dms.domain.notification.service.NotificationService
 
 @UseCase
-class QueryAndReadMyNotificationsUseCase(
+class QueryMyNotificationsUseCase(
     private val securityService: SecurityService,
     private val notificationService: NotificationService
 ) {
@@ -14,7 +14,6 @@ class QueryAndReadMyNotificationsUseCase(
     fun execute(): NotificationsResponse {
         val userId = securityService.getCurrentUserId()
         val notificationsOfUser = notificationService.getNotificationOfUsersByUserId(userId)
-        notificationService.saveNotificationsOfUser(notificationsOfUser.map { it.read() })
         return NotificationsResponse.of(notificationsOfUser)
     }
 }

--- a/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/ReadNotificationUseCase.kt
+++ b/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/usecase/ReadNotificationUseCase.kt
@@ -1,0 +1,15 @@
+package team.aliens.dms.domain.notification.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.notification.service.NotificationService
+import java.util.UUID
+
+@UseCase
+class ReadNotificationUseCase(
+    private val notificationService: NotificationService
+) {
+    fun execute(notificationOfUserId: UUID) {
+        val notificationOfUser = notificationService.getNotificationOfUserById(notificationOfUserId)
+        notificationService.saveNotificationOfUser(notificationOfUser.read())
+    }
+}

--- a/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -37,6 +37,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/notifications/topic").authenticated()
                     .requestMatchers(HttpMethod.PATCH, "/notifications/topic").authenticated()
                     .requestMatchers(HttpMethod.GET, "/notifications").authenticated()
+                    .requestMatchers(HttpMethod.PATCH, "/notifications/{notification-of-user-id}/read").authenticated()
                     .requestMatchers(HttpMethod.PATCH, "/notifications/topic/toggle").authenticated()
             }
         http

--- a/dms-notification/notification-presentation/src/main/kotlin/team/aliens/dms/domain/notification/NotificationWebAdapter.kt
+++ b/dms-notification/notification-presentation/src/main/kotlin/team/aliens/dms/domain/notification/NotificationWebAdapter.kt
@@ -19,8 +19,9 @@ import team.aliens.dms.domain.notification.dto.TopicSubscriptionGroupsResponse
 import team.aliens.dms.domain.notification.dto.request.DeviceTokenWebRequest
 import team.aliens.dms.domain.notification.dto.request.TopicRequest
 import team.aliens.dms.domain.notification.dto.request.UpdateTopicSubscriptionsWebRequest
-import team.aliens.dms.domain.notification.usecase.QueryAndReadMyNotificationsUseCase
+import team.aliens.dms.domain.notification.usecase.QueryMyNotificationsUseCase
 import team.aliens.dms.domain.notification.usecase.QueryTopicSubscriptionUseCase
+import team.aliens.dms.domain.notification.usecase.ReadNotificationUseCase
 import team.aliens.dms.domain.notification.usecase.RemoveMyAllNotificationUseCase
 import team.aliens.dms.domain.notification.usecase.RemoveNotificationUseCase
 import team.aliens.dms.domain.notification.usecase.SetDeviceTokenUseCase
@@ -35,7 +36,8 @@ import java.util.UUID
 @RestController
 class NotificationWebAdapter(
     private val setDeviceTokenUseCase: SetDeviceTokenUseCase,
-    private val queryAndReadMyNotificationsUseCase: QueryAndReadMyNotificationsUseCase,
+    private val queryMyNotificationsUseCase: QueryMyNotificationsUseCase,
+    private val readNotificationUseCase: ReadNotificationUseCase,
     private val subscribeTopicUseCase: SubscribeTopicUseCase,
     private val unsubscribeTopicUseCase: UnsubscribeTopicUseCase,
     private val updateTopicSubscriptionsUseCase: UpdateTopicSubscriptionsUseCase,
@@ -54,7 +56,13 @@ class NotificationWebAdapter(
 
     @GetMapping
     fun queryMyNotifications(): NotificationsResponse {
-        return queryAndReadMyNotificationsUseCase.execute()
+        return queryMyNotificationsUseCase.execute()
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/{notification-of-user-id}/read")
+    fun readNotification(@PathVariable("notification-of-user-id") notificationOfUserId: UUID) {
+        readNotificationUseCase.execute(notificationOfUserId)
     }
 
     @PostMapping("/topic")


### PR DESCRIPTION
## 작업 내용 설명
- [x] 알림 조회 API에서 읽기 로직 제거
- [x] 개별 알림 읽음 처리 API 추가
- [x] ReadNotificationUseCase 신규 생성
- [x] SecurityConfig에 새 엔드포인트 인증 설정 추가

## 주요 변경 사항
- **QueryMyNotificationsUseCase**: 알림 조회만 수행 (기존 QueryAndReadMyNotificationsUseCase 리네임)
- **ReadNotificationUseCase**: 개별 알림 읽음 처리를 위한 UseCase 신규 생성
- **GetNotificationService**: getNotificationOfUserById() 메서드 추가
- **NotificationWebAdapter**: PATCH /notifications/{notification-of-user-id}/read 엔드포인트 추가
- **SecurityConfig**: 새 엔드포인트에 대한 인증 설정 추가

## 결과물
클라이언트에서 알림을 개별적으로 읽음 처리할 수 있도록 API 분리
- GET /notifications - 알림 목록 조회
- PATCH /notifications/{notification-of-user-id}/read - 개별 알림 읽음 처리

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #949