### PR TITLE
merge: (#978) 모범학생 후보 제외학생 조회시 n+1 문제 개선

### DIFF
--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/StudentJpaRepository.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/StudentJpaRepository.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.persistence.student.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import team.aliens.dms.persistence.student.entity.StudentJpaEntity
@@ -19,5 +20,6 @@ interface StudentJpaRepository : CrudRepository<StudentJpaEntity, UUID> {
 
     fun existsByUserId(userId: UUID): Boolean
 
+    @EntityGraph(attributePaths = ["room"])
     fun findAllByIdIn(ids: List<UUID>): List<StudentJpaEntity>
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 모범학생 후보 제외학생을 조회할 때 연관 엔티티 room을 조회하면서 n+1 문제 발생

## 주요 변경 사항
- EntityGraph(["room"]) 추가

## 결과물
Docker를 활용하여 독립적인 환경에서 성능 부하 테스트를 진행하였고, 도커 환경은 t4g.medium과 비슷한 성능으로, vcpu 2개, memory 4Ggib로 하였습니다

### before
<img width="1511" height="718" alt="image" src="https://github.com/user-attachments/assets/5cf3c2fb-1f26-47e6-beab-72ca4a3163df" />

### after
<img width="1502" height="720" alt="image" src="https://github.com/user-attachments/assets/e70f549f-2a0d-4816-9191-cc9579c887c7" />


###  성능 개선 결과

| 지표 (Metric) | 기존 (12:23) | 변경 후 (12:02) | 성능 개선 (배수) |
| :--- | :---: | :---: | :--- |
| **Mean (평균)** | 1,697 ms | 812 ms |  **2.09배** 빨라짐 |
| **Min (최소)** | 410 ms | 220 ms |  **1.86배** 빨라짐 |
| **Max (최대)** | 2,217 ms | 1,008 ms |  **2.20배** 빨라짐 |
| **50th pct (중간값)** | 1,795 ms | 865 ms |  **2.08배** 빨라짐 |



## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #978