### PR TITLE
merge: (#987) 학생이 자신의 새벽 자습 신청 상태 조회 기능 추가

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/dto/response/DaybreakResponse.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/dto/response/DaybreakResponse.kt
@@ -1,6 +1,8 @@
 package team.aliens.dms.domain.daybreak.dto.response
 
+import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationVO
+import java.time.LocalDate
 import java.util.UUID
 
 data class DaybreakStudyApplicationResponse(
@@ -15,3 +17,9 @@ data class DaybreakStudyTypesResponse(
         val name: String,
     )
 }
+
+data class DaybreakStudyApplicationStatusResponse(
+    val status: Status,
+    val startDate: LocalDate,
+    val endDate: LocalDate
+)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakService.kt
@@ -4,6 +4,7 @@ import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyType
 import team.aliens.dms.domain.daybreak.model.Status
+import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationStatusVO
 import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationVO
 import java.time.LocalDate
 import java.util.UUID
@@ -35,4 +36,6 @@ interface GetDaybreakService {
     fun getDaybreakStudyTypesBySchoolId(schoolId: UUID): List<DaybreakStudyType>
 
     fun getAllByIdIn(ids: List<UUID>): List<DaybreakStudyApplication>
+
+    fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID): DaybreakStudyApplicationStatusVO
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
@@ -75,4 +75,8 @@ class GetDaybreakServiceImpl(
         return queryDaybreakStudyApplicationPort.getAllByIdIn(ids)
             .apply { if (size != ids.size) throw DaybreakStudyApplicationNotFoundException }
     }
+
+    override fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID) =
+        queryDaybreakStudyApplicationPort.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) ?: throw DaybreakStudyApplicationNotFoundException
+
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
@@ -78,5 +78,4 @@ class GetDaybreakServiceImpl(
 
     override fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID) =
         queryDaybreakStudyApplicationPort.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) ?: throw DaybreakStudyApplicationNotFoundException
-
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/QueryDaybreakStudyApplicationPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/QueryDaybreakStudyApplicationPort.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.domain.daybreak.spi
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
 import team.aliens.dms.domain.daybreak.model.Status
+import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationStatusVO
 import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationVO
 import java.time.LocalDate
 import java.util.UUID
@@ -33,4 +34,6 @@ interface QueryDaybreakStudyApplicationPort {
     ): List<DaybreakStudyApplicationVO>
 
     fun getAllByIdIn(ids: List<UUID>): List<DaybreakStudyApplication>
+
+    fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID): DaybreakStudyApplicationStatusVO?
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/vo/DaybreakStudyApplicationStatusVO.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/vo/DaybreakStudyApplicationStatusVO.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.daybreak.spi.vo
+
+import team.aliens.dms.domain.daybreak.model.Status
+import java.time.LocalDate
+
+open class DaybreakStudyApplicationStatusVO(
+    val status: Status,
+    val startDate: LocalDate,
+    val endDate: LocalDate
+)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCase.kt
@@ -11,7 +11,7 @@ class QueryDaybreakStudyApplicationStatusUseCase(
     private val studentService: StudentService
 ) {
 
-    fun execute() : DaybreakStudyApplicationStatusResponse{
+    fun execute(): DaybreakStudyApplicationStatusResponse {
         val student = studentService.getCurrentStudent()
 
         val statusInfo = daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(student.id)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCase.kt
@@ -1,0 +1,25 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationStatusResponse
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.student.service.StudentService
+
+@ReadOnlyUseCase
+class QueryDaybreakStudyApplicationStatusUseCase(
+    private val daybreakService: DaybreakService,
+    private val studentService: StudentService
+) {
+
+    fun execute() : DaybreakStudyApplicationStatusResponse{
+        val student = studentService.getCurrentStudent()
+
+        val statusInfo = daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(student.id)
+
+        return DaybreakStudyApplicationStatusResponse(
+            status = statusInfo.status,
+            startDate = statusInfo.startDate,
+            endDate = statusInfo.endDate
+        )
+    }
+}

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyTypesUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyTypesUseCase.kt
@@ -1,12 +1,12 @@
 package team.aliens.dms.domain.daybreak.usecase
 
-import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyTypesResponse
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyTypesResponse.DaybreakStudyTypeResponse
 import team.aliens.dms.domain.daybreak.service.DaybreakService
 
-@UseCase
+@ReadOnlyUseCase
 class QueryDaybreakStudyTypesUseCase(
     private val daybreakService: DaybreakService,
     private val securityService: SecurityService

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryGeneralTeacherDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryGeneralTeacherDaybreakStudyApplicationUseCase.kt
@@ -1,6 +1,6 @@
 package team.aliens.dms.domain.daybreak.usecase
 
-import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
@@ -8,7 +8,7 @@ import team.aliens.dms.domain.daybreak.service.DaybreakService
 import java.time.LocalDate
 import java.util.UUID
 
-@UseCase
+@ReadOnlyUseCase
 class QueryGeneralTeacherDaybreakStudyApplicationUseCase(
     private val daybreakService: DaybreakService,
     private val securityService: SecurityService

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryHeadTeacherDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryHeadTeacherDaybreakStudyApplicationUseCase.kt
@@ -1,6 +1,6 @@
 package team.aliens.dms.domain.daybreak.usecase
 
-import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
@@ -10,7 +10,7 @@ import team.aliens.dms.domain.teacher.service.TeacherService
 import java.time.LocalDate
 import java.util.UUID
 
-@UseCase
+@ReadOnlyUseCase
 class QueryHeadTeacherDaybreakStudyApplicationUseCase(
     private val daybreakService: DaybreakService,
     private val securityService: SecurityService,

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryManagerDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryManagerDaybreakStudyApplicationUseCase.kt
@@ -1,11 +1,11 @@
 package team.aliens.dms.domain.daybreak.usecase
 
-import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
 import team.aliens.dms.domain.daybreak.service.DaybreakService
 
-@UseCase
+@ReadOnlyUseCase
 class QueryManagerDaybreakStudyApplicationUseCase(
     private val daybreakService: DaybreakService,
 ) {

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCaseTest.kt
@@ -1,0 +1,41 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.service.StudentService
+import java.util.UUID
+
+class QueryDaybreakStudyApplicationStatusUseCaseTest : DescribeSpec({
+
+    val daybreakService = mockk<DaybreakService>()
+    val studentService = mockk<StudentService>()
+
+    val useCase = QueryDaybreakStudyApplicationStatusUseCase(daybreakService, studentService)
+
+    describe("execute"){
+        context("학생이 자신의 새벽 자습 신청 상태를 조회하면") {
+            val student = mockk<Student>()
+
+            every { studentService.getCurrentStudent() } returns student
+            every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(student.id) } returns mockk(relaxed = true)
+
+            it("자신의 새벽 자습 신청 상태를 반환한다"){
+                shouldNotThrowAny {
+                    val response = useCase.execute()
+
+                    response shouldNotBe null
+                }
+            }
+
+        }
+
+    }
+
+})

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryDaybreakStudyApplicationStatusUseCaseTest.kt
@@ -2,15 +2,12 @@ package team.aliens.dms.domain.daybreak.usecase
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import team.aliens.dms.domain.daybreak.service.DaybreakService
 import team.aliens.dms.domain.student.model.Student
 import team.aliens.dms.domain.student.service.StudentService
-import java.util.UUID
 
 class QueryDaybreakStudyApplicationStatusUseCaseTest : DescribeSpec({
 
@@ -19,23 +16,20 @@ class QueryDaybreakStudyApplicationStatusUseCaseTest : DescribeSpec({
 
     val useCase = QueryDaybreakStudyApplicationStatusUseCase(daybreakService, studentService)
 
-    describe("execute"){
+    describe("execute") {
         context("학생이 자신의 새벽 자습 신청 상태를 조회하면") {
             val student = mockk<Student>()
 
             every { studentService.getCurrentStudent() } returns student
             every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(student.id) } returns mockk(relaxed = true)
 
-            it("자신의 새벽 자습 신청 상태를 반환한다"){
+            it("자신의 새벽 자습 신청 상태를 반환한다") {
                 shouldNotThrowAny {
                     val response = useCase.execute()
 
                     response shouldNotBe null
                 }
             }
-
         }
-
     }
-
 })

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -236,10 +236,14 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-type").hasAnyAuthority(HEAD_TEACHER.name,GENERAL_TEACHER.name,STUDENT.name)
                     .requestMatchers(HttpMethod.PATCH, "/daybreaks/study-application").hasAnyAuthority(HEAD_TEACHER.name, GENERAL_TEACHER.name)
                     .requestMatchers(HttpMethod.POST, "/daybreaks/study-type").hasAuthority(HEAD_TEACHER.name)
+<<<<<<< HEAD
 
                 authorize
                     // /teachers
                     .requestMatchers(HttpMethod.GET, "/teachers/general").hasAuthority(STUDENT.name)
+=======
+                    .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)
+>>>>>>> 38018b506 (feat: (987) 새벽 자습 신청 상태 조회 기능 추가)
                 .anyRequest().denyAll()
             }
         http

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -236,14 +236,11 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-type").hasAnyAuthority(HEAD_TEACHER.name,GENERAL_TEACHER.name,STUDENT.name)
                     .requestMatchers(HttpMethod.PATCH, "/daybreaks/study-application").hasAnyAuthority(HEAD_TEACHER.name, GENERAL_TEACHER.name)
                     .requestMatchers(HttpMethod.POST, "/daybreaks/study-type").hasAuthority(HEAD_TEACHER.name)
-<<<<<<< HEAD
+                    .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)
 
                 authorize
                     // /teachers
                     .requestMatchers(HttpMethod.GET, "/teachers/general").hasAuthority(STUDENT.name)
-=======
-                    .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)
->>>>>>> 38018b506 (feat: (987) 새벽 자습 신청 상태 조회 기능 추가)
                 .anyRequest().denyAll()
             }
         http

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -7,10 +7,12 @@ import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
 import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.spi.DaybreakStudyApplicationPort
+import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationStatusVO
 import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationVO
 import team.aliens.dms.persistence.daybreak.entity.QDaybreakStudyApplicationJpaEntity.daybreakStudyApplicationJpaEntity
 import team.aliens.dms.persistence.daybreak.mapper.DaybreakStudyApplicationMapper
 import team.aliens.dms.persistence.daybreak.repository.DaybreakStudyApplicationJpaRepository
+import team.aliens.dms.persistence.daybreak.repository.vo.QQueryDaybreakStudyApplicationStatusVO
 import team.aliens.dms.persistence.daybreak.repository.vo.QQueryDaybreakStudyApplicationVO
 import team.aliens.dms.persistence.student.entity.QStudentJpaEntity.studentJpaEntity
 import java.time.LocalDate
@@ -148,6 +150,21 @@ class DaybreakStudyApplicationPersistenceAdapter(
         return daybreakStudyApplicationRepository.findAllByIdIn(ids).mapNotNull {
             daybreakStudyApplicationMapper.toDomain(it)
         }
+    }
+
+    override fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID): DaybreakStudyApplicationStatusVO? {
+        return queryFactory
+            .select(
+                QQueryDaybreakStudyApplicationStatusVO(
+                    daybreakStudyApplicationJpaEntity.status,
+                    daybreakStudyApplicationJpaEntity.startDate,
+                    daybreakStudyApplicationJpaEntity.endDate
+                )
+            )
+            .from(daybreakStudyApplicationJpaEntity)
+            .where(daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId))
+            .orderBy(daybreakStudyApplicationJpaEntity.createdAt.desc())
+            .fetchFirst()
     }
 
     override fun saveDaybreakStudyApplication(application: DaybreakStudyApplication) {

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/repository/vo/QueryDaybreakStudyApplicationStatusVO.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/repository/vo/QueryDaybreakStudyApplicationStatusVO.kt
@@ -1,0 +1,16 @@
+package team.aliens.dms.persistence.daybreak.repository.vo
+
+import com.querydsl.core.annotations.QueryProjection
+import team.aliens.dms.domain.daybreak.model.Status
+import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationStatusVO
+import java.time.LocalDate
+
+class QueryDaybreakStudyApplicationStatusVO @QueryProjection constructor(
+    status: Status,
+    startDate: LocalDate,
+    endDate: LocalDate
+) : DaybreakStudyApplicationStatusVO(
+    status = status,
+    startDate = startDate,
+    endDate = endDate
+)

--- a/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
+++ b/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
@@ -20,11 +20,13 @@ import team.aliens.dms.domain.daybreak.dto.request.ChangeDaybreakStudyApplicatio
 import team.aliens.dms.domain.daybreak.dto.request.CreateDaybreakStudyTypeRequest
 import team.aliens.dms.domain.daybreak.dto.request.CreateDaybreakStudyTypeWebRequest
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
+import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationStatusResponse
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyTypesResponse
 import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.usecase.ApplyDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.ChangeStatusDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.CreateDaybreakStudyTypeUseCase
+import team.aliens.dms.domain.daybreak.usecase.QueryDaybreakStudyApplicationStatusUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryDaybreakStudyTypesUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryGeneralTeacherDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryHeadTeacherDaybreakStudyApplicationUseCase
@@ -42,7 +44,8 @@ class DaybreakWebAdapter(
     private val queryManagerDaybreakStudyApplicationUseCase: QueryManagerDaybreakStudyApplicationUseCase,
     private val queryDaybreakStudyTypesUseCase: QueryDaybreakStudyTypesUseCase,
     private val changeStatusDaybreakStudyApplicationUseCase: ChangeStatusDaybreakStudyApplicationUseCase,
-    private val createDaybreakStudyTypeUseCase: CreateDaybreakStudyTypeUseCase
+    private val createDaybreakStudyTypeUseCase: CreateDaybreakStudyTypeUseCase,
+    private val queryDaybreakStudyApplicationStatusUseCase: QueryDaybreakStudyApplicationStatusUseCase
 ) {
 
     @ResponseStatus(code = HttpStatus.CREATED)
@@ -116,5 +119,11 @@ class DaybreakWebAdapter(
                 name = request.name
             )
         )
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @GetMapping("/study-application/my")
+    fun getRecentDaybreakStudyApplicationStatus(): DaybreakStudyApplicationStatusResponse {
+        return queryDaybreakStudyApplicationStatusUseCase.execute()
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 학생이 자신이 신청한 새벽 자습 신청 상태를 조회하는 기능 추가

## 주요 변경 사항
- daybreak Service 레이어 학생에 최근 새벽 자습 신청 상태를 가져오는 메서드 추가
- 기존의 조회용 UseCase에 사용된 UseCase를 ReadOnlyUseCase로 수정

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #987 