### PR TITLE
merge: (#985) 새벽 자습 신청 푸시 알림 기능 추가

### DIFF
--- a/contracts/enum-contracts/notification-enum/src/main/kotlin/team/aliens/dms/contract/model/notification/Topic.kt
+++ b/contracts/enum-contracts/notification-enum/src/main/kotlin/team/aliens/dms/contract/model/notification/Topic.kt
@@ -6,7 +6,8 @@ enum class TopicGroup(
     NOTICE("공지"),
     STUDY_ROOM("자습실"),
     POINT("상벌점"),
-    OUTING("외출")
+    OUTING("외출"),
+    DAYBREAK_STUDY_APPLICATION("새벽 자습 신청")
 }
 
 enum class Topic(
@@ -30,5 +31,8 @@ enum class Topic(
 
     OUTING(
         topicGroup = TopicGroup.OUTING
+    ),
+    DAYBREAK_STUDY_APPLICATION(
+        topicGroup = TopicGroup.DAYBREAK_STUDY_APPLICATION
     )
 }

--- a/dms-gateway/gateway-infrastructure/src/main/resources/application.yml
+++ b/dms-gateway/gateway-infrastructure/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
               - "https://admin-dms.dsmhs.kr"
               - "https://admin-dev-dms.dsmhs.kr"
               - "https://webview-dms.dsmhs.kr"
+              - "https://head-teacher-dms.dsmhs.kr"
+              - "https://general-teacher-dms.dsmhs.kr"
             allowedMethods:
               - GET
               - POST

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
@@ -55,4 +55,12 @@ data class DaybreakStudyApplication(
         if (status != Status.FIRST_APPROVED) throw InvalidRoleException
         if (newStatus != Status.SECOND_APPROVED && newStatus != Status.REJECTED) throw InvalidRoleException
     }
+
+    // REJECTED와 SECOND_APPROVED만 알림을 발송함
+    fun getTitle(): String =
+        when (status){
+            Status.REJECTED -> "새벽 자습 신청이 거절되었습니다"
+            Status.SECOND_APPROVED -> "새벽 자습 신청이 승인되었습니다"
+            else -> ""
+        }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
@@ -58,7 +58,7 @@ data class DaybreakStudyApplication(
 
     // REJECTED와 SECOND_APPROVED만 알림을 발송함
     fun getTitle(): String =
-        when (status){
+        when (status) {
             Status.REJECTED -> "새벽 자습 신청이 거절되었습니다"
             Status.SECOND_APPROVED -> "새벽 자습 신청이 승인되었습니다"
             else -> ""

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -1,15 +1,22 @@
 package team.aliens.dms.domain.daybreak.service
 
 import team.aliens.dms.common.annotation.Service
+import team.aliens.dms.common.spi.NotificationEventPort
+import team.aliens.dms.contract.model.notification.NotificationInfo
+import team.aliens.dms.contract.model.notification.Topic
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyType
+import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.spi.CommandDaybreakStudyApplicationPort
 import team.aliens.dms.domain.daybreak.spi.CommandDaybreakStudyTypePort
+import team.aliens.dms.domain.student.service.StudentService
 
 @Service
 class CommandDaybreakServiceImpl(
     private val commandDaybreakStudyApplicationPort: CommandDaybreakStudyApplicationPort,
-    private val commandDaybreakStudyTypePort: CommandDaybreakStudyTypePort
+    private val commandDaybreakStudyTypePort: CommandDaybreakStudyTypePort,
+    private val notificationEventPort: NotificationEventPort,
+    private val studentService: StudentService
 ) : CommandDaybreakService {
 
     override fun saveDaybreakStudyApplication(application: DaybreakStudyApplication) {
@@ -21,6 +28,25 @@ class CommandDaybreakServiceImpl(
     }
 
     override fun saveAllDaybreakStudyApplications(applications: List<DaybreakStudyApplication>) {
+
         commandDaybreakStudyApplicationPort.saveAllDaybreakStudyApplications(applications)
+
+        val firstApplication = applications.first()
+        val studentIds = applications.map { it.studentId}
+        val userIds = studentService.getAllStudentsByIdsIn(studentIds).map { it.userId!! }
+
+        if(firstApplication.status == Status.SECOND_APPROVED || firstApplication.status == Status.REJECTED) {
+
+            val notificationInfo = NotificationInfo(
+                schoolId = firstApplication.schoolId,
+                topic = Topic.DAYBREAK_STUDY_APPLICATION,
+                linkIdentifier = firstApplication.id.toString(),
+                title = firstApplication.getTitle(),
+                content = "새벽 자습 신청 상태가 변경되었습니다.",
+                threadId = firstApplication.id.toString(),
+                isSaveRequired = true
+            )
+            notificationEventPort.publishNotificationToApplicant(userIds, notificationInfo)
+        }
     }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -33,7 +33,7 @@ class CommandDaybreakServiceImpl(
 
         val firstApplication = applications.first()
         val studentIds = applications.map { it.studentId }
-        val userIds = queryStudentPort.queryAllStudentsByIdsIn(studentIds).map { it.userId!! }
+        val userIds = queryStudentPort.queryAllStudentsByIdsIn(studentIds).mapNotNull { it.userId }
 
         if (firstApplication.status == Status.SECOND_APPROVED || firstApplication.status == Status.REJECTED) {
 

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -9,14 +9,14 @@ import team.aliens.dms.domain.daybreak.model.DaybreakStudyType
 import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.spi.CommandDaybreakStudyApplicationPort
 import team.aliens.dms.domain.daybreak.spi.CommandDaybreakStudyTypePort
-import team.aliens.dms.domain.student.service.StudentService
+import team.aliens.dms.domain.student.spi.QueryStudentPort
 
 @Service
 class CommandDaybreakServiceImpl(
     private val commandDaybreakStudyApplicationPort: CommandDaybreakStudyApplicationPort,
     private val commandDaybreakStudyTypePort: CommandDaybreakStudyTypePort,
     private val notificationEventPort: NotificationEventPort,
-    private val studentService: StudentService
+    private val queryStudentPort: QueryStudentPort
 ) : CommandDaybreakService {
 
     override fun saveDaybreakStudyApplication(application: DaybreakStudyApplication) {
@@ -32,10 +32,10 @@ class CommandDaybreakServiceImpl(
         commandDaybreakStudyApplicationPort.saveAllDaybreakStudyApplications(applications)
 
         val firstApplication = applications.first()
-        val studentIds = applications.map { it.studentId}
-        val userIds = studentService.getAllStudentsByIdsIn(studentIds).map { it.userId!! }
+        val studentIds = applications.map { it.studentId }
+        val userIds = queryStudentPort.queryAllStudentsByIdsIn(studentIds).map { it.userId!! }
 
-        if(firstApplication.status == Status.SECOND_APPROVED || firstApplication.status == Status.REJECTED) {
+        if (firstApplication.status == Status.SECOND_APPROVED || firstApplication.status == Status.REJECTED) {
 
             val notificationInfo = NotificationInfo(
                 schoolId = firstApplication.schoolId,

--- a/dms-notification/notification-infrastructure/src/main/resources/db/migration/V5__change_column_in_tbl_notification_of_user.sql
+++ b/dms-notification/notification-infrastructure/src/main/resources/db/migration/V5__change_column_in_tbl_notification_of_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tbl_notification_of_user
+    MODIFY COLUMN topic VARCHAR(30);


### PR DESCRIPTION
## 작업 내용 설명
- [x] fcm을 이용하여 새벽 자습 신청 상태가 바뀔시 푸시 알림 보내는 기능 추가

## 주요 변경 사항
- TOPIC enum에 DAYBREAK_STUDY_APPLICATION 추가
- saveAllDaybreakStudyApplications()에 이벤트 생성 추가

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #985 