### PR TITLE
merge: (#988) 공지 managerId 하드코딩 제거 

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/notice/usecase/CreateNoticeUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/notice/usecase/CreateNoticeUseCase.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.notice.usecase
 
 import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.notice.dto.NoticeIdResponse
 import team.aliens.dms.domain.notice.model.Notice
 import team.aliens.dms.domain.notice.service.NoticeService
@@ -11,15 +12,15 @@ import java.util.UUID
 @UseCase
 class CreateNoticeUseCase(
     private val noticeService: NoticeService,
-    private val userService: UserService
+    private val securityService: SecurityService
 ) {
 
     fun execute(title: String, content: String): NoticeIdResponse {
 
-        val firstUuid = UUID.fromString("33386262-6332-6663-2d37-6664312d3131")
+        val managerId = securityService.getCurrentUserId()
 
         val notice = Notice(
-            managerId = firstUuid,
+            managerId = managerId,
             title = title,
             content = content,
             createdAt = LocalDateTime.now(),

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notice/usecase/CreateNoticeUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notice/usecase/CreateNoticeUseCaseTest.kt
@@ -1,0 +1,54 @@
+package team.aliens.dms.domain.notice.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.aliens.dms.common.service.security.SecurityService
+import team.aliens.dms.domain.notice.model.Notice
+import team.aliens.dms.domain.notice.service.NoticeService
+import java.util.UUID
+
+class CreateNoticeUseCaseTest : DescribeSpec({
+
+    val noticeService = mockk<NoticeService>()
+    val securityService = mockk<SecurityService>()
+
+    val useCase = CreateNoticeUseCase(noticeService, securityService)
+
+    describe("execute"){
+        context("사감선생님이 공지를 생성하면"){
+
+            val managerId = UUID.randomUUID()
+            val noticeId = UUID.randomUUID()
+
+            it("공지를 생성한다"){
+                // given
+                every { securityService.getCurrentUserId() } returns managerId
+                every { noticeService.saveNotice(any()) } answers {
+                    val arg = firstArg<Notice>()
+                    Notice(
+                        id = noticeId,
+                        managerId = arg.managerId,
+                        title = arg.title,
+                        content = arg.content,
+                        createdAt = arg.createdAt,
+                        updatedAt = arg.updatedAt
+                    )
+                }
+
+                // when
+                useCase.execute("제목", "내용")
+
+                // then
+                verify(exactly = 1) { securityService.getCurrentUserId() }
+                verify(exactly = 1) { noticeService.saveNotice(match {
+                    it.managerId == managerId &&
+                    it.title == "제목" &&
+                    it.content == "내용"
+                })
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 공지를 생성할 때 하드코딩으로 작성된 managerId를 로그인한 managerId로 수정

## 주요 변경 사항
- getCurrentUserId() 메서드를 통해 현재 사용자의 id를 가져와서 공지 생성

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #988 