### PR TITLE
merge: (#994) 비즈니스 로직 처리 후, ack 하도록 변경

### DIFF
--- a/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/DeviceTokenConsumer.kt
+++ b/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/DeviceTokenConsumer.kt
@@ -1,6 +1,9 @@
 package team.aliens.dms.thirdparty.messagebroker
 
+import com.rabbitmq.client.Channel
 import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.amqp.support.AmqpHeaders
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
 import team.aliens.dms.contract.remote.rabbitmq.DeleteDeviceTokenMessage
 import team.aliens.dms.contract.remote.rabbitmq.DeviceTokenMessage
@@ -14,16 +17,29 @@ class DeviceTokenConsumer(
 ) {
 
     @RabbitListener(queues = ["device_token_queue"])
-    fun handleDeviceTokenMessage(message: DeviceTokenMessage) {
-        when (message) {
-            is SaveDeviceTokenMessage -> {
-                notificationService.saveDeviceToken(
-                    DeviceToken.from(message.deviceTokenInfo)
-                )
+    fun handleDeviceTokenMessage(
+        message: DeviceTokenMessage,
+        channel: Channel,
+        @Header(AmqpHeaders.DELIVERY_TAG) deliveryTag: Long
+    ) {
+        try {
+            when (message) {
+                is SaveDeviceTokenMessage -> {
+                    notificationService.saveDeviceToken(
+                        DeviceToken.from(message.deviceTokenInfo)
+                    )
+                }
+
+                is DeleteDeviceTokenMessage -> {
+                    notificationService.deleteDeviceTokenByUserId(message.userId)
+                }
             }
-            is DeleteDeviceTokenMessage -> {
-                notificationService.deleteDeviceTokenByUserId(message.userId)
-            }
+
+            channel.basicAck(deliveryTag, false)
+
+        } catch (e: Exception) {
+            channel.basicNack(deliveryTag, false, true)
+            throw e
         }
     }
 }

--- a/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/NotificationConsumer.kt
+++ b/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/NotificationConsumer.kt
@@ -1,6 +1,9 @@
 package team.aliens.dms.thirdparty.messagebroker
 
+import com.rabbitmq.client.Channel
 import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.amqp.support.AmqpHeaders
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
 import team.aliens.dms.contract.remote.rabbitmq.GroupNotificationMessage
 import team.aliens.dms.contract.remote.rabbitmq.NotificationMessage
@@ -13,28 +16,41 @@ import team.aliens.dms.domain.notification.service.NotificationService
 class NotificationConsumer(
     private val notificationService: NotificationService
 ) {
+
     @RabbitListener(queues = ["notification_queue"])
-    fun handleNotificationMessage(message: NotificationMessage) {
-        when (message) {
-            is GroupNotificationMessage -> {
-                notificationService.sendMessages(
-                    notificationService.getDiviceTokensByUserIds(message.userIds),
-                    Notification.from(message.notificationInfo)
-                )
+    fun handleNotificationMessage(
+        message: NotificationMessage,
+        channel: Channel,
+        @Header(AmqpHeaders.DELIVERY_TAG) deliveryTag: Long
+    ) {
+        try {
+            when (message) {
+                is GroupNotificationMessage -> {
+                    notificationService.sendMessages(
+                        notificationService.getDiviceTokensByUserIds(message.userIds),
+                        Notification.from(message.notificationInfo)
+                    )
+                }
+
+                is SingleNotificationMessage -> {
+                    notificationService.sendMessage(
+                        notificationService.getDeviceTokenByUserId(message.userId),
+                        Notification.from(message.notificationInfo)
+                    )
+                }
+
+                is TopicNotificationMessage -> {
+                    notificationService.sendMessagesByTopic(
+                        Notification.from(message.notificationInfo)
+                    )
+                }
             }
 
-            is SingleNotificationMessage -> {
-                notificationService.sendMessage(
-                    notificationService.getDeviceTokenByUserId(message.userId),
-                    Notification.from(message.notificationInfo)
-                )
-            }
+            channel.basicAck(deliveryTag, false)
 
-            is TopicNotificationMessage -> {
-                notificationService.sendMessagesByTopic(
-                    Notification.from(message.notificationInfo)
-                )
-            }
+        } catch (e: Exception) {
+            channel.basicNack(deliveryTag, false, true)
+            throw e
         }
     }
 }

--- a/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/config/RabbitMqConfig.kt
+++ b/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/config/RabbitMqConfig.kt
@@ -6,10 +6,12 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.amqp.core.AcknowledgeMode
 import org.springframework.amqp.core.Binding
 import org.springframework.amqp.core.BindingBuilder
 import org.springframework.amqp.core.Queue
 import org.springframework.amqp.core.TopicExchange
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
@@ -32,6 +34,21 @@ class RabbitMqConfig(
         connectionFactory.setUsername(rabbitMqProperties.username)
         connectionFactory.setPassword(rabbitMqProperties.password)
         return connectionFactory
+    }
+
+    @Bean
+    fun rabbitListenerContainerFactory(
+        connectionFactory: ConnectionFactory,
+        messageConverter: MessageConverter,
+    ): SimpleRabbitListenerContainerFactory {
+        val factory = SimpleRabbitListenerContainerFactory()
+        factory.setConnectionFactory(connectionFactory)
+        factory.setMessageConverter(messageConverter)
+
+        // 수동 ACK 모드
+        factory.setAcknowledgeMode(AcknowledgeMode.MANUAL)
+
+        return factory
     }
 
     @Bean


### PR DESCRIPTION
## 작업 내용 설명
* 기존엔 컨슈머가 메세지를 받기만 하면 ack 되어서, 비즈니스 로직이 실패해도 재시도가 이루어 지지 않음.
* 비즈니스 로직 성공 후, ack 를 보내도록 하여 비즈니스 로직이 실패하면 메세지 재발송을 통해 at-leastly-once-delivery 를 더 완전하게 구현함.

## 주요 변경 사항
*  NotificationConsumer
*  DeviceTokenConsumer
* RabbitMqConfig  


## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #994 