### PR TITLE
merge: (#1004) 디바이스 토큰 삭제 시 재큐잉 문제

### DIFF
--- a/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/CommandNotificationServiceImpl.kt
+++ b/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/CommandNotificationServiceImpl.kt
@@ -1,7 +1,6 @@
 package team.aliens.dms.domain.notification.service
 
 import team.aliens.dms.common.annotation.Service
-import team.aliens.dms.domain.notification.exception.DeviceTokenNotFoundException
 import team.aliens.dms.domain.notification.exception.NotificationOfUserNotFoundException
 import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.NotificationOfUser
@@ -31,14 +30,10 @@ class CommandNotificationServiceImpl(
     }
 
     override fun deleteDeviceTokenByUserId(userId: UUID) {
-        val deviceToken = deviceTokenPort.queryDeviceTokenByUserId(userId)
+        val deviceToken = deviceTokenPort.queryDeviceTokenByUserId(userId) ?: return
 
-        if (deviceToken != null) {
-            topicSubscriptionPort.deleteAllByDeviceTokenId(deviceToken.id)
-            deviceTokenPort.deleteDeviceTokenByUserId(userId)
-        } else {
-            throw DeviceTokenNotFoundException
-        }
+        topicSubscriptionPort.deleteAllByDeviceTokenId(deviceToken.id)
+        deviceTokenPort.deleteDeviceTokenByUserId(userId)
     }
 
     override fun deleteNotificationOfUserByUserIdAndId(userId: UUID, notificationOfUserId: UUID) {

--- a/dms-notification/notification-core/src/test/kotlin/team/aliens/dms/domain/notification/service/CommandNotificationServiceImplTest.kt
+++ b/dms-notification/notification-core/src/test/kotlin/team/aliens/dms/domain/notification/service/CommandNotificationServiceImplTest.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.domain.notification.service
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -9,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import team.aliens.dms.contract.model.notification.Topic
-import team.aliens.dms.domain.notification.exception.DeviceTokenNotFoundException
 import team.aliens.dms.domain.notification.exception.NotificationOfUserNotFoundException
 import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.NotificationOfUser
@@ -91,10 +91,11 @@ class CommandNotificationServiceImplTest : DescribeSpec({
 
             every { deviceTokenPort.queryDeviceTokenByUserId(userId) } returns null
 
-            it("DeviceTokenNotFoundException을 던진다") {
-                shouldThrow<DeviceTokenNotFoundException> {
+            it("예외 없이 아무 동작도 하지 않는다") {
+                shouldNotThrowAny {
                     service.deleteDeviceTokenByUserId(userId)
                 }
+                verify(exactly = 0) { deviceTokenPort.deleteDeviceTokenByUserId(userId) }
             }
         }
     }

--- a/dms-notification/notification-core/src/test/kotlin/team/aliens/dms/domain/notification/service/impl/CommandNotificationServiceImplTest.kt
+++ b/dms-notification/notification-core/src/test/kotlin/team/aliens/dms/domain/notification/service/impl/CommandNotificationServiceImplTest.kt
@@ -6,7 +6,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import team.aliens.dms.domain.notification.exception.DeviceTokenNotFoundException
+import io.mockk.verify
 import team.aliens.dms.domain.notification.exception.NotificationOfUserNotFoundException
 import team.aliens.dms.domain.notification.service.CommandNotificationServiceImpl
 import team.aliens.dms.domain.notification.spi.CommandNotificationOfUserPort
@@ -71,10 +71,11 @@ class CommandNotificationServiceImplTest : DescribeSpec({
 
             every { deviceTokenPort.queryDeviceTokenByUserId(userId) } returns null
 
-            it("DeviceTokenNotFoundException을 발생시킨다") {
-                shouldThrow<DeviceTokenNotFoundException> {
+            it("예외 없이 아무 동작도 하지 않는다") {
+                shouldNotThrowAny {
                     commandNotificationService.deleteDeviceTokenByUserId(userId)
                 }
+                verify(exactly = 0) { deviceTokenPort.deleteDeviceTokenByUserId(userId) }
             }
         }
     }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 디바이스 토큰 삭제를 시도할 때 예외를 던져서 재큐잉하는 문제를 early return으로 수정


## 주요 변경 사항
- 기존 예외를 삭제하고 early return

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1004 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 기기 토큰이 없을 때 삭제 요청 시 발생하던 오류가 제거되었습니다. 이제 해당 경우에는 예외 없이 즉시 처리되며, 불필요한 삭제 작업도 수행하지 않습니다.  
  * 토큰이 존재하는 경우에는 기존과 동일하게 관련 구독을 정리한 뒤 기기 토큰을 삭제합니다.  
* **테스트**
  * 토큰 미존재 시나리오에 대한 기대 동작을 예외 처리에서 “무동작” 검증으로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->