### PR TITLE
merge: (#1010) UpdateStudentTagsUseCase 스케줄러 미작동 버그 수정

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/model/WarningTag.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/model/WarningTag.kt
@@ -69,6 +69,5 @@ enum class WarningTag(val warningMessage: String, val point: Int) {
         )
     }
 
-    fun nextLevel() =
-        entries[this.ordinal + 1]
+    fun nextLevel(): WarningTag? = entries.getOrNull(this.ordinal + 1)
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCase.kt
@@ -23,7 +23,7 @@ class UpdateStudentTagsUseCase(
             .filter { it.tagName in warningTagNames }
             .groupBy { it.studentId }
 
-        val studentIdsToDelete = mutableListOf<UUID>()
+        val warningTagsToDelete = mutableListOf<StudentTagDetailVO>()
         val tagsToSave = mutableListOf<StudentTag>()
 
         for (studentPoint in pointService.getPointTotalsGroupByStudent()) {
@@ -44,13 +44,13 @@ class UpdateStudentTagsUseCase(
                 if (completedLowerTag != null) {
                     val nextLevel = completedLowerTag.nextLevel() ?: continue
                     val tagId = warningTagByName[nextLevel.warningMessage] ?: continue
-                    studentIdsToDelete.add(studentPoint.studentId)
+                    warningTagsToDelete.addAll(currentWarningTags)
                     tagsToSave.add(StudentTag(studentPoint.studentId, tagId, LocalDateTime.now()))
                 }
             }
         }
 
-        tagService.deleteAllStudentTagsByStudentIdIn(studentIdsToDelete)
+        warningTagsToDelete.forEach { tagService.deleteStudentTagById(it.studentId, it.tagId) }
         tagService.saveAllStudentTags(tagsToSave)
     }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCase.kt
@@ -3,7 +3,6 @@ package team.aliens.dms.domain.tag.usecase
 import team.aliens.dms.common.annotation.SchedulerUseCase
 import team.aliens.dms.domain.point.service.PointService
 import team.aliens.dms.domain.tag.model.StudentTag
-import team.aliens.dms.domain.tag.model.Tag
 import team.aliens.dms.domain.tag.model.WarningTag
 import team.aliens.dms.domain.tag.service.TagService
 import team.aliens.dms.domain.tag.spi.vo.StudentTagDetailVO
@@ -16,45 +15,42 @@ class UpdateStudentTagsUseCase(
     private val tagService: TagService
 ) {
     fun execute() {
-        val tagList: List<Tag> = tagService.getTagsByTagNameIn(WarningTag.getAllMessages())
+        val warningTagEntities = tagService.getTagsByTagNameIn(WarningTag.getAllMessages())
+        val warningTagByName: Map<String, UUID> = warningTagEntities.associate { it.name to it.id }
+        val warningTagNames = warningTagByName.keys
 
-        val warningTagMap: Map<String, UUID> = tagList.associate { it.name to it.id }
-
-        val reverseWarningTagMap: Map<UUID, String> = tagList.associate { it.id to it.name }
-
-        val studentTagDetailMap: Map<UUID, List<StudentTagDetailVO>> = tagService.getAllStudentTagDetails()
+        val studentWarningTagMap: Map<UUID, List<StudentTagDetailVO>> = tagService.getAllStudentTagDetails()
+            .filter { it.tagName in warningTagNames }
             .groupBy { it.studentId }
 
-        val studentIdsToDeleteStudentTags = ArrayList<UUID>()
+        val studentIdsToDelete = mutableListOf<UUID>()
+        val tagsToSave = mutableListOf<StudentTag>()
 
-        val saveList: List<StudentTag> = pointService.getPointTotalsGroupByStudent().mapNotNull {
-            val warningTag = WarningTag.byPoint(it.minusTotal)
+        for (studentPoint in pointService.getPointTotalsGroupByStudent()) {
+            val requiredLevel = WarningTag.byPoint(studentPoint.minusTotal)
+            if (requiredLevel == WarningTag.SAFE) continue
 
-            val isWarningTag = warningTag != WarningTag.SAFE
-            val hasWarningTag = studentTagDetailMap.containsKey(it.studentId)
-            val isHighLevelWarningAndCompleted = if (hasWarningTag) studentTagDetailMap[it.studentId]!!.any {
-                WarningTag.byContent(it.tagName).point < warningTag.point && WarningTag.byContent(it.tagName).name.startsWith("C_")
-            } else false
+            val currentWarningTags = studentWarningTagMap[studentPoint.studentId]
 
-            if (isWarningTag &&
-                (!hasWarningTag || isHighLevelWarningAndCompleted)
-            ) {
-                val ownedWarningTag = reverseWarningTagMap[
-                    studentTagDetailMap[it.studentId]?.first()?.tagId
-                ]?.let { WarningTag.byContent(it) } ?: WarningTag.SAFE
+            if (currentWarningTags == null) {
+                val tagId = warningTagByName[WarningTag.FIRST_WARNING.warningMessage] ?: continue
+                tagsToSave.add(StudentTag(studentPoint.studentId, tagId, LocalDateTime.now()))
+            } else {
+                val completedLowerTag = currentWarningTags
+                    .map { WarningTag.byContent(it.tagName) }
+                    .filter { it.name.startsWith("C_") && it.point < requiredLevel.point }
+                    .maxByOrNull { it.point }
 
-                studentIdsToDeleteStudentTags.add(it.studentId)
-
-                StudentTag(
-                    it.studentId,
-                    warningTagMap[ownedWarningTag.nextLevel().warningMessage]!!,
-                    LocalDateTime.now()
-                )
-            } else null
+                if (completedLowerTag != null) {
+                    val nextLevel = completedLowerTag.nextLevel() ?: continue
+                    val tagId = warningTagByName[nextLevel.warningMessage] ?: continue
+                    studentIdsToDelete.add(studentPoint.studentId)
+                    tagsToSave.add(StudentTag(studentPoint.studentId, tagId, LocalDateTime.now()))
+                }
+            }
         }
 
-        tagService.deleteAllStudentTagsByStudentIdIn(studentIdsToDeleteStudentTags)
-
-        tagService.saveAllStudentTags(saveList)
+        tagService.deleteAllStudentTagsByStudentIdIn(studentIdsToDelete)
+        tagService.saveAllStudentTags(tagsToSave)
     }
 }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
@@ -1,0 +1,192 @@
+package team.aliens.dms.domain.tag.usecase
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import team.aliens.dms.domain.point.service.PointService
+import team.aliens.dms.domain.point.spi.vo.StudentTotalVO
+import team.aliens.dms.domain.tag.model.StudentTag
+import team.aliens.dms.domain.tag.model.WarningTag
+import team.aliens.dms.domain.tag.service.TagService
+import team.aliens.dms.domain.tag.spi.vo.StudentTagDetailVO
+import team.aliens.dms.domain.tag.stub.createTagStub
+import java.util.UUID
+
+class UpdateStudentTagsUseCaseTest : DescribeSpec({
+
+    val pointService = mockk<PointService>()
+    val tagService = mockk<TagService>()
+    val useCase = UpdateStudentTagsUseCase(pointService, tagService)
+
+    val schoolId = UUID.randomUUID()
+    val studentId = UUID.randomUUID()
+
+    val firstWarningTagId = UUID.randomUUID()
+    val secondWarningTagId = UUID.randomUUID()
+    val thirdWarningTagId = UUID.randomUUID()
+    val cFirstWarningTagId = UUID.randomUUID()
+    val cSecondWarningTagId = UUID.randomUUID()
+
+    val warningTagEntities = listOf(
+        createTagStub(id = firstWarningTagId,   name = WarningTag.FIRST_WARNING.warningMessage,    schoolId = schoolId),
+        createTagStub(id = cFirstWarningTagId,  name = WarningTag.C_FIRST_WARNING.warningMessage,  schoolId = schoolId),
+        createTagStub(id = secondWarningTagId,  name = WarningTag.SECOND_WARNING.warningMessage,   schoolId = schoolId),
+        createTagStub(id = cSecondWarningTagId, name = WarningTag.C_SECOND_WARNING.warningMessage, schoolId = schoolId),
+        createTagStub(id = thirdWarningTagId,   name = WarningTag.THIRD_WARNING.warningMessage,    schoolId = schoolId),
+    )
+
+    fun mockSaveAndDelete() {
+        every { tagService.deleteAllStudentTagsByStudentIdIn(any()) } just runs
+        every { tagService.saveAllStudentTags(any()) } just runs
+    }
+
+    describe("execute") {
+
+        context("감점이 기준 미만(SAFE)인 학생만 있을 때") {
+            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+            every { tagService.getAllStudentTagDetails() } returns emptyList()
+            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 10)
+            )
+            mockSaveAndDelete()
+
+            it("아무 태그도 저장하지 않는다") {
+                val savedTags = slot<List<StudentTag>>()
+                every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
+
+                shouldNotThrowAny { useCase.execute() }
+                savedTags.captured.size shouldBe 0
+            }
+        }
+
+        context("경고 태그가 없는 학생이 감점 15점(경고 1단계 기준)일 때") {
+            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+            every { tagService.getAllStudentTagDetails() } returns emptyList()
+            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
+            )
+            mockSaveAndDelete()
+
+            it("경고 1단계 태그가 저장된다") {
+                val savedTags = slot<List<StudentTag>>()
+                every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
+
+                useCase.execute()
+
+                savedTags.captured.size shouldBe 1
+                savedTags.captured[0].tagId shouldBe firstWarningTagId
+            }
+        }
+
+        context("경고 1단계(완료) 태그를 가진 학생이 감점 20점(경고 2단계 기준)일 때") {
+            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+            every { tagService.getAllStudentTagDetails() } returns listOf(
+                StudentTagDetailVO(
+                    studentId = studentId,
+                    studentName = "홍길동",
+                    tagId = cFirstWarningTagId,
+                    tagColor = "#FF4646",
+                    tagName = WarningTag.C_FIRST_WARNING.warningMessage
+                )
+            )
+            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
+            )
+            mockSaveAndDelete()
+
+            it("경고 2단계 태그로 업그레이드된다") {
+                val savedTags = slot<List<StudentTag>>()
+                every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
+
+                useCase.execute()
+
+                savedTags.captured.size shouldBe 1
+                savedTags.captured[0].tagId shouldBe secondWarningTagId
+            }
+        }
+
+        context("경고 1단계(완료) 태그를 가진 학생이 아직 감점 15점(경고 2단계 미만)일 때") {
+            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+            every { tagService.getAllStudentTagDetails() } returns listOf(
+                StudentTagDetailVO(
+                    studentId = studentId,
+                    studentName = "홍길동",
+                    tagId = cFirstWarningTagId,
+                    tagColor = "#FF4646",
+                    tagName = WarningTag.C_FIRST_WARNING.warningMessage
+                )
+            )
+            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
+            )
+            mockSaveAndDelete()
+
+            it("업그레이드하지 않는다") {
+                val savedTags = slot<List<StudentTag>>()
+                every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
+
+                useCase.execute()
+
+                savedTags.captured.size shouldBe 0
+            }
+        }
+
+        context("경고 1단계(미완료) 태그를 가진 학생이 감점 20점일 때") {
+            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+            every { tagService.getAllStudentTagDetails() } returns listOf(
+                StudentTagDetailVO(
+                    studentId = studentId,
+                    studentName = "홍길동",
+                    tagId = firstWarningTagId,
+                    tagColor = "#FF4646",
+                    tagName = WarningTag.FIRST_WARNING.warningMessage
+                )
+            )
+            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
+            )
+            mockSaveAndDelete()
+
+            it("처벌 미이행이므로 업그레이드하지 않는다") {
+                val savedTags = slot<List<StudentTag>>()
+                every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
+
+                useCase.execute()
+
+                savedTags.captured.size shouldBe 0
+            }
+        }
+
+        context("일반 태그(경고 태그 아님)만 가진 학생이 감점 15점일 때") {
+            val generalTagId = UUID.randomUUID()
+            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+            every { tagService.getAllStudentTagDetails() } returns listOf(
+                StudentTagDetailVO(
+                    studentId = studentId,
+                    studentName = "홍길동",
+                    tagId = generalTagId,
+                    tagColor = "#0000FF",
+                    tagName = "소프트웨어개발과"
+                )
+            )
+            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
+            )
+            mockSaveAndDelete()
+
+            it("TagNotFoundException 없이 경고 1단계 태그가 저장된다") {
+                val savedTags = slot<List<StudentTag>>()
+                every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
+
+                shouldNotThrowAny { useCase.execute() }
+                savedTags.captured.size shouldBe 1
+                savedTags.captured[0].tagId shouldBe firstWarningTagId
+            }
+        }
+    }
+})

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
@@ -40,22 +40,16 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
         createTagStub(id = thirdWarningTagId,   name = WarningTag.THIRD_WARNING.warningMessage,    schoolId = schoolId),
     )
 
-    fun mockSaveAndDelete() {
-        every { tagService.deleteAllStudentTagsByStudentIdIn(any()) } just runs
-        every { tagService.saveAllStudentTags(any()) } just runs
-    }
-
     describe("execute") {
 
         context("감점이 기준 미만(SAFE)인 학생만 있을 때") {
-            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
-            every { tagService.getAllStudentTagDetails() } returns emptyList()
-            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
-                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 10)
-            )
-            mockSaveAndDelete()
-
             it("아무 태그도 저장하지 않는다") {
+                every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+                every { tagService.getAllStudentTagDetails() } returns emptyList()
+                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                    StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 10)
+                )
+                every { tagService.deleteStudentTagById(any(), any()) } just runs
                 val savedTags = slot<List<StudentTag>>()
                 every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
 
@@ -65,14 +59,13 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
         }
 
         context("경고 태그가 없는 학생이 감점 15점(경고 1단계 기준)일 때") {
-            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
-            every { tagService.getAllStudentTagDetails() } returns emptyList()
-            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
-                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
-            )
-            mockSaveAndDelete()
-
             it("경고 1단계 태그가 저장된다") {
+                every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+                every { tagService.getAllStudentTagDetails() } returns emptyList()
+                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                    StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
+                )
+                every { tagService.deleteStudentTagById(any(), any()) } just runs
                 val savedTags = slot<List<StudentTag>>()
                 every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
 
@@ -84,22 +77,21 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
         }
 
         context("경고 1단계(완료) 태그를 가진 학생이 감점 20점(경고 2단계 기준)일 때") {
-            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
-            every { tagService.getAllStudentTagDetails() } returns listOf(
-                StudentTagDetailVO(
-                    studentId = studentId,
-                    studentName = "홍길동",
-                    tagId = cFirstWarningTagId,
-                    tagColor = "#FF4646",
-                    tagName = WarningTag.C_FIRST_WARNING.warningMessage
-                )
-            )
-            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
-                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
-            )
-            mockSaveAndDelete()
-
             it("경고 2단계 태그로 업그레이드된다") {
+                every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+                every { tagService.getAllStudentTagDetails() } returns listOf(
+                    StudentTagDetailVO(
+                        studentId = studentId,
+                        studentName = "홍길동",
+                        tagId = cFirstWarningTagId,
+                        tagColor = "#FF4646",
+                        tagName = WarningTag.C_FIRST_WARNING.warningMessage
+                    )
+                )
+                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                    StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
+                )
+                every { tagService.deleteStudentTagById(any(), any()) } just runs
                 val savedTags = slot<List<StudentTag>>()
                 every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
 
@@ -111,22 +103,21 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
         }
 
         context("경고 1단계(완료) 태그를 가진 학생이 아직 감점 15점(경고 2단계 미만)일 때") {
-            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
-            every { tagService.getAllStudentTagDetails() } returns listOf(
-                StudentTagDetailVO(
-                    studentId = studentId,
-                    studentName = "홍길동",
-                    tagId = cFirstWarningTagId,
-                    tagColor = "#FF4646",
-                    tagName = WarningTag.C_FIRST_WARNING.warningMessage
-                )
-            )
-            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
-                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
-            )
-            mockSaveAndDelete()
-
             it("업그레이드하지 않는다") {
+                every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+                every { tagService.getAllStudentTagDetails() } returns listOf(
+                    StudentTagDetailVO(
+                        studentId = studentId,
+                        studentName = "홍길동",
+                        tagId = cFirstWarningTagId,
+                        tagColor = "#FF4646",
+                        tagName = WarningTag.C_FIRST_WARNING.warningMessage
+                    )
+                )
+                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                    StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
+                )
+                every { tagService.deleteStudentTagById(any(), any()) } just runs
                 val savedTags = slot<List<StudentTag>>()
                 every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
 
@@ -137,22 +128,21 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
         }
 
         context("경고 1단계(미완료) 태그를 가진 학생이 감점 20점일 때") {
-            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
-            every { tagService.getAllStudentTagDetails() } returns listOf(
-                StudentTagDetailVO(
-                    studentId = studentId,
-                    studentName = "홍길동",
-                    tagId = firstWarningTagId,
-                    tagColor = "#FF4646",
-                    tagName = WarningTag.FIRST_WARNING.warningMessage
-                )
-            )
-            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
-                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
-            )
-            mockSaveAndDelete()
-
             it("처벌 미이행이므로 업그레이드하지 않는다") {
+                every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+                every { tagService.getAllStudentTagDetails() } returns listOf(
+                    StudentTagDetailVO(
+                        studentId = studentId,
+                        studentName = "홍길동",
+                        tagId = firstWarningTagId,
+                        tagColor = "#FF4646",
+                        tagName = WarningTag.FIRST_WARNING.warningMessage
+                    )
+                )
+                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                    StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
+                )
+                every { tagService.deleteStudentTagById(any(), any()) } just runs
                 val savedTags = slot<List<StudentTag>>()
                 every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
 
@@ -163,23 +153,22 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
         }
 
         context("일반 태그(경고 태그 아님)만 가진 학생이 감점 15점일 때") {
-            val generalTagId = UUID.randomUUID()
-            every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
-            every { tagService.getAllStudentTagDetails() } returns listOf(
-                StudentTagDetailVO(
-                    studentId = studentId,
-                    studentName = "홍길동",
-                    tagId = generalTagId,
-                    tagColor = "#0000FF",
-                    tagName = "소프트웨어개발과"
-                )
-            )
-            every { pointService.getPointTotalsGroupByStudent() } returns listOf(
-                StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
-            )
-            mockSaveAndDelete()
-
             it("TagNotFoundException 없이 경고 1단계 태그가 저장된다") {
+                val generalTagId = UUID.randomUUID()
+                every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
+                every { tagService.getAllStudentTagDetails() } returns listOf(
+                    StudentTagDetailVO(
+                        studentId = studentId,
+                        studentName = "홍길동",
+                        tagId = generalTagId,
+                        tagColor = "#0000FF",
+                        tagName = "소프트웨어개발과"
+                    )
+                )
+                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                    StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
+                )
+                every { tagService.deleteStudentTagById(any(), any()) } just runs
                 val savedTags = slot<List<StudentTag>>()
                 every { tagService.saveAllStudentTags(capture(savedTags)) } just runs
 

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.persistence.point
 
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
@@ -168,9 +169,12 @@ class PointHistoryPersistenceAdapter(
             .from(latestPointHistory)
             .where(
                 latestPointHistory.studentGcn.eq(
-                    studentJpaEntity.grade.stringValue().toString() +
-                        studentJpaEntity.classRoom.stringValue() +
-                        studentJpaEntity.number.stringValue().toString().padStart(2, '0')
+                    Expressions.stringTemplate(
+                        "CONCAT({0}, {1}, LPAD(CAST({2} AS string), 2, '0'))",
+                        studentJpaEntity.grade,
+                        studentJpaEntity.classRoom,
+                        studentJpaEntity.number
+                    )
                 ),
                 latestPointHistory.studentName.eq(studentJpaEntity.name)
             )

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -170,7 +170,7 @@ class PointHistoryPersistenceAdapter(
             .where(
                 latestPointHistory.studentGcn.eq(
                     Expressions.stringTemplate(
-                        "CONCAT({0}, {1}, LPAD(CAST({2} AS string), 2, '0'))",
+                        "CONCAT({0}, {1}, LPAD(CAST({2} AS CHAR), 2, '0'))",
                         studentJpaEntity.grade,
                         studentJpaEntity.classRoom,
                         studentJpaEntity.number

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/VolunteerScorePersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/volunteer/VolunteerScorePersistenceAdapter.kt
@@ -65,7 +65,7 @@ class VolunteerScorePersistenceAdapter(
 
     override fun queryAllVolunteerScoresWithStudentVO(): List<VolunteerScoreWithStudentVO> {
         val gcnExpression = Expressions.stringTemplate(
-            "CONCAT({0}, {1}, LPAD(CAST({2} AS string), 2, '0'))",
+            "CONCAT({0}, {1}, LPAD(CAST({2} AS CHAR), 2, '0'))",
             studentJpaEntity.grade,
             studentJpaEntity.classRoom,
             studentJpaEntity.number


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 일반 태그를 가진 학생이 있을 경우 `WarningTag.byContent()` 에서 `TagNotFoundException` 발생으로 스케줄러 전체 실패하는 버그 수정
- [ ] `queryPointTotalsGroupByStudent()` 에서 QueryDSL 표현식에 Kotlin `.toString()` 호출로 GCN 비교가 항상 실패하여 빈 결과 반환하는 버그 수정
- [ ] `WarningTag.nextLevel()` 에서 마지막 항목 접근 시 `ArrayIndexOutOfBoundsException` 발생 가능한 버그 수정

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 경고 태그의 다음 단계 계산이 안전하게 변경되어, 마지막 단계에서 오류 대신 더 이상 다음 태그가 없음을 처리합니다.
  * 학생 경고 태그 갱신 로직이 개선되어, 감점 기준에 따라 태그 추가·업그레이드가 더 안정적으로 동작합니다.

* **Tests**
  * 경고 태그 갱신의 주요 시나리오를 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->