### PR TITLE
merge: (#1012) 토큰 재발급 시 refresh token 회전으로 인한 잦은 로그아웃 버그 수정

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/auth/spi/JwtPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/auth/spi/JwtPort.kt
@@ -2,8 +2,11 @@ package team.aliens.dms.domain.auth.spi
 
 import team.aliens.dms.domain.auth.dto.TokenResponse
 import team.aliens.dms.domain.auth.model.Authority
+import team.aliens.dms.domain.auth.model.RefreshToken
 import java.util.UUID
 
 interface JwtPort {
     fun receiveToken(userId: UUID, authority: Authority, schoolId: UUID): TokenResponse
+
+    fun reissueAccessToken(refreshToken: RefreshToken, schoolId: UUID): TokenResponse
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCase.kt
@@ -20,8 +20,8 @@ class ReissueTokenUseCase(
 
         val user = userService.queryUserById(queryToken.userId)
 
-        val tokenResponse = jwtPort.receiveToken(
-            userId = queryToken.userId, authority = queryToken.authority, schoolId = user.schoolId
+        val tokenResponse = jwtPort.reissueAccessToken(
+            refreshToken = queryToken, schoolId = user.schoolId
         )
 
         val availableFeatures = schoolService.getAvailableFeaturesBySchoolId(user.schoolId)

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -1,0 +1,62 @@
+package team.aliens.dms.domain.auth.usecase
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import team.aliens.dms.domain.auth.dto.TokenResponse
+import team.aliens.dms.domain.auth.service.AuthService
+import team.aliens.dms.domain.auth.spi.JwtPort
+import team.aliens.dms.domain.auth.stub.createRefreshToken
+import team.aliens.dms.domain.school.service.SchoolService
+import team.aliens.dms.domain.user.service.UserService
+import team.aliens.dms.domain.user.stub.createUserStub
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ReissueTokenUseCaseTest : DescribeSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val authService = mockk<AuthService>()
+    val userService = mockk<UserService>()
+    val schoolService = mockk<SchoolService>()
+    val jwtPort = mockk<JwtPort>()
+    val reissueTokenUseCase = ReissueTokenUseCase(jwtPort, userService, schoolService, authService)
+
+    describe("execute") {
+
+        context("유효한 refresh token으로 재발급을 요청하면") {
+
+            val token = "refresh-token"
+            val userId = UUID.randomUUID()
+            val schoolId = UUID.randomUUID()
+
+            val queryToken = createRefreshToken(token = token, userId = userId)
+            val user = createUserStub(id = userId, schoolId = schoolId)
+
+            // 수정된 동작: 재발급 시 refresh token은 그대로(token) 두고 access token만 새로 발급
+            val tokenResponse = TokenResponse(
+                accessToken = "new-access-token",
+                accessTokenExpiredAt = LocalDateTime.now().plusHours(1),
+                refreshToken = token,
+                refreshTokenExpiredAt = LocalDateTime.now().plusWeeks(2)
+            )
+
+            every { authService.getRefreshTokenByToken(token) } returns queryToken
+            every { userService.queryUserById(userId) } returns user
+            every { jwtPort.reissueAccessToken(queryToken, schoolId) } returns tokenResponse
+            every { schoolService.getAvailableFeaturesBySchoolId(schoolId) } returns mockk(relaxed = true)
+
+            it("access token만 새로 발급하고 refresh token은 기존 값을 그대로 반환한다") {
+                val result = reissueTokenUseCase.execute(token)
+
+                result.accessToken shouldBe "new-access-token"
+
+                result.refreshToken shouldBe token
+            }
+
+        }
+    }
+})

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
@@ -27,15 +27,6 @@ class GenerateJwtAdapter(
         refreshTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.refreshExp.toLong())
     )
 
-    /**
-     * 토큰 재발급 시 refresh token 은 회전(재발급)시키지 않고 access token 만 새로 발급한다.
-     *
-     * 기존에는 재발급 시에도 [receiveToken] 을 호출해 refresh token 까지 새로 발급/교체했는데,
-     * 이 경우 기존 refresh token 이 즉시 무효화되어 재발급 응답 유실/동시 요청 시
-     * 클라이언트가 무효화된 옛 토큰을 들고 있다가 다음 재발급에서 404 를 받아 로그아웃되는 문제가 있었다.
-     *
-     * refresh token 값은 그대로 유지하되 TTL 만 갱신하여 기존 슬라이딩 세션 동작은 보존한다.
-     */
     override fun reissueAccessToken(refreshToken: RefreshToken, schoolId: UUID): TokenResponse {
         // refresh token 값은 유지하고 TTL(만료 시간)만 갱신하여 슬라이딩 세션을 유지한다.
         commandRefreshTokenPort.save(

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/token/GenerateJwtAdapter.kt
@@ -27,6 +27,29 @@ class GenerateJwtAdapter(
         refreshTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.refreshExp.toLong())
     )
 
+    /**
+     * 토큰 재발급 시 refresh token 은 회전(재발급)시키지 않고 access token 만 새로 발급한다.
+     *
+     * 기존에는 재발급 시에도 [receiveToken] 을 호출해 refresh token 까지 새로 발급/교체했는데,
+     * 이 경우 기존 refresh token 이 즉시 무효화되어 재발급 응답 유실/동시 요청 시
+     * 클라이언트가 무효화된 옛 토큰을 들고 있다가 다음 재발급에서 404 를 받아 로그아웃되는 문제가 있었다.
+     *
+     * refresh token 값은 그대로 유지하되 TTL 만 갱신하여 기존 슬라이딩 세션 동작은 보존한다.
+     */
+    override fun reissueAccessToken(refreshToken: RefreshToken, schoolId: UUID): TokenResponse {
+        // refresh token 값은 유지하고 TTL(만료 시간)만 갱신하여 슬라이딩 세션을 유지한다.
+        commandRefreshTokenPort.save(
+            refreshToken.copy(expirationTime = securityProperties.refreshExp)
+        )
+
+        return TokenResponse(
+            accessToken = generateAccessToken(refreshToken.userId, refreshToken.authority, schoolId),
+            accessTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.accessExp.toLong()),
+            refreshToken = refreshToken.token,
+            refreshTokenExpiredAt = LocalDateTime.now().withNano(0).plusSeconds(securityProperties.refreshExp.toLong())
+        )
+    }
+
     private fun generateAccessToken(userId: UUID, authority: Authority, schoolId: UUID) =
         Jwts.builder()
             .signWith(securityProperties.secretKey, SignatureAlgorithm.HS512)


### PR DESCRIPTION
## 작업 내용 설명
- [x] 토큰 재발급(`PUT /auth/reissue`) 시 refresh token 을 회전(재발급)시키지 않고 **access token 만 새로 발급**하도록 수정
- [x] refresh token 값은 유지하고 TTL 만 갱신하여 기존 슬라이딩 세션 동작은 보존

## 주요 변경 사항
- `JwtPort` 에 `reissueAccessToken(refreshToken, schoolId)` 메서드 추가
- `GenerateJwtAdapter.reissueAccessToken` 구현: access token 만 새로 발급하고, 기존 refresh token 값은 그대로 둔 채 `expirationTime(TTL)` 만 갱신하여 저장
- `ReissueTokenUseCase` 가 기존 `receiveToken`(로그인과 동일, refresh 재발급 포함) 대신 `reissueAccessToken` 을 호출하도록 변경

### 배경 (버그 원인)
- 기존 재발급은 로그인과 동일한 `receiveToken` 을 호출 → access/refresh 를 모두 새로 발급하고 `RefreshTokenEntity`(`@Id = userId`) 를 덮어써 **기존 refresh token 을 즉시 무효화**함
- 모바일 환경에서 재발급 응답이 유실되거나 동시 요청이 겹치면, 클라이언트가 이미 무효화된 옛 refresh token 을 보관 → 다음 재발급에서 `REFRESH_TOKEN_NOT_FOUND`(404) → 클라이언트 전체 토큰 삭제 → 로그아웃
- access token 만료가 1시간(`access-exp: 3600`)이라 재발급이 잦아 자주 재현됨
- 재발급 시 refresh token 을 회전시키지 않으므로 위 경쟁/유실 상황에서도 옛 token 이 그대로 유효 → 문제 해소

## 결과물
<!-- 서버 로직 변경으로 별도 화면 캡처 없음 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요? (`:dms-main:main-core`, `:dms-main:main-infrastructure` compileKotlin BUILD SUCCESSFUL)
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요? (`reissueAccessToken` KDoc 추가)
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요? (기존 auth usecase 테스트 부재, 후속 보강 필요)

## 관련 이슈
- resolved #1012


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리프레시 토큰을 사용해 새 액세스 토큰을 재발급하는 기능이 추가되었습니다.
  * 재발급 시 리프레시 토큰의 값은 그대로 유지되고, 만료 시간만 갱신됩니다.
  * 재발급 응답에는 최신 액세스 토큰과 갱신된 리프레시 토큰 만료 정보가 함께 제공됩니다.
* **Tests**
  * 리프레시 토큰 기반 재발급 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->