### PR TITLE
merge: (#1016) 새벽 자습 신청 만료 트리거 작동 시간 수정

### DIFF
--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -56,7 +56,6 @@ class ReissueTokenUseCaseTest : DescribeSpec({
 
                 result.refreshToken shouldBe token
             }
-
         }
     }
 })

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
@@ -33,11 +33,11 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
     val cSecondWarningTagId = UUID.randomUUID()
 
     val warningTagEntities = listOf(
-        createTagStub(id = firstWarningTagId,   name = WarningTag.FIRST_WARNING.warningMessage,    schoolId = schoolId),
-        createTagStub(id = cFirstWarningTagId,  name = WarningTag.C_FIRST_WARNING.warningMessage,  schoolId = schoolId),
-        createTagStub(id = secondWarningTagId,  name = WarningTag.SECOND_WARNING.warningMessage,   schoolId = schoolId),
+        createTagStub(id = firstWarningTagId, name = WarningTag.FIRST_WARNING.warningMessage, schoolId = schoolId),
+        createTagStub(id = cFirstWarningTagId, name = WarningTag.C_FIRST_WARNING.warningMessage, schoolId = schoolId),
+        createTagStub(id = secondWarningTagId, name = WarningTag.SECOND_WARNING.warningMessage, schoolId = schoolId),
         createTagStub(id = cSecondWarningTagId, name = WarningTag.C_SECOND_WARNING.warningMessage, schoolId = schoolId),
-        createTagStub(id = thirdWarningTagId,   name = WarningTag.THIRD_WARNING.warningMessage,    schoolId = schoolId),
+        createTagStub(id = thirdWarningTagId, name = WarningTag.THIRD_WARNING.warningMessage, schoolId = schoolId),
     )
 
     describe("execute") {

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/scheduler/quartz/config/QuartzConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/scheduler/quartz/config/QuartzConfig.kt
@@ -166,7 +166,7 @@ class QuartzConfig {
         return TriggerBuilder.newTrigger()
             .forJob(closeDaybreakStudyApplicationJobDetail)
             .withIdentity("expireDaybreakStudyApplicationJobTrigger", "daybreak")
-            .withDescription("Every Friday at midnight (Asia/Seoul)")
+            .withDescription("Every Saturday at midnight (Asia/Seoul)")
             .withSchedule(
                 CronScheduleBuilder.cronSchedule("0 0 0 ? * SAT")
                     .inTimeZone(java.util.TimeZone.getTimeZone("Asia/Seoul"))

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/scheduler/quartz/config/QuartzConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/scheduler/quartz/config/QuartzConfig.kt
@@ -153,7 +153,7 @@ class QuartzConfig {
     }
 
     @Bean
-    fun expireDaybreakStudyApplicationJobDetail(): JobDetail {
+    fun closeDaybreakStudyApplicationJobDetail(): JobDetail {
         return JobBuilder.newJob(DaybreakStudyApplicationJob::class.java)
             .withIdentity("expireDaybreakStudyApplicationJob", "daybreak")
             .withDescription("Expire daybreak study application")
@@ -162,13 +162,13 @@ class QuartzConfig {
     }
 
     @Bean
-    fun expireDaybreakStudyApplicationJobTrigger(expireDaybreakStudyApplicationJobDetail: JobDetail): Trigger {
+    fun closeDaybreakStudyApplicationJobTrigger(closeDaybreakStudyApplicationJobDetail: JobDetail): Trigger {
         return TriggerBuilder.newTrigger()
-            .forJob(expireDaybreakStudyApplicationJobDetail)
+            .forJob(closeDaybreakStudyApplicationJobDetail)
             .withIdentity("expireDaybreakStudyApplicationJobTrigger", "daybreak")
             .withDescription("Every Friday at midnight (Asia/Seoul)")
             .withSchedule(
-                CronScheduleBuilder.cronSchedule("0 0 0 ? * FRI")
+                CronScheduleBuilder.cronSchedule("0 0 0 ? * SAT")
                     .inTimeZone(java.util.TimeZone.getTimeZone("Asia/Seoul"))
             )
             .build()


### PR DESCRIPTION
## 작업 내용 설명
- [x] 새벽 자습 신청 만료(close) 처리 스케줄러의 작동 시간을 매주 **금요일 00시 → 토요일 00시(Asia/Seoul)** 로 변경

## 주요 변경 사항
- `QuartzConfig` 의 새벽 자습 만료 트리거 cron 을 `0 0 0 ? * FRI` → `0 0 0 ? * SAT` 로 수정
- Job 의 실제 동작(만료 처리)에 맞춰 Bean 명을 `expireDaybreakStudyApplicationJob*` → `closeDaybreakStudyApplicationJob*` 으로 정리

## 결과물
<!-- 스케줄러 설정 변경으로 별도 화면 캡처 없음 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daybreak Study 신청 만료 처리 일정이 매주 **금요일 00:00(Asia/Seoul)**에서 **토요일 00:00(Asia/Seoul)**로 변경되었습니다.
  * 토큰 재발급 동작 검증이 개선되어, 기존 흐름에 맞게 **새 access token만 갱신**되고 **refresh token은 유지**됨을 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->