### PR TITLE
merge: (#1018) S3 파일 저장 경로에 prefix 옵션 추가

### DIFF
--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/storage/AwsS3Adapter.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/storage/AwsS3Adapter.kt
@@ -36,7 +36,7 @@ class AwsS3Adapter(
             }
 
             amazonS3Client.putObject(
-                PutObjectRequest(awsProperties.bucket, fileName, inputStream, objectMetadata)
+                PutObjectRequest(awsProperties.bucket, buildKey(fileName), inputStream, objectMetadata)
                     .withCannedAcl(
                         CannedAccessControlList.PublicRead
                     )
@@ -49,16 +49,21 @@ class AwsS3Adapter(
     }
 
     override fun getResourceUrl(fileName: String): String {
-        return amazonS3Client.getResourceUrl(awsProperties.bucket, fileName)
+        return amazonS3Client.getResourceUrl(awsProperties.bucket, buildKey(fileName))
     }
 
     override fun getUploadUrl(fileName: String): String {
 
         val generatePresignedUrlRequest =
-            GeneratePresignedUrlRequest(awsProperties.bucket, fileName)
+            GeneratePresignedUrlRequest(awsProperties.bucket, buildKey(fileName))
                 .withMethod(HttpMethod.PUT)
                 .withExpiration(Timestamp.valueOf(LocalDateTime.now().plusHours(4)))
 
         return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest).toString()
+    }
+
+    private fun buildKey(fileName: String): String {
+        val prefix = awsProperties.prefix.trim('/')
+        return if (prefix.isEmpty()) fileName else "$prefix/$fileName"
     }
 }

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/storage/AwsS3Properties.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/storage/AwsS3Properties.kt
@@ -5,4 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("cloud.aws.s3")
 class AwsS3Properties(
     val bucket: String,
+    val prefix: String,
 )

--- a/dms-main/main-infrastructure/src/main/resources/application.yml
+++ b/dms-main/main-infrastructure/src/main/resources/application.yml
@@ -125,6 +125,7 @@ cloud:
       auto: false
     s3:
       bucket: ${S3_BUCKET_NAME:dms}
+      prefix: ${S3_PREFIX_NAME:dsm_DMS}
 
 sentry:
   dsn: ${SENTRY_DSN:asdf}


### PR DESCRIPTION
## 작업 내용 설명
- [x] S3 업로드 시 prefix 없이 저장되던 것을 prefix가 붙도록 수정
- [x] prefix를 환경변수(S3_PREFIX_NAME)로 주입받도록 처리

## 주요 변경 사항
- `AwsS3Properties`에 `prefix` 필드 추가, `application.yml`에 `S3_PREFIX_NAME` 환경변수 바인딩
- `AwsS3Adapter`에 `buildKey` 헬퍼를 추가해 upload/getResourceUrl/getUploadUrl 모두 동일한 prefix가 붙은 키를 사용하도록 통일

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 파일 업로드 및 접근 경로가 공통 규칙으로 통일되어, 저장된 파일 경로와 다운로드/미리보기 링크가 일관되게 생성됩니다.
  * S3 경로 접두어를 설정할 수 있어, 업로드 파일을 원하는 폴더 구조로 구분할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->