### PR TITLE
merge: (#1022) 존재하지 않는 ECR 레포 대신 dsm-dms 레포 공유하도록 CD 수정

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -64,17 +64,18 @@ jobs:
               '. + [{service:$s, ecr_repo:$e, target:$t, path:$p}]' <<<"$inc")
           }
 
+          # 서비스별 ECR 레포가 따로 없고 dsm-dms 하나만 존재 — 이미지 태그 접두사(서비스명)로 구분
           # gateway: 공유 or 본인 모듈
           if [ "$SHARED" = "true" ] || [ "$GW" = "true" ]; then
-            add gateway dms-gateway dms-prod-gateway /opt/dms/gateway
+            add gateway dsm-dms dms-prod-gateway /opt/dms/gateway
           fi
           # main: 공유 or contracts or 본인 모듈
           if [ "$SHARED" = "true" ] || [ "$CONTRACTS" = "true" ] || [ "$MN" = "true" ]; then
-            add main dms-main dms-prod-main /opt/dms/main
+            add main dsm-dms dms-prod-main /opt/dms/main
           fi
           # notification: 공유 or contracts or 본인 모듈
           if [ "$SHARED" = "true" ] || [ "$CONTRACTS" = "true" ] || [ "$NT" = "true" ]; then
-            add notification dms-notification dms-prod-notification /opt/dms/notification
+            add notification dsm-dms dms-prod-notification /opt/dms/notification
           fi
 
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
@@ -136,7 +137,8 @@ jobs:
           provenance: false
           # :latest는 여기서 밀지 않는다 — deploy 잡에서 배포 성공이 확인된 시점에 :<sha>를 승격.
           # 빌드만 성공하고 배포는 안 됐거나 실패한 이미지가 latest를 오염시키는 것을 방지
-          tags: ${{ steps.ecr.outputs.registry }}/${{ matrix.ecr_repo }}:${{ github.sha }}
+          # 레포 하나(dsm-dms)를 서비스 3개가 공유하므로 태그 앞에 서비스명을 붙여 구분
+          tags: ${{ steps.ecr.outputs.registry }}/${{ matrix.ecr_repo }}:${{ matrix.service }}-${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
@@ -211,7 +213,7 @@ jobs:
 
           # 변수 주입 줄 + 본문을 commands 배열로 안전하게 JSON 인코딩
           jq -n --arg region "$AWS_REGION" --arg path "$DEPLOY_PATH" \
-                --arg repo "$ECR_REPO" --arg tag "$GITHUB_SHA" --rawfile body /tmp/remote.sh \
+                --arg repo "$ECR_REPO" --arg tag "${{ matrix.service }}-$GITHUB_SHA" --rawfile body /tmp/remote.sh \
             '{commands: [("AWS_REGION=" + ($region | @sh)), ("DEPLOY_PATH=" + ($path | @sh)), ("ECR_REPO=" + ($repo | @sh)), ("IMAGE_TAG=" + ($tag | @sh)), $body]}' \
             > /tmp/params.json
 
@@ -250,22 +252,25 @@ jobs:
             exit 1
           fi
 
-          # 5) 배포가 에러 없이 끝난 것을 확인한 시점에만 ECR의 :latest를 이번 이미지로 승격
+          # 5) 배포가 에러 없이 끝난 것을 확인한 시점에만 ECR의 :<service>-latest를 이번 이미지로 승격
+          #    (레포 하나를 서비스 3개가 공유하므로 latest 태그도 서비스별로 분리)
+          SERVICE_TAG="${{ matrix.service }}-${GITHUB_SHA}"
+          LATEST_TAG="${{ matrix.service }}-latest"
           IMAGE=$(aws ecr batch-get-image \
             --repository-name "${ECR_REPO}" \
-            --image-ids imageTag="${GITHUB_SHA}" \
+            --image-ids imageTag="${SERVICE_TAG}" \
             --output json)
           MANIFEST=$(jq -r '.images[0].imageManifest // empty' <<<"$IMAGE")
           MEDIA_TYPE=$(jq -r '.images[0].imageManifestMediaType // empty' <<<"$IMAGE")
           if [ -z "$MANIFEST" ]; then
-            echo "::error::image ${ECR_REPO}:${GITHUB_SHA} not found in ECR"; exit 1
+            echo "::error::image ${ECR_REPO}:${SERVICE_TAG} not found in ECR"; exit 1
           fi
           # 재실행 시 latest가 이미 같은 이미지를 가리키면 ImageAlreadyExistsException — 정상 케이스
           if ! PUT_OUT=$(aws ecr put-image \
               --repository-name "${ECR_REPO}" \
-              --image-tag latest \
+              --image-tag "${LATEST_TAG}" \
               --image-manifest "$MANIFEST" \
               --image-manifest-media-type "$MEDIA_TYPE" 2>&1); then
             grep -q ImageAlreadyExistsException <<<"$PUT_OUT" || { echo "$PUT_OUT"; exit 1; }
           fi
-          echo "promoted ${ECR_REPO}:${GITHUB_SHA::7} -> latest"
+          echo "promoted ${ECR_REPO}:${SERVICE_TAG} -> ${LATEST_TAG}"


### PR DESCRIPTION
## 작업 내용 설명
- [x] `prod-cd.yml`이 존재하지 않는 ECR 레포(dms-gateway/dms-main/dms-notification)를 참조해서 CD 배포가 403으로 실패하던 문제 수정
- [x] 실제 존재하는 `dsm-dms` 레포 하나를 3개 서비스가 공유하도록 변경

## 주요 변경 사항
- `changes` job에서 서비스별 `ecr_repo`를 전부 `dsm-dms`로 통일
- 이미지 태그에 서비스명 접두사 추가 (`gateway-<sha>`, `main-<sha>`, `notification-<sha>`)로 레포 공유 시 충돌 방지
- 배포 성공 후 `:latest` 승격 태그도 서비스별로 분리 (`gateway-latest`, `main-latest`, `notification-latest`)

## 결과물
`workflow_dispatch`로 수동 실행 테스트 예정

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요? (워크플로우 파일만 변경, 앱 코드 영향 없음)
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 서비스별 이미지 태그가 분리되어 배포되도록 변경되었습니다.
  * 각 서비스는 이제 공용 리포지토리에서 `서비스명-커밋` 형식의 태그로 관리됩니다.
  * 배포 후 `latest` 태그도 서비스별로 독립적으로 갱신되어, 서로 다른 서비스 이미지가 섞일 가능성이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->