### PR TITLE
merge: (#1024) 빈 deviceToken으로 인한 notification-prod OOMKilled 방지

### DIFF
--- a/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImpl.kt
+++ b/dms-notification/notification-core/src/main/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImpl.kt
@@ -100,6 +100,9 @@ class NotificationServiceImpl(
     }
 
     override fun sendMessages(deviceTokens: List<DeviceToken>, notification: Notification) {
+        if (deviceTokens.isEmpty()) {
+            return
+        }
         notification.runIfSaveRequired {
             notificationOfUserPort.saveNotificationsOfUser(
                 deviceTokens.map { notification.toNotificationOfUser(it.userId) }

--- a/dms-notification/notification-core/src/test/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImplTest.kt
+++ b/dms-notification/notification-core/src/test/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImplTest.kt
@@ -2,10 +2,12 @@ package team.aliens.dms.domain.notification.service
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.verify
 import team.aliens.dms.contract.model.notification.Topic
 import team.aliens.dms.domain.notification.model.DeviceToken
 import team.aliens.dms.domain.notification.model.Notification
@@ -172,6 +174,29 @@ class NotificationServiceImplTest : DescribeSpec({
                 shouldNotThrowAny {
                     service.sendMessages(deviceTokens, notification)
                 }
+            }
+        }
+
+        context("디바이스 토큰이 하나도 없으면") {
+            val notification = Notification(
+                schoolId = UUID.randomUUID(),
+                topic = Topic.NOTICE,
+                linkIdentifier = null,
+                title = "title",
+                content = "content",
+                threadId = "thread-id",
+                isSaveRequired = true
+            )
+
+            it("알림 전송을 시도하지 않는다") {
+                clearMocks(notificationPort, notificationOfUserPort, answers = false)
+
+                shouldNotThrowAny {
+                    service.sendMessages(emptyList(), notification)
+                }
+
+                verify(exactly = 0) { notificationPort.sendMessages(any(), any()) }
+                verify(exactly = 0) { notificationOfUserPort.saveNotificationsOfUser(any()) }
             }
         }
     }

--- a/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/NotificationConsumer.kt
+++ b/dms-notification/notification-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/messagebroker/NotificationConsumer.kt
@@ -49,7 +49,7 @@ class NotificationConsumer(
             channel.basicAck(deliveryTag, false)
 
         } catch (e: Exception) {
-            channel.basicNack(deliveryTag, false, true)
+            channel.basicNack(deliveryTag, false, false)
             throw e
         }
     }


### PR DESCRIPTION
## 작업 내용
- [ ] `notification-prod`가 OOMKilled로 반복 재시작되던 문제 수정
- [ ] deviceToken이 없는 유저에게 그룹 알림을 보내려 할 때 `FCMAdapter`가 빈 토큰 리스트로 `MulticastMessage`를 생성하며 `IllegalArgumentException`을 던졌고, `NotificationConsumer`가 이를 `requeue=true`로 무한 재큐잉하면서 서비스가 반복적으로 죽던 상황이었습니다.

## 변경 사항
- `NotificationServiceImpl.sendMessages`: 디바이스 토큰이 비어있으면 저장/전송 로직을 스킵 (근본 원인 제거)
- `NotificationConsumer`: 예외 발생 시 `basicNack`을 `requeue=false`로 변경해, 향후 다른 종류의 미처리 예외가 터지더라도 poison message가 무한 루프 돌며 서비스를 crash loop 시키지 않도록 안전장치 추가
  - `DeviceTokenConsumer`는 이번 변경에서 제외 (`requeue=true` 유지) — 토큰 저장 실패 시 재시도가 없어지면 deviceToken 유실 문제를 악화시킬 수 있어서 별도 판단이 필요하다고 보고 남겨둠
- `NotificationServiceImplTest`: 빈 토큰 리스트일 때 알림 전송을 시도하지 않는지 검증하는 테스트 추가

## 관련 이슈
- resolved #1024 

## Test plan
- [x] `:dms-notification:notification-core:compileKotlin`, `:dms-notification:notification-infrastructure:compileKotlin` 빌드 성공 확인
- [x] `:dms-notification:notification-core:test` (NotificationServiceImplTest, 신규 케이스 포함) 통과 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 전송할 디바이스 토큰이 없을 때 불필요한 알림 저장 및 전송을 수행하지 않습니다.
  * 알림 처리 중 오류가 발생한 메시지는 반복 재처리되지 않고 폐기되거나 설정에 따라 별도 처리됩니다.
  * 디바이스 토큰이 없는 경우의 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->