### PR TITLE
merge: (#1026) Dockerfile에서 gradle 빌드 실패 문제 해결

### DIFF
--- a/dms-gateway/Dockerfile
+++ b/dms-gateway/Dockerfile
@@ -50,8 +50,8 @@ RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
 RUN ./gradlew dependencies || true
 
 COPY ./dms-gateway ./dms-gateway
-RUN ./gradlew :dms-gateway:gateway-infrastructure:clean :dms-gateway:gateway-infrastructure:bootJar -x test && \
-    rm -rf .gradle /app/.gradle /root/.kotlin /tmp/* /var/tmp/* /tmp/kotlin-daemon*.log* 2>/dev/null || true
+RUN ./gradlew :dms-gateway:gateway-infrastructure:clean :dms-gateway:gateway-infrastructure:bootJar -x test
+RUN rm -rf .gradle /app/.gradle /root/.kotlin /tmp/* /var/tmp/* /tmp/kotlin-daemon*.log* 2>/dev/null || true
 
 
 FROM eclipse-temurin:17-jre-alpine

--- a/dms-main/Dockerfile
+++ b/dms-main/Dockerfile
@@ -51,8 +51,8 @@ RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
 RUN ./gradlew dependencies || true
 
 COPY ./dms-main ./dms-main
-RUN ./gradlew :dms-main:main-infrastructure:clean :dms-main:main-infrastructure:bootJar -x test && \
-    rm -rf .gradle /app/.gradle /root/.kotlin /tmp/* /var/tmp/* /tmp/kotlin-daemon*.log* 2>/dev/null || true
+RUN ./gradlew :dms-main:main-infrastructure:clean :dms-main:main-infrastructure:bootJar -x test
+RUN rm -rf .gradle /app/.gradle /root/.kotlin /tmp/* /var/tmp/* /tmp/kotlin-daemon*.log* 2>/dev/null || true
 
 
 FROM eclipse-temurin:17-jre-alpine

--- a/dms-notification/Dockerfile
+++ b/dms-notification/Dockerfile
@@ -52,8 +52,8 @@ RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
 RUN ./gradlew dependencies || true
 
 COPY ./dms-notification ./dms-notification
-RUN ./gradlew :dms-notification:notification-infrastructure:clean :dms-notification:notification-infrastructure:bootJar -x test && \
-    rm -rf .gradle /app/.gradle /root/.kotlin /tmp/* /var/tmp/* /tmp/kotlin-daemon*.log* 2>/dev/null || true
+RUN ./gradlew :dms-notification:notification-infrastructure:clean :dms-notification:notification-infrastructure:bootJar -x test
+RUN rm -rf .gradle /app/.gradle /root/.kotlin /tmp/* /var/tmp/* /tmp/kotlin-daemon*.log* 2>/dev/null || true
 
 
 FROM eclipse-temurin:17-jre-alpine


### PR DESCRIPTION
## 작업 내용
- `notification-stag` CD 빌드가 `COPY --from=build .../build/libs/*.jar` 단계에서 `no such file or directory`로 계속 실패하던 문제 수정 
- 근본 원인: `RUN ./gradlew ... clean bootJar -x test && rm -rf ... || true`가 셸 연산자 우선순위상 `(CMD1 && CMD2) || true`로 해석되어, gradle 빌드 자체가 실패해도 RUN 스텝이 exit 0으로 "성공" 처리됨. 이 때문에 (최초엔 빌더의 일시적 DNS 장애로) jar 없는 빈 레이어가 캐싱되었고, 이후 동일 소스 내용의 빌드가 계속 이 깨진 캐시를 재사용하며 반복 실패

## 변경 사항
- `dms-main/Dockerfile`, `dms-gateway/Dockerfile`, `dms-notification/Dockerfile` 세 곳 모두 동일 패턴 수정: 빌드 명령과 정리 명령(`rm -rf`)을 별도 RUN으로 분리
  - 멀티스테이지 빌드라 build stage는 최종 이미지에 포함되지 않으므로 레이어 분리에 따른 이미지 크기 영향 없음
  - 이제 gradle 빌드가 실패하면 그 자리에서 정직하게 RUN 스텝이 실패하고, BuildKit이 성공 레이어로 캐싱하지 않음

## 체크리스트

    - [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요? (워크플로우 파일만 변경, 앱 코드 영향 없음)
    - [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
    - [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
 resolved #1026 