### PR TITLE
merge: (#1028) CD 배포 경로를 DMS-Infra의 실제 compose 위치로 수정

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -67,15 +67,15 @@ jobs:
           # 서비스별 ECR 레포가 따로 없고 dsm-dms 하나만 존재 — 이미지 태그 접두사(서비스명)로 구분
           # gateway: 공유 or 본인 모듈
           if [ "$SHARED" = "true" ] || [ "$GW" = "true" ]; then
-            add gateway dsm-dms dms-prod-gateway /opt/dms/gateway
+            add gateway dsm-dms dms-prod-gateway /home/ubuntu/DMS-Infra/infra/compose/gateway
           fi
           # main: 공유 or contracts or 본인 모듈
           if [ "$SHARED" = "true" ] || [ "$CONTRACTS" = "true" ] || [ "$MN" = "true" ]; then
-            add main dsm-dms dms-prod-main /opt/dms/main
+            add main dsm-dms dms-prod-main /home/ubuntu/DMS-Infra/infra/compose/main
           fi
           # notification: 공유 or contracts or 본인 모듈
           if [ "$SHARED" = "true" ] || [ "$CONTRACTS" = "true" ] || [ "$NT" = "true" ]; then
-            add notification dsm-dms dms-prod-notification /opt/dms/notification
+            add notification dsm-dms dms-prod-notification /home/ubuntu/DMS-Infra/infra/compose/notification
           fi
 
           echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 주요 변경 사항
- `prod-cd.yml`의 `DEPLOY_PATH`가 `/opt/dms/<service>`로 되어 있었는데, 이 경로는 어떤 인스턴스에도 존재한 적이 없어 배포가 `cd: can't cd to /opt/dms/gateway` 등으로 실패했음 (gateway/main/notification 3개 서비스 전부 동일 증상)
- 실제 compose 정의는 각 인스턴스 부트스트랩이 clone해두는 `DMS-Infra` 레포 안 `infra/compose/<service>/`에 이미 준비되어 있음 (docker-compose.yml + .env 모두 존재 확인)
- CD의 `DEPLOY_PATH`를 실제 위치(`/home/ubuntu/DMS-Infra/infra/compose/<service>`)로 수정

## 체크리스트
 - [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요? (워크플로우 파일만 변경, 앱 코드 영향 없음)
 - [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
 - [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
 resolved #1028 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로덕션 배포 시 서비스별 작업 경로를 최신 인프라 구성에 맞게 수정했습니다.
  * Gateway, Main, Notification 서비스의 배포 경로가 올바르게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->