### PR TITLE
merge: (#1047) 학생의 최근 상벌점 이력 조회 쿼리 수정

### DIFF
--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -176,7 +176,8 @@ class PointHistoryPersistenceAdapter(
             .from(latestPointHistory)
             .where(
                 latestPointHistory.studentGcn.eq(pointHistoryJpaEntity.studentGcn),
-                latestPointHistory.studentName.eq(pointHistoryJpaEntity.studentName)
+                latestPointHistory.studentName.eq(pointHistoryJpaEntity.studentName),
+                latestPointHistory.school.id.eq(pointHistoryJpaEntity.school.id)
             )
 
         return queryFactory
@@ -190,7 +191,8 @@ class PointHistoryPersistenceAdapter(
             .from(studentJpaEntity)
             .join(pointHistoryJpaEntity).on(
                 pointHistoryJpaEntity.studentGcn.eq(studentGcn),
-                pointHistoryJpaEntity.studentName.eq(studentJpaEntity.name)
+                pointHistoryJpaEntity.studentName.eq(studentJpaEntity.name),
+                pointHistoryJpaEntity.school.id.eq(studentJpaEntity.room.school.id)
             )
             .where(
                 pointHistoryJpaEntity.createdAt.eq(latestCreatedAt)

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -164,22 +164,20 @@ class PointHistoryPersistenceAdapter(
     override fun queryPointTotalsGroupByStudent(): List<StudentTotalVO> {
         val latestPointHistory = QPointHistoryJpaEntity("latestPointHistory")
 
-        val history = JPAExpressions
-            .select(latestPointHistory.id)
+        val studentGcn = Expressions.stringTemplate(
+            "CONCAT({0}, {1}, LPAD(CAST({2} AS string), 2, '0'))",
+            studentJpaEntity.grade,
+            studentJpaEntity.classRoom,
+            studentJpaEntity.number
+        )
+
+        val latestCreatedAt = JPAExpressions
+            .select(latestPointHistory.createdAt.max())
             .from(latestPointHistory)
             .where(
-                latestPointHistory.studentGcn.eq(
-                    Expressions.stringTemplate(
-                        "CONCAT({0}, {1}, LPAD(CAST({2} AS CHAR), 2, '0'))",
-                        studentJpaEntity.grade,
-                        studentJpaEntity.classRoom,
-                        studentJpaEntity.number
-                    )
-                ),
-                latestPointHistory.studentName.eq(studentJpaEntity.name)
+                latestPointHistory.studentGcn.eq(pointHistoryJpaEntity.studentGcn),
+                latestPointHistory.studentName.eq(pointHistoryJpaEntity.studentName)
             )
-            .orderBy(latestPointHistory.createdAt.desc())
-            .limit(1)
 
         return queryFactory
             .select(
@@ -191,7 +189,11 @@ class PointHistoryPersistenceAdapter(
             )
             .from(studentJpaEntity)
             .join(pointHistoryJpaEntity).on(
-                pointHistoryJpaEntity.id.`in`(history)
+                pointHistoryJpaEntity.studentGcn.eq(studentGcn),
+                pointHistoryJpaEntity.studentName.eq(studentJpaEntity.name)
+            )
+            .where(
+                pointHistoryJpaEntity.createdAt.eq(latestCreatedAt)
             )
             .fetch()
     }


### PR DESCRIPTION
## 작업 내용 설명
  - [x] 학생 경고 태그 스케줄러(`studentTagJob`)가 매일 자정 실패하던 버그를 수정했습니다. 원인은 `queryPointTotalsGroupByStudent()` 쿼리의 두 가지 문제였습니다.
  - [x] 첫번째 문제는 cast 대상 타입입니다. `Expressions.stringTemplate`의 내용은 SQL이 아니라 HQL로 먼저 파싱되는데, `CHAR`는 SQL 타입명이라 Hibernate HQL 파서의 cast 타깃 목록에 없어 파싱 단계에서 실패했습니다. HQL 타입명인 `string`으로 변경했고, MySQLDialect가 최종 SQL에서 `cast(... as char)`로 번역하므로 실행되는 SQL은 의도했던 것과 동일합니다.
  - [x] 두번째 문제는 서브쿼리의 `limit`이 사라지는 것입니다. JPQL 표준에 서브쿼리 LIMIT이 없어 QueryDSL-JPA가 `.limit(1)`을 경고 없이 버립니다(`order by`는 렌더링되지만 `IN` 집합 검사에서는 무의미). 그 결과 "학생별 최신 이력 1건"이
  아니라 "학생의 모든 이력"이 반환되어, 학생 1명이 이력 개수만큼 중복 처리되고 과거의 낮은 벌점 스냅샷으로도 태그가 판정되었습니다. `max(created_at)` 상관 서브쿼리로 대체해 `limit` 의존 자체를 제거했습니다.

  ## 주요 변경 사항
  - `CONCAT({0}, {1}, LPAD(CAST({2} AS CHAR), 2, '0'))` → `CONCAT({0}, {1}, LPAD(CAST({2} AS string), 2, '0'))`
  - `IN` 서브쿼리(`order by ... limit 1`) 제거 → 조인 조건을 GCN·이름 직접 매칭으로 바꾸고, `latestCreatedAt` 상관 서브쿼리(`max(createdAt)`)를 `where`에 추가

  ## 체크리스트
  - [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
  - [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
  - [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

  ## 관련 이슈
  - resolved #1047


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 학생별 포인트 합계 조회 시 학생의 최신 포인트 이력이 정확히 반영되도록 개선했습니다.
  * 동일한 학생 정보에 해당하는 이력 중 가장 최근 기록을 기준으로 조회합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->