### PR TITLE
merge: (#1049) 관리자 학생 상벌점 리스트 조회 성능 개선

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/manager/dto/PointFilter.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/manager/dto/PointFilter.kt
@@ -14,4 +14,18 @@ data class PointFilter(
             }
         }
     }
+
+    fun matches(bonusPoint: Int, minusPoint: Int): Boolean {
+        val type = filterType ?: return true
+        val min = minPoint ?: return true
+        val max = maxPoint ?: return true
+
+        val totalPoint = when (type) {
+            PointFilterType.BONUS -> bonusPoint
+            PointFilterType.MINUS -> minusPoint
+            PointFilterType.ALL -> bonusPoint - minusPoint
+        }
+
+        return totalPoint in min..max
+    }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/service/GetPointService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/service/GetPointService.kt
@@ -64,5 +64,5 @@ interface GetPointService {
         schoolId: UUID
     ): List<PointHistory>
 
-    fun getPointTotalsGroupByStudent(schoolId: UUID? = null): List<StudentTotalVO>
+    fun getPointTotalsGroupByStudent(schoolId: UUID?): List<StudentTotalVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/service/GetPointService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/service/GetPointService.kt
@@ -64,5 +64,5 @@ interface GetPointService {
         schoolId: UUID
     ): List<PointHistory>
 
-    fun getPointTotalsGroupByStudent(): List<StudentTotalVO>
+    fun getPointTotalsGroupByStudent(schoolId: UUID? = null): List<StudentTotalVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/service/GetPointServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/service/GetPointServiceImpl.kt
@@ -117,7 +117,7 @@ class GetPointServiceImpl(
         }
     }
 
-    override fun getPointTotalsGroupByStudent(): List<StudentTotalVO> {
-        return queryPointHistoryPort.queryPointTotalsGroupByStudent()
+    override fun getPointTotalsGroupByStudent(schoolId: UUID?): List<StudentTotalVO> {
+        return queryPointHistoryPort.queryPointTotalsGroupByStudent(schoolId)
     }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -45,5 +45,5 @@ interface QueryPointHistoryPort {
         gcns: List<String>
     ): List<PointHistory>
 
-    fun queryPointTotalsGroupByStudent(schoolId: UUID? = null): List<StudentTotalVO>
+    fun queryPointTotalsGroupByStudent(schoolId: UUID?): List<StudentTotalVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/spi/QueryPointHistoryPort.kt
@@ -45,5 +45,5 @@ interface QueryPointHistoryPort {
         gcns: List<String>
     ): List<PointHistory>
 
-    fun queryPointTotalsGroupByStudent(): List<StudentTotalVO>
+    fun queryPointTotalsGroupByStudent(schoolId: UUID? = null): List<StudentTotalVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/usecase/ExportPointHistoryUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/point/usecase/ExportPointHistoryUseCase.kt
@@ -24,7 +24,7 @@ class ExportPointHistoryUseCase(
         val user = userService.getCurrentUser()
         val school = schoolService.getSchoolById(user.schoolId)
 
-        val students = studentService.getStudentsByNameAndSortAndFilter(
+        val students = studentService.getStudentsByNameAndSortAndTag(
             schoolId = school.id
         )
 

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/service/GetStudentService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/service/GetStudentService.kt
@@ -1,7 +1,6 @@
 package team.aliens.dms.domain.student.service
 
 import team.aliens.dms.domain.file.spi.vo.ExcelStudentVO
-import team.aliens.dms.domain.manager.dto.PointFilter
 import team.aliens.dms.domain.manager.dto.Sort
 import team.aliens.dms.domain.manager.spi.vo.StudentWithTag
 import team.aliens.dms.domain.point.spi.vo.StudentWithPointVO
@@ -26,11 +25,10 @@ interface GetStudentService {
 
     fun getStudentByUserId(userId: UUID): Student
 
-    fun getStudentsByNameAndSortAndFilter(
+    fun getStudentsByNameAndSortAndTag(
         name: String? = null,
         sort: Sort = Sort.GCN,
         schoolId: UUID,
-        pointFilter: PointFilter = PointFilter(null, null, null),
         tagIds: List<UUID>? = null
     ): List<StudentWithTag>
 

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/service/GetStudentServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/service/GetStudentServiceImpl.kt
@@ -3,7 +3,6 @@ package team.aliens.dms.domain.student.service
 import team.aliens.dms.common.annotation.Service
 import team.aliens.dms.common.spi.SecurityPort
 import team.aliens.dms.domain.file.spi.vo.ExcelStudentVO
-import team.aliens.dms.domain.manager.dto.PointFilter
 import team.aliens.dms.domain.manager.dto.Sort
 import team.aliens.dms.domain.room.exception.RoomNotFoundException
 import team.aliens.dms.domain.room.model.Room
@@ -45,13 +44,12 @@ class GetStudentServiceImpl(
     override fun getStudentByUserId(userId: UUID) =
         queryStudentPort.queryStudentByUserId(userId) ?: throw StudentNotFoundException
 
-    override fun getStudentsByNameAndSortAndFilter(
+    override fun getStudentsByNameAndSortAndTag(
         name: String?,
         sort: Sort,
         schoolId: UUID,
-        pointFilter: PointFilter,
         tagIds: List<UUID>?,
-    ) = queryStudentPort.queryStudentsByNameAndSortAndFilter(name, sort, schoolId, pointFilter, tagIds)
+    ) = queryStudentPort.queryStudentsByNameAndSortAndTag(name, sort, schoolId, tagIds)
 
     override fun getRoommates(studentId: UUID, roomNumber: String, schoolId: UUID): List<Student> {
         return queryStudentPort.queryStudentsByRoomNumberAndSchoolId(roomNumber, schoolId)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/spi/QueryStudentPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/spi/QueryStudentPort.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.domain.student.spi
 
-import team.aliens.dms.domain.manager.dto.PointFilter
 import team.aliens.dms.domain.manager.dto.Sort
 import team.aliens.dms.domain.manager.spi.vo.StudentWithTag
 import team.aliens.dms.domain.point.spi.vo.StudentWithPointVO
@@ -26,11 +25,10 @@ interface QueryStudentPort {
 
     fun queryBySchoolIdAndRoomNumberAndRoomLocationIn(schoolId: UUID, roomNumberLocations: List<Pair<String, String>>): List<Student>
 
-    fun queryStudentsByNameAndSortAndFilter(
+    fun queryStudentsByNameAndSortAndTag(
         name: String?,
         sort: Sort,
         schoolId: UUID,
-        pointFilter: PointFilter,
         tagIds: List<UUID>?
     ): List<StudentWithTag>
 

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/usecase/ManagerGetAllStudentsUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/student/usecase/ManagerGetAllStudentsUseCase.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.domain.student.usecase
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
 import team.aliens.dms.domain.manager.dto.PointFilter
 import team.aliens.dms.domain.manager.dto.Sort
+import team.aliens.dms.domain.point.service.PointService
 import team.aliens.dms.domain.student.dto.StudentsResponse
 import team.aliens.dms.domain.student.service.StudentService
 import team.aliens.dms.domain.user.service.UserService
@@ -11,7 +12,8 @@ import java.util.UUID
 @ReadOnlyUseCase
 class ManagerGetAllStudentsUseCase(
     private val userService: UserService,
-    private val studentService: StudentService
+    private val studentService: StudentService,
+    private val pointService: PointService
 ) {
 
     fun execute(
@@ -22,14 +24,24 @@ class ManagerGetAllStudentsUseCase(
     ): StudentsResponse {
         val user = userService.getCurrentUser()
 
-        val students = studentService.getStudentsByNameAndSortAndFilter(
+        val students = studentService.getStudentsByNameAndSortAndTag(
             name = name,
             sort = sort,
             schoolId = user.schoolId,
-            pointFilter = pointFilter,
             tagIds = tagIds
         )
 
-        return StudentsResponse.of(students)
+        val pointTotals = pointService.getPointTotalsGroupByStudent(user.schoolId)
+            .associateBy { it.studentId }
+
+        val studentsWithPoint = students
+            .map { student ->
+                pointTotals[student.id]
+                    ?.let { student.copy(bonusPoint = it.bonusTotal, minusPoint = it.minusTotal) }
+                    ?: student
+            }
+            .filter { pointFilter.matches(it.bonusPoint, it.minusPoint) }
+
+        return StudentsResponse.of(studentsWithPoint)
     }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCase.kt
@@ -26,7 +26,7 @@ class UpdateStudentTagsUseCase(
         val warningTagsToDelete = mutableListOf<StudentTagDetailVO>()
         val tagsToSave = mutableListOf<StudentTag>()
 
-        for (studentPoint in pointService.getPointTotalsGroupByStudent()) {
+        for (studentPoint in pointService.getPointTotalsGroupByStudent(schoolId = null)) {
             val requiredLevel = WarningTag.byPoint(studentPoint.minusTotal)
             if (requiredLevel == WarningTag.SAFE) continue
 

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/point/stub/GetPointServiceStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/point/stub/GetPointServiceStub.kt
@@ -70,5 +70,6 @@ abstract class GetPointServiceStub : GetPointService {
         schoolId: UUID
     ): List<PointHistory> = throw UnsupportedOperationException()
 
-    override fun getPointTotalsGroupByStudent(): List<StudentTotalVO> = throw UnsupportedOperationException()
+    override fun getPointTotalsGroupByStudent(schoolId: UUID?): List<StudentTotalVO> =
+        throw UnsupportedOperationException()
 }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/student/stub/StudentWithTagStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/student/stub/StudentWithTagStub.kt
@@ -1,0 +1,32 @@
+package team.aliens.dms.domain.manager.stub
+
+import team.aliens.dms.domain.manager.spi.vo.StudentWithTag
+import team.aliens.dms.domain.student.model.Sex
+import team.aliens.dms.domain.tag.model.Tag
+import java.util.UUID
+
+internal fun createStudentWithTagStub(
+    id: UUID = UUID.randomUUID(),
+    name: String = "이름",
+    grade: Int = 2,
+    classRoom: Int = 2,
+    number: Int = 1,
+    roomNumber: String = "415",
+    profileImageUrl: String = "image",
+    sex: Sex = Sex.MALE,
+    bonusPoint: Int = 0,
+    minusPoint: Int = 0,
+    tags: List<Tag> = emptyList()
+) = StudentWithTag(
+    id = id,
+    name = name,
+    grade = grade,
+    classRoom = classRoom,
+    number = number,
+    roomNumber = roomNumber,
+    profileImageUrl = profileImageUrl,
+    sex = sex,
+    bonusPoint = bonusPoint,
+    minusPoint = minusPoint,
+    tags = tags
+)

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/student/usecase/ManagerGetAllStudentsUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/student/usecase/ManagerGetAllStudentsUseCaseTest.kt
@@ -1,0 +1,236 @@
+package team.aliens.dms.domain.student.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.aliens.dms.domain.manager.dto.PointFilter
+import team.aliens.dms.domain.manager.dto.PointFilterType
+import team.aliens.dms.domain.manager.dto.Sort
+import team.aliens.dms.domain.manager.stub.createStudentWithTagStub
+import team.aliens.dms.domain.point.service.PointService
+import team.aliens.dms.domain.point.spi.vo.StudentTotalVO
+import team.aliens.dms.domain.student.service.StudentService
+import team.aliens.dms.domain.user.service.UserService
+import team.aliens.dms.domain.user.stub.createUserStub
+import java.util.UUID
+
+class ManagerGetAllStudentsUseCaseTest : DescribeSpec({
+
+    val userService = mockk<UserService>()
+    val studentService = mockk<StudentService>()
+    val pointService = mockk<PointService>()
+    val useCase = ManagerGetAllStudentsUseCase(userService, studentService, pointService)
+
+    val schoolId = UUID.randomUUID()
+    val user = createUserStub(schoolId = schoolId)
+
+    val firstStudentId = UUID.randomUUID()
+    val secondStudentId = UUID.randomUUID()
+    val thirdStudentId = UUID.randomUUID()
+
+    val noPointFilter = PointFilter(filterType = null, minPoint = null, maxPoint = null)
+
+    describe("execute") {
+
+        context("학생마다 상벌점 이력이 있으면") {
+            it("studentId를 기준으로 총점이 매칭된다") {
+                clearAllMocks()
+                every { userService.getCurrentUser() } returns user
+                every {
+                    studentService.getStudentsByNameAndSortAndTag(
+                        name = null,
+                        sort = Sort.GCN,
+                        schoolId = schoolId,
+                        tagIds = null
+                    )
+                } returns listOf(
+                    createStudentWithTagStub(id = firstStudentId, name = "김철수"),
+                    createStudentWithTagStub(id = secondStudentId, name = "박영희")
+                )
+                every { pointService.getPointTotalsGroupByStudent(schoolId) } returns listOf(
+                    StudentTotalVO(secondStudentId, bonusTotal = 7, minusTotal = 3),
+                    StudentTotalVO(firstStudentId, bonusTotal = 10, minusTotal = 5)
+                )
+
+                val response = useCase.execute(
+                    name = null,
+                    sort = Sort.GCN,
+                    pointFilter = noPointFilter,
+                    tagIds = null
+                )
+
+                response.students.map { Triple(it.name, it.bonusPoint, it.minusPoint) } shouldBe listOf(
+                    Triple("김철수", 10, 5),
+                    Triple("박영희", 7, 3)
+                )
+            }
+        }
+
+        context("상벌점 이력이 없는 학생이 섞여 있으면") {
+            it("그 학생의 상벌점은 0으로 반환된다") {
+                clearAllMocks()
+                every { userService.getCurrentUser() } returns user
+                every {
+                    studentService.getStudentsByNameAndSortAndTag(
+                        name = null,
+                        sort = Sort.GCN,
+                        schoolId = schoolId,
+                        tagIds = null
+                    )
+                } returns listOf(
+                    createStudentWithTagStub(id = firstStudentId, name = "이력있음"),
+                    createStudentWithTagStub(id = secondStudentId, name = "이력없음")
+                )
+                every { pointService.getPointTotalsGroupByStudent(schoolId) } returns listOf(
+                    StudentTotalVO(firstStudentId, bonusTotal = 10, minusTotal = 5)
+                )
+
+                val response = useCase.execute(
+                    name = null,
+                    sort = Sort.GCN,
+                    pointFilter = noPointFilter,
+                    tagIds = null
+                )
+
+                response.students.map { Triple(it.name, it.bonusPoint, it.minusPoint) } shouldBe listOf(
+                    Triple("이력있음", 10, 5),
+                    Triple("이력없음", 0, 0)
+                )
+            }
+        }
+
+        context("학생 조회 결과 순서는") {
+            it("상벌점을 합친 뒤에도 그대로 유지된다") {
+                clearAllMocks()
+                every { userService.getCurrentUser() } returns user
+                every {
+                    studentService.getStudentsByNameAndSortAndTag(
+                        name = null,
+                        sort = Sort.NAME,
+                        schoolId = schoolId,
+                        tagIds = null
+                    )
+                } returns listOf(
+                    createStudentWithTagStub(id = firstStudentId, name = "첫번째"),
+                    createStudentWithTagStub(id = secondStudentId, name = "두번째"),
+                    createStudentWithTagStub(id = thirdStudentId, name = "세번째")
+                )
+                every { pointService.getPointTotalsGroupByStudent(schoolId) } returns listOf(
+                    StudentTotalVO(thirdStudentId, bonusTotal = 3, minusTotal = 0),
+                    StudentTotalVO(firstStudentId, bonusTotal = 1, minusTotal = 0)
+                )
+
+                val response = useCase.execute(
+                    name = null,
+                    sort = Sort.NAME,
+                    pointFilter = noPointFilter,
+                    tagIds = null
+                )
+
+                response.students.map { it.name } shouldBe listOf("첫번째", "두번째", "세번째")
+            }
+        }
+
+        context("상벌점 필터가 주어지면") {
+            it("필터 타입과 범위에 맞는 학생만 반환한다") {
+                forAll(
+                    // 상점 10점, 벌점 5점인 학생 하나를 두고 필터만 바꿔가며 검증한다
+                    row(PointFilterType.BONUS, 10, 10, 1),
+                    row(PointFilterType.BONUS, 0, 9, 0),
+                    row(PointFilterType.BONUS, 11, 20, 0),
+                    row(PointFilterType.MINUS, 5, 5, 1),
+                    row(PointFilterType.MINUS, 6, 10, 0),
+                    row(PointFilterType.ALL, 5, 5, 1),
+                    row(PointFilterType.ALL, 6, 10, 0)
+                ) { filterType, minPoint, maxPoint, expectedSize ->
+                    clearAllMocks()
+                    every { userService.getCurrentUser() } returns user
+                    every {
+                        studentService.getStudentsByNameAndSortAndTag(
+                            name = null,
+                            sort = Sort.GCN,
+                            schoolId = schoolId,
+                            tagIds = null
+                        )
+                    } returns listOf(createStudentWithTagStub(id = firstStudentId))
+                    every { pointService.getPointTotalsGroupByStudent(schoolId) } returns listOf(
+                        StudentTotalVO(firstStudentId, bonusTotal = 10, minusTotal = 5)
+                    )
+
+                    val response = useCase.execute(
+                        name = null,
+                        sort = Sort.GCN,
+                        pointFilter = PointFilter(filterType, minPoint, maxPoint),
+                        tagIds = null
+                    )
+
+                    response.students.size shouldBe expectedSize
+                }
+            }
+        }
+
+        context("상벌점 이력이 없는 학생에 상점 0점 필터를 걸면") {
+            it("그 학생이 포함된다") {
+                clearAllMocks()
+                every { userService.getCurrentUser() } returns user
+                every {
+                    studentService.getStudentsByNameAndSortAndTag(
+                        name = null,
+                        sort = Sort.GCN,
+                        schoolId = schoolId,
+                        tagIds = null
+                    )
+                } returns listOf(createStudentWithTagStub(id = firstStudentId, name = "이력없음"))
+                every { pointService.getPointTotalsGroupByStudent(schoolId) } returns emptyList()
+
+                val response = useCase.execute(
+                    name = null,
+                    sort = Sort.GCN,
+                    pointFilter = PointFilter(PointFilterType.BONUS, 0, 0),
+                    tagIds = null
+                )
+
+                response.students.map { it.name } shouldBe listOf("이력없음")
+            }
+        }
+
+        context("이름과 태그로 조회하면") {
+            it("조회 조건을 그대로 전달하고 현재 사용자의 학교로 상벌점을 조회한다") {
+                clearAllMocks()
+                val tagId = UUID.randomUUID()
+                every { userService.getCurrentUser() } returns user
+                every {
+                    studentService.getStudentsByNameAndSortAndTag(
+                        name = "김",
+                        sort = Sort.NAME,
+                        schoolId = schoolId,
+                        tagIds = listOf(tagId)
+                    )
+                } returns listOf(createStudentWithTagStub(id = firstStudentId, name = "김철수"))
+                every { pointService.getPointTotalsGroupByStudent(schoolId) } returns emptyList()
+
+                useCase.execute(
+                    name = "김",
+                    sort = Sort.NAME,
+                    pointFilter = noPointFilter,
+                    tagIds = listOf(tagId)
+                )
+
+                verify(exactly = 1) {
+                    studentService.getStudentsByNameAndSortAndTag(
+                        name = "김",
+                        sort = Sort.NAME,
+                        schoolId = schoolId,
+                        tagIds = listOf(tagId)
+                    )
+                }
+                verify(exactly = 1) { pointService.getPointTotalsGroupByStudent(schoolId) }
+            }
+        }
+    }
+})

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/tag/usecase/UpdateStudentTagsUseCaseTest.kt
@@ -46,7 +46,7 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
             it("아무 태그도 저장하지 않는다") {
                 every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
                 every { tagService.getAllStudentTagDetails() } returns emptyList()
-                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                every { pointService.getPointTotalsGroupByStudent(schoolId = null) } returns listOf(
                     StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 10)
                 )
                 every { tagService.deleteStudentTagById(any(), any()) } just runs
@@ -62,7 +62,7 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
             it("경고 1단계 태그가 저장된다") {
                 every { tagService.getTagsByTagNameIn(any()) } returns warningTagEntities
                 every { tagService.getAllStudentTagDetails() } returns emptyList()
-                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                every { pointService.getPointTotalsGroupByStudent(schoolId = null) } returns listOf(
                     StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
                 )
                 every { tagService.deleteStudentTagById(any(), any()) } just runs
@@ -88,7 +88,7 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
                         tagName = WarningTag.C_FIRST_WARNING.warningMessage
                     )
                 )
-                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                every { pointService.getPointTotalsGroupByStudent(schoolId = null) } returns listOf(
                     StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
                 )
                 every { tagService.deleteStudentTagById(any(), any()) } just runs
@@ -114,7 +114,7 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
                         tagName = WarningTag.C_FIRST_WARNING.warningMessage
                     )
                 )
-                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                every { pointService.getPointTotalsGroupByStudent(schoolId = null) } returns listOf(
                     StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
                 )
                 every { tagService.deleteStudentTagById(any(), any()) } just runs
@@ -139,7 +139,7 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
                         tagName = WarningTag.FIRST_WARNING.warningMessage
                     )
                 )
-                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                every { pointService.getPointTotalsGroupByStudent(schoolId = null) } returns listOf(
                     StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 20)
                 )
                 every { tagService.deleteStudentTagById(any(), any()) } just runs
@@ -165,7 +165,7 @@ class UpdateStudentTagsUseCaseTest : DescribeSpec({
                         tagName = "소프트웨어개발과"
                     )
                 )
-                every { pointService.getPointTotalsGroupByStudent() } returns listOf(
+                every { pointService.getPointTotalsGroupByStudent(schoolId = null) } returns listOf(
                     StudentTotalVO(studentId, bonusTotal = 0, minusTotal = 15)
                 )
                 every { tagService.deleteStudentTagById(any(), any()) } just runs

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/PointHistoryPersistenceAdapter.kt
@@ -1,7 +1,6 @@
 package team.aliens.dms.persistence.point
 
 import com.querydsl.core.types.dsl.Expressions
-import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -12,7 +11,6 @@ import team.aliens.dms.domain.point.spi.PointHistoryPort
 import team.aliens.dms.domain.point.spi.vo.PointHistoryVO
 import team.aliens.dms.domain.point.spi.vo.StudentPointHistoryVO
 import team.aliens.dms.domain.point.spi.vo.StudentTotalVO
-import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity
 import team.aliens.dms.persistence.point.entity.QPointHistoryJpaEntity.pointHistoryJpaEntity
 import team.aliens.dms.persistence.point.mapper.PointHistoryMapper
 import team.aliens.dms.persistence.point.repository.PointHistoryJpaRepository
@@ -161,9 +159,7 @@ class PointHistoryPersistenceAdapter(
         pointHistoryRepository.findByStudentGcnIn(gcns)
             .map { pointHistoryMapper.toDomain(it)!! }
 
-    override fun queryPointTotalsGroupByStudent(): List<StudentTotalVO> {
-        val latestPointHistory = QPointHistoryJpaEntity("latestPointHistory")
-
+    override fun queryPointTotalsGroupByStudent(schoolId: UUID?): List<StudentTotalVO> {
         val studentGcn = Expressions.stringTemplate(
             "CONCAT({0}, {1}, LPAD(CAST({2} AS string), 2, '0'))",
             studentJpaEntity.grade,
@@ -171,21 +167,13 @@ class PointHistoryPersistenceAdapter(
             studentJpaEntity.number
         )
 
-        val latestCreatedAt = JPAExpressions
-            .select(latestPointHistory.createdAt.max())
-            .from(latestPointHistory)
-            .where(
-                latestPointHistory.studentGcn.eq(pointHistoryJpaEntity.studentGcn),
-                latestPointHistory.studentName.eq(pointHistoryJpaEntity.studentName),
-                latestPointHistory.school.id.eq(pointHistoryJpaEntity.school.id)
-            )
-
         return queryFactory
             .select(
                 QQueryStudentTotalVO(
                     studentJpaEntity.id,
                     pointHistoryJpaEntity.bonusTotal,
-                    pointHistoryJpaEntity.minusTotal
+                    pointHistoryJpaEntity.minusTotal,
+                    pointHistoryJpaEntity.createdAt
                 )
             )
             .from(studentJpaEntity)
@@ -195,8 +183,10 @@ class PointHistoryPersistenceAdapter(
                 pointHistoryJpaEntity.school.id.eq(studentJpaEntity.room.school.id)
             )
             .where(
-                pointHistoryJpaEntity.createdAt.eq(latestCreatedAt)
+                schoolId?.let { studentJpaEntity.room.school.id.eq(it) }
             )
             .fetch()
+            .groupBy { it.studentId }
+            .map { (_, histories) -> histories.maxBy { it.createdAt } }
     }
 }

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryStudentTotalVO.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/point/repository/vo/QueryStudentTotalVO.kt
@@ -2,12 +2,14 @@ package team.aliens.dms.persistence.point.repository.vo
 
 import com.querydsl.core.annotations.QueryProjection
 import team.aliens.dms.domain.point.spi.vo.StudentTotalVO
+import java.time.LocalDateTime
 import java.util.UUID
 
 class QueryStudentTotalVO @QueryProjection constructor(
     id: UUID,
     bonusTotal: Int,
-    minusTotal: Int
+    minusTotal: Int,
+    val createdAt: LocalDateTime
 ) : StudentTotalVO(
     studentId = id,
     bonusTotal = bonusTotal,

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/student/StudentPersistenceAdapter.kt
@@ -7,14 +7,11 @@ import com.querydsl.core.group.GroupBy.list
 import com.querydsl.core.types.Expression
 import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
-import com.querydsl.core.types.dsl.CaseBuilder
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.JPAExpressions.select
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
-import team.aliens.dms.domain.manager.dto.PointFilter
-import team.aliens.dms.domain.manager.dto.PointFilterType
 import team.aliens.dms.domain.manager.dto.Sort
 import team.aliens.dms.domain.manager.spi.vo.StudentWithTag
 import team.aliens.dms.domain.point.model.PointType
@@ -155,23 +152,20 @@ class StudentPersistenceAdapter(
         return tuple.toTypedArray()
     }
 
-    override fun queryStudentsByNameAndSortAndFilter(
+    override fun queryStudentsByNameAndSortAndTag(
         name: String?,
         sort: Sort,
         schoolId: UUID,
-        pointFilter: PointFilter,
         tagIds: List<UUID>?
     ): List<StudentWithTag> {
         return queryFactory
             .selectFrom(studentJpaEntity)
             .join(studentJpaEntity.room, roomJpaEntity)
-            .leftJoin(studentTagJpaEntity).on(studentJpaEntity.id.eq(studentTagJpaEntity.student.id)).fetchJoin()
+            .leftJoin(studentTagJpaEntity).on(studentJpaEntity.id.eq(studentTagJpaEntity.student.id))
             .leftJoin(tagJpaEntity).on(studentTagJpaEntity.tag.id.eq(tagJpaEntity.id))
-            .leftJoin(pointHistoryJpaEntity).on(eqStudentRecentPointHistory())
             .where(
                 roomJpaEntity.school.id.eq(schoolId),
                 nameContains(name),
-                pointTotalBetween(pointFilter),
                 hasAllTags(tagIds)
             )
             .orderBy(
@@ -192,8 +186,6 @@ class StudentPersistenceAdapter(
                             roomJpaEntity.number,
                             studentJpaEntity.profileImageUrl,
                             studentJpaEntity.sex,
-                            pointHistoryJpaEntity.bonusTotal,
-                            pointHistoryJpaEntity.minusTotal,
                             list(tagJpaEntity)
                         )
                     )
@@ -208,8 +200,8 @@ class StudentPersistenceAdapter(
                     roomNumber = it.roomNumber,
                     profileImageUrl = it.profileImageUrl,
                     sex = it.sex,
-                    bonusPoint = it.bonusPoint,
-                    minusPoint = it.minusPoint,
+                    bonusPoint = 0,
+                    minusPoint = 0,
                     tags = it.tags
                         .map { tag ->
                             tagMapper.toDomain(tag)!!
@@ -219,35 +211,6 @@ class StudentPersistenceAdapter(
     }
 
     private fun nameContains(name: String?) = name?.run { studentJpaEntity.name.contains(this) }
-
-    private fun pointTotalBetween(pointFilter: PointFilter): BooleanExpression? {
-        if (pointFilter.filterType == null) {
-            return null
-        }
-
-        return when (pointFilter.filterType) {
-            PointFilterType.BONUS -> {
-                CaseBuilder()
-                    .`when`(pointHistoryJpaEntity.isNotNull)
-                    .then(pointHistoryJpaEntity.bonusTotal)
-                    .otherwise(0).between(pointFilter.minPoint, pointFilter.maxPoint)
-            }
-
-            PointFilterType.MINUS -> {
-                CaseBuilder()
-                    .`when`(pointHistoryJpaEntity.isNotNull)
-                    .then(pointHistoryJpaEntity.minusTotal)
-                    .otherwise(0).between(pointFilter.minPoint, pointFilter.maxPoint)
-            }
-
-            else -> {
-                CaseBuilder()
-                    .`when`(pointHistoryJpaEntity.isNotNull)
-                    .then(pointHistoryJpaEntity.bonusTotal.subtract(pointHistoryJpaEntity.minusTotal))
-                    .otherwise(0).between(pointFilter.minPoint, pointFilter.maxPoint)
-            }
-        }
-    }
 
     private fun hasAllTags(tagIds: List<UUID>?): BooleanExpression? =
         tagIds?.run {

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/vo/QueryStudentsWithTagVO.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/student/repository/vo/QueryStudentsWithTagVO.kt
@@ -14,7 +14,5 @@ data class QueryStudentsWithTagVO @QueryProjection constructor(
     val roomNumber: String,
     val profileImageUrl: String,
     val sex: Sex,
-    val bonusPoint: Int,
-    val minusPoint: Int,
     val tags: List<TagJpaEntity>
 )


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 기존에 상관 서브쿼리로 인하여 student 행 + 태그 행 개수만큼 돌던 쿼리를 삭제하고 kotlin maxby{}를 사용하여 sql이 아닌 kotlin 단계에서 created_at값을 비교하여 최신 이력을 조회하도록 로직을 수정함

## 주요 변경 사항
- 상관 서브쿼리를 삭제하고, kotlin에서 maxby{}를 사용하여 최신 상벌점 이력을 조회하도록 수정함
- ManagerGetAllStudentsUseCaseTest 추가
- 기존에 PointFilter를 쿼리에서 사용하지 않고 2개의 쿼리를 날려서 조합한 값을 통해 point를 확인

## 결과물
로컬에서 Gatling 성능 부하 테스트를 했을 때 동시 요청 10건 시 평균 192ms로 측정되었음
<img width="1524" height="784" alt="image" src="https://github.com/user-attachments/assets/f504af38-f584-4c5a-b8e4-b2c01bad0adc" />
[성능부하테스트-로컬.zip](https://github.com/user-attachments/files/30975183/-.zip)


## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1049 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 학생 목록에서 상벌점 합계를 기준으로 필터링할 수 있습니다.
  - 보너스 점수, 차감 점수 또는 합산 결과를 기준으로 지정된 범위의 학생을 조회할 수 있습니다.
  - 학교 기준으로 학생별 최신 상벌점 합계를 조회합니다.
  - 상벌점 이력이 없는 학생은 0점으로 처리됩니다.
  - 이름, 태그, 정렬 조건과 상벌점 필터를 함께 적용할 수 있습니다.

- **개선 사항**
  - 학생 목록 조회와 상벌점 조회 흐름이 분리되어 결과의 정확성과 일관성이 향상되었습니다.
  - 학생 상벌점 이력 내보내기 기능이 최신 학생 조회 조건을 사용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->