### PR TITLE
merge: (#1053) ACL 기능 삭제

### DIFF
--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/storage/AwsS3Adapter.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/thirdparty/storage/AwsS3Adapter.kt
@@ -3,7 +3,6 @@ package team.aliens.dms.thirdparty.storage
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.internal.Mimetypes
-import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
@@ -37,9 +36,6 @@ class AwsS3Adapter(
 
             amazonS3Client.putObject(
                 PutObjectRequest(awsProperties.bucket, buildKey(fileName), inputStream, objectMetadata)
-                    .withCannedAcl(
-                        CannedAccessControlList.PublicRead
-                    )
             )
 
             file.delete()


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 새로운 버킷에서는 버킷 정책을 따르기 때문에 기존에 ACL 기능을 지원하지 않아서 파일이 업로드 되지 않는 문제가 발생함. 
- [ ] ACL 관련 기능을 삭제함

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1053 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 파일 업로드 시 객체에 공개 읽기 권한을 자동으로 설정하지 않도록 변경했습니다.
  * 업로드된 파일의 접근 권한은 기본 저장소 정책을 따릅니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->