### PR TITLE
merge: (#1056) 로그인 시 device token 을 삭제해서 400 발생

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCase.kt
@@ -31,8 +31,6 @@ class SignInUseCase(
         val availableFeatures = schoolService.getAvailableFeaturesBySchoolId(user.schoolId)
 
         if (!request.deviceToken.isNullOrBlank()) {
-            eventPort.publishDeleteDeviceToken(user.id)
-
             eventPort.publishSaveDeviceToken(
                 DeviceTokenInfo(
                     userId = user.id,

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/notification/exception/NotificationErrorCode.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/notification/exception/NotificationErrorCode.kt
@@ -9,8 +9,8 @@ enum class NotificationErrorCode(
     private val sequence: Int
 ) : ErrorProperty {
 
-    DEVICE_TOKEN_NOT_FOUND(ErrorStatus.BAD_REQUEST, "Notification Token Not Found", 1),
-    NOTIFICATION_OF_USER_NOT_FOUND(ErrorStatus.BAD_REQUEST, "NotificationOfUser Not Found", 2),
+    DEVICE_TOKEN_NOT_FOUND(ErrorStatus.NOT_FOUND, "Notification Token Not Found", 1),
+    NOTIFICATION_OF_USER_NOT_FOUND(ErrorStatus.NOT_FOUND, "NotificationOfUser Not Found", 2),
     NOTIFICATION_SEND_FAILED(ErrorStatus.INTERNAL_SERVER_ERROR, "Notification Send Failed", 3)
     ;
 

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCaseTest.kt
@@ -1,0 +1,111 @@
+package team.aliens.dms.domain.auth.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Called
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import team.aliens.dms.common.service.security.SecurityService
+import team.aliens.dms.common.spi.EventPort
+import team.aliens.dms.domain.auth.dto.SignInRequest
+import team.aliens.dms.domain.auth.dto.TokenResponse
+import team.aliens.dms.domain.auth.spi.JwtPort
+import team.aliens.dms.domain.school.service.SchoolService
+import team.aliens.dms.domain.school.stub.createAvailableFeatureStub
+import team.aliens.dms.domain.user.service.UserService
+import team.aliens.dms.domain.user.stub.createUserStub
+import java.time.LocalDateTime
+import java.util.UUID
+
+class SignInUseCaseTest : DescribeSpec({
+
+    val tokenResponse = TokenResponse(
+        accessToken = "access-token",
+        accessTokenExpiredAt = LocalDateTime.now().plusHours(1),
+        refreshToken = "refresh-token",
+        refreshTokenExpiredAt = LocalDateTime.now().plusDays(7)
+    )
+
+    describe("execute") {
+        context("디바이스 토큰과 함께 로그인하면") {
+            val securityService = mockk<SecurityService>()
+            val userService = mockk<UserService>()
+            val schoolService = mockk<SchoolService>()
+            val eventPort = mockk<EventPort>()
+            val jwtPort = mockk<JwtPort>()
+            val signInUseCase = SignInUseCase(
+                securityService = securityService,
+                userService = userService,
+                schoolService = schoolService,
+                eventPort = eventPort,
+                jwtPort = jwtPort
+            )
+
+            val schoolId = UUID.randomUUID()
+            val user = createUserStub(schoolId = schoolId)
+            val availableFeature = createAvailableFeatureStub(schoolId = schoolId)
+            val request = SignInRequest(
+                accountId = user.accountId,
+                password = "raw-password",
+                deviceToken = "device-token"
+            )
+
+            every { userService.queryUserByAccountId(request.accountId) } returns user
+            every { securityService.checkIsPasswordMatches(request.password, user.password) } just runs
+            every { jwtPort.receiveToken(user.id, user.authority, schoolId) } returns tokenResponse
+            every { schoolService.getAvailableFeaturesBySchoolId(schoolId) } returns availableFeature
+            every { eventPort.publishSaveDeviceToken(any()) } just runs
+
+            signInUseCase.execute(request)
+
+            it("디바이스 토큰 저장 이벤트를 발행한다") {
+                verify(exactly = 1) { eventPort.publishSaveDeviceToken(any()) }
+                confirmVerified(eventPort)
+            }
+        }
+
+        context("디바이스 토큰 없이 로그인하면") {
+            val securityService = mockk<SecurityService>()
+            val userService = mockk<UserService>()
+            val schoolService = mockk<SchoolService>()
+            val eventPort = mockk<EventPort>()
+            val jwtPort = mockk<JwtPort>()
+            val signInUseCase = SignInUseCase(
+                securityService = securityService,
+                userService = userService,
+                schoolService = schoolService,
+                eventPort = eventPort,
+                jwtPort = jwtPort
+            )
+
+            val schoolId = UUID.randomUUID()
+            val user = createUserStub(schoolId = schoolId)
+            val availableFeature = createAvailableFeatureStub(schoolId = schoolId)
+            val request = SignInRequest(
+                accountId = user.accountId,
+                password = "raw-password",
+                deviceToken = null
+            )
+
+            every { userService.queryUserByAccountId(request.accountId) } returns user
+            every { securityService.checkIsPasswordMatches(request.password, user.password) } just runs
+            every { jwtPort.receiveToken(user.id, user.authority, schoolId) } returns tokenResponse
+            every { schoolService.getAvailableFeaturesBySchoolId(schoolId) } returns availableFeature
+
+            val result = signInUseCase.execute(request)
+
+            it("토큰을 발급한다") {
+                result.accessToken shouldBe tokenResponse.accessToken
+                result.refreshToken shouldBe tokenResponse.refreshToken
+            }
+
+            it("어떤 이벤트도 발행하지 않는다") {
+                verify { eventPort wasNot Called }
+            }
+        }
+    }
+})

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/auth/usecase/SignInUseCaseTest.kt
@@ -1,8 +1,8 @@
 package team.aliens.dms.domain.auth.usecase
 
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.shouldBe
-import io.mockk.Called
+import io.kotest.data.forAll
+import io.kotest.data.row
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.just
@@ -60,15 +60,23 @@ class SignInUseCaseTest : DescribeSpec({
             every { schoolService.getAvailableFeaturesBySchoolId(schoolId) } returns availableFeature
             every { eventPort.publishSaveDeviceToken(any()) } just runs
 
-            signInUseCase.execute(request)
+            it("디바이스 토큰 저장 이벤트만 발행한다") {
+                signInUseCase.execute(request)
 
-            it("디바이스 토큰 저장 이벤트를 발행한다") {
-                verify(exactly = 1) { eventPort.publishSaveDeviceToken(any()) }
+                verify(exactly = 1) {
+                    eventPort.publishSaveDeviceToken(
+                        match {
+                            it.userId == user.id &&
+                                it.schoolId == schoolId &&
+                                it.token == request.deviceToken
+                        }
+                    )
+                }
                 confirmVerified(eventPort)
             }
         }
 
-        context("디바이스 토큰 없이 로그인하면") {
+        context("디바이스 토큰이 비어 있으면") {
             val securityService = mockk<SecurityService>()
             val userService = mockk<UserService>()
             val schoolService = mockk<SchoolService>()
@@ -85,26 +93,28 @@ class SignInUseCaseTest : DescribeSpec({
             val schoolId = UUID.randomUUID()
             val user = createUserStub(schoolId = schoolId)
             val availableFeature = createAvailableFeatureStub(schoolId = schoolId)
-            val request = SignInRequest(
-                accountId = user.accountId,
-                password = "raw-password",
-                deviceToken = null
-            )
 
-            every { userService.queryUserByAccountId(request.accountId) } returns user
-            every { securityService.checkIsPasswordMatches(request.password, user.password) } just runs
+            every { userService.queryUserByAccountId(user.accountId) } returns user
+            every { securityService.checkIsPasswordMatches(any(), user.password) } just runs
             every { jwtPort.receiveToken(user.id, user.authority, schoolId) } returns tokenResponse
             every { schoolService.getAvailableFeaturesBySchoolId(schoolId) } returns availableFeature
 
-            val result = signInUseCase.execute(request)
+            it("디바이스 토큰 저장 이벤트를 발행하지 않는다") {
+                forAll(
+                    row(null),
+                    row(""),
+                ) { deviceToken ->
 
-            it("토큰을 발급한다") {
-                result.accessToken shouldBe tokenResponse.accessToken
-                result.refreshToken shouldBe tokenResponse.refreshToken
-            }
+                    val request = SignInRequest(
+                        accountId = user.accountId,
+                        password = "raw-password",
+                        deviceToken = deviceToken
+                    )
 
-            it("어떤 이벤트도 발행하지 않는다") {
-                verify { eventPort wasNot Called }
+                    signInUseCase.execute(request)
+
+                    verify(exactly = 0) { eventPort.publishSaveDeviceToken(any()) }
+                }
             }
         }
     }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/service/impl/CommandNotificationServiceImplTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/service/impl/CommandNotificationServiceImplTest.kt
@@ -14,8 +14,8 @@ import team.aliens.dms.domain.notification.spi.DeviceTokenPort
 import team.aliens.dms.domain.notification.spi.NotificationPort
 import team.aliens.dms.domain.notification.spi.QueryNotificationOfUserPort
 import team.aliens.dms.domain.notification.spi.TopicSubscriptionPort
-import team.aliens.dms.stub.createDeviceTokenStub
-import team.aliens.dms.stub.createNotificationOfUserStub
+import team.aliens.dms.domain.notification.stub.createDeviceTokenStub
+import team.aliens.dms.domain.notification.stub.createNotificationOfUserStub
 import java.time.LocalDateTime
 import java.util.UUID
 

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/service/impl/GetNotificationServiceImplTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/service/impl/GetNotificationServiceImplTest.kt
@@ -10,9 +10,9 @@ import team.aliens.dms.domain.notification.service.GetNotificationServiceImpl
 import team.aliens.dms.domain.notification.spi.QueryDeviceTokenPort
 import team.aliens.dms.domain.notification.spi.QueryNotificationOfUserPort
 import team.aliens.dms.domain.notification.spi.QueryTopicSubscriptionPort
-import team.aliens.dms.stub.createDeviceTokenStub
-import team.aliens.dms.stub.createNotificationOfUserStub
-import team.aliens.dms.stub.createTopicSubscriptionStub
+import team.aliens.dms.domain.notification.stub.createDeviceTokenStub
+import team.aliens.dms.domain.notification.stub.createNotificationOfUserStub
+import team.aliens.dms.domain.notification.stub.createTopicSubscriptionStub
 import java.util.UUID
 
 class GetNotificationServiceImplTest : DescribeSpec({

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/DeviceTokenStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/DeviceTokenStub.kt
@@ -1,4 +1,4 @@
-package team.aliens.dms.stub
+package team.aliens.dms.domain.notification.stub
 
 import team.aliens.dms.domain.notification.model.DeviceToken
 import java.util.UUID

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/NotificationOfUserStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/NotificationOfUserStub.kt
@@ -1,4 +1,4 @@
-package team.aliens.dms.stub
+package team.aliens.dms.domain.notification.stub
 
 import team.aliens.dms.contract.model.notification.Topic
 import team.aliens.dms.domain.notification.model.NotificationOfUser

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/NotificationStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/NotificationStub.kt
@@ -1,4 +1,4 @@
-package team.aliens.dms.stub
+package team.aliens.dms.domain.notification.stub
 
 import team.aliens.dms.contract.model.notification.Topic
 import team.aliens.dms.domain.notification.model.Notification

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/TopicSubscriptionStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/stub/TopicSubscriptionStub.kt
@@ -1,4 +1,4 @@
-package team.aliens.dms.stub
+package team.aliens.dms.domain.notification.stub
 
 import team.aliens.dms.contract.model.notification.Topic
 import team.aliens.dms.domain.notification.model.TopicSubscription

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/usecase/QueryTopicSubscriptionUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/usecase/QueryTopicSubscriptionUseCaseTest.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import team.aliens.dms.contract.model.notification.Topic
 import team.aliens.dms.domain.notification.service.NotificationService
-import team.aliens.dms.stub.createTopicSubscriptionStub
+import team.aliens.dms.domain.notification.stub.createTopicSubscriptionStub
 
 class QueryTopicSubscriptionUseCaseTest : DescribeSpec({
 

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/usecase/SetDeviceTokenUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/usecase/SetDeviceTokenUseCaseTest.kt
@@ -7,7 +7,7 @@ import io.mockk.mockk
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.notification.dto.SetDeviceTokenRequest
 import team.aliens.dms.domain.notification.service.NotificationService
-import team.aliens.dms.stub.createDeviceTokenStub
+import team.aliens.dms.domain.notification.stub.createDeviceTokenStub
 import java.util.UUID
 
 class SetDeviceTokenUseCaseTest : DescribeSpec({


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 기존에 device token을 값을 수정할 때 삭제 후, 재저장을 하는 로직이였는데 순서 보장이 되지 않아 삭제 로직이 먼저 실행되어서 400이 발생함 여기서 400은 기존 코드 문제인 것으로 보여서 404로 수정하였음
- [ ] 기존 삭제 후 재저장 로직이 아닌 save 메서드를 통해 수정하는 방식으로 수정하였음

## 주요 변경 사항
- `eventPort.publishDeleteDeviceToken()` 메서드 호출 삭제
- 기존에 없던 `SignInUseCaseTest` 추가
- 기존에 따로 빠져있던 stub 디렉토리를 notification 디렉토리로 이동
- `DEVICE_TOKEN_NOT_FOUND`, `NOTIFICATION_OF_USER_NOT_FOUND` 의 에러 코드를 404로 수정

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1056 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 로그인 시 유효한 요청 토큰만 저장되도록 개선했습니다.
  * 기존 디바이스 토큰이 불필요하게 삭제되는 동작을 제거했습니다.
  * 디바이스 토큰 및 사용자 알림을 찾을 수 없는 경우 올바른 오류 상태를 반환하도록 수정했습니다.

* **테스트**
  * 디바이스 토큰 유무에 따른 로그인 및 토큰 저장 동작 검증을 강화했습니다.
  * 알림 관련 테스트 구성을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->