### PR TITLE
merge: (#1060) 새벽자습 알림 저장을 하지 않도록 수정

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -46,7 +46,7 @@ class CommandDaybreakServiceImpl(
                 title = firstApplication.getTitle(),
                 content = "새벽 자습 신청 상태가 변경되었습니다.",
                 threadId = firstApplication.id.toString(),
-                isSaveRequired = true
+                isSaveRequired = false
             )
             notificationEventPort.publishNotificationToApplicant(userIds, notificationInfo)
         }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImplTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/notification/service/NotificationServiceImplTest.kt
@@ -133,10 +133,15 @@ class NotificationServiceImplTest : DescribeSpec({
 
             every { notificationPort.sendMessage(any(), any()) } just runs
 
-            it("알림을 전송한다") {
+            it("알림함에 저장하지 않고 알림을 전송한다") {
+                clearMocks(notificationPort, notificationOfUserPort, answers = false)
+
                 shouldNotThrowAny {
                     service.sendMessage(deviceToken, notification)
                 }
+
+                verify(exactly = 1) { notificationPort.sendMessage(any(), any()) }
+                verify(exactly = 0) { notificationOfUserPort.saveNotificationOfUser(any()) }
             }
         }
     }
@@ -174,6 +179,45 @@ class NotificationServiceImplTest : DescribeSpec({
                 shouldNotThrowAny {
                     service.sendMessages(deviceTokens, notification)
                 }
+            }
+        }
+
+        context("여러 디바이스에 저장이 필요하지 않은 알림을 전송하면") {
+            val deviceTokens = listOf(
+                DeviceToken(
+                    id = UUID.randomUUID(),
+                    userId = UUID.randomUUID(),
+                    schoolId = UUID.randomUUID(),
+                    token = "token1"
+                ),
+                DeviceToken(
+                    id = UUID.randomUUID(),
+                    userId = UUID.randomUUID(),
+                    schoolId = UUID.randomUUID(),
+                    token = "token2"
+                )
+            )
+            val notification = Notification(
+                schoolId = UUID.randomUUID(),
+                topic = Topic.DAYBREAK_STUDY_APPLICATION,
+                linkIdentifier = null,
+                title = "title",
+                content = "content",
+                threadId = "thread-id",
+                isSaveRequired = false
+            )
+
+            every { notificationPort.sendMessages(any(), any()) } just runs
+
+            it("알림함에 저장하지 않고 여러 알림을 전송한다") {
+                clearMocks(notificationPort, notificationOfUserPort, answers = false)
+
+                shouldNotThrowAny {
+                    service.sendMessages(deviceTokens, notification)
+                }
+
+                verify(exactly = 1) { notificationPort.sendMessages(any(), any()) }
+                verify(exactly = 0) { notificationOfUserPort.saveNotificationsOfUser(any()) }
             }
         }
 


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 기존에 새벽자습 신청이 최종 승인 또는 거절이 나올 때 fcm을 발송하면서 알림을 저장했지만 클라이언트와 디자인이 되어있지 않아 저장을 삭제함

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1060 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 상태 변경 알림 전송 시 불필요한 알림 저장이 발생하지 않도록 개선했습니다.
  * 여러 디바이스로 전송되는 알림이 저장 없이 정상적으로 일괄 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->