### PR TITLE
merge: (#1064) 1차 승인으로 상태 변이 시 FCM 알림 발송

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
@@ -95,11 +95,12 @@ data class DaybreakStudyApplication(
         if (newStatus != Status.SECOND_APPROVED && newStatus != Status.REJECTED) throw InvalidRoleException
     }
 
-    // REJECTED와 SECOND_APPROVED만 알림을 발송함
+    // REJECTED, FIRST_APPROVED, SECOND_APPROVED만 알림을 발송함
     fun getTitle(): String =
         when (status) {
             Status.REJECTED -> "새벽 자습 신청이 거절되었습니다"
-            Status.SECOND_APPROVED -> "새벽 자습 신청이 승인되었습니다"
+            Status.FIRST_APPROVED -> "새벽 자습 신청이 1차 승인되었습니다."
+            Status.SECOND_APPROVED -> "새벽 자습 신청이 최종 승인되었습니다."
             else -> ""
         }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -37,7 +37,7 @@ class CommandDaybreakServiceImpl(
         val studentIds = applications.map { it.studentId }
         val userIds = queryStudentPort.queryAllStudentsByIdsIn(studentIds).mapNotNull { it.userId }
 
-        if (firstApplication.status == Status.SECOND_APPROVED || firstApplication.status == Status.REJECTED) {
+        if (isDaybreakStudyFcmSendable(firstApplication)) {
 
             val notificationInfo = NotificationInfo(
                 schoolId = firstApplication.schoolId,
@@ -55,4 +55,11 @@ class CommandDaybreakServiceImpl(
     override fun deleteOutdatedDaybreakStudyApplications() {
         commandDaybreakStudyApplicationPort.deleteOutdatedDaybreakStudyApplications()
     }
+
+    private fun isDaybreakStudyFcmSendable(application: DaybreakStudyApplication): Boolean =
+        application.status in setOf(
+            Status.FIRST_APPROVED,
+            Status.SECOND_APPROVED,
+            Status.REJECTED,
+        )
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 기존에 새벽자습 신청이 최종 승인 그리고 거절됨 일 때만 보내던 FCM 발송을 1차 승인도 보내도록 수정

## 주요 변경 사항
- 1차 승인일 때 알림 메시지 작성

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1064 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 데이브레이크 학습 신청이 1차 승인된 경우에도 알림을 받을 수 있습니다.
  * 거절, 1차 승인, 최종 승인 상태별로 알림 제목이 구분되어 더 명확해졌습니다.
  * 최종 승인 알림 문구가 변경되어 승인 결과를 더욱 정확하게 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->