### PR TITLE
merge: (#1058) 학생 새벽자습 신청 이력 조회 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ CLAUDE.md
 tmpclaude-*
 .opencode/
 AGENTS.md
+.omc
 
 ### AI/Agent Files ###
 AGENTS.md

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/DaybreakException.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/DaybreakException.kt
@@ -30,3 +30,7 @@ object DaybreakPastDateException : DmsException(
 object DaybreakInvalidDateRangeException : DmsException(
     DaybreakErrorCode.DAYBREAK_INVALID_DATE_RANGE
 )
+
+object DaybreakStudentSchoolMismatchException : DmsException(
+    DaybreakErrorCode.DAYBREAK_STUDENT_SCHOOL_MISMATCH
+)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
@@ -17,7 +17,9 @@ enum class DaybreakErrorCode(
 
     DAYBREAK_START_DATE_AFTER_END_DATE(ErrorStatus.BAD_REQUEST, "Start Date Cannot Be After End Date", 1),
     DAYBREAK_PAST_DATE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Cannot Be In The Past", 2),
-    DAYBREAK_INVALID_DATE_RANGE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Must Be Within Monday To Thursday", 3);
+    DAYBREAK_INVALID_DATE_RANGE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Must Be Within Monday To Thursday", 3),
+
+    DAYBREAK_STUDENT_SCHOOL_MISMATCH(ErrorStatus.FORBIDDEN, "Student Does Not Belong To Current School", 1);
 
     override fun status(): Int = status
     override fun message(): String = message

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakService.kt
@@ -43,4 +43,7 @@ interface GetDaybreakService {
     fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID): DaybreakStudyApplicationStatusVO
 
     fun findExpiredDaybreakStudyApplications(): List<DaybreakStudyApplication>
+
+    // 학생의 새벽자습 신청 이력(상태가 SECONDE_APPROVED + EXPIRED)을 조회하는 메서드
+    fun getStudentDaybreakStudyApplicationHistoryByStudentId(studentId: UUID): List<DaybreakStudyApplicationVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
@@ -82,8 +82,20 @@ class GetDaybreakServiceImpl(
     }
 
     override fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID) =
-        queryDaybreakStudyApplicationPort.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) ?: throw DaybreakStudyApplicationNotFoundException
+        queryDaybreakStudyApplicationPort.getRecentDaybreakStudyApplicationStatusByStudentId(studentId)
+            ?: throw DaybreakStudyApplicationNotFoundException
 
     override fun findExpiredDaybreakStudyApplications() =
         queryDaybreakStudyApplicationPort.findExpiredDaybreakStudyApplications()
+
+    override fun getStudentDaybreakStudyApplicationHistoryByStudentId(studentId: UUID): List<DaybreakStudyApplicationVO> {
+        val applications =
+            queryDaybreakStudyApplicationPort.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+
+        if (applications.isEmpty()) {
+            throw DaybreakStudyApplicationNotFoundException
+        }
+
+        return applications
+    }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/QueryDaybreakStudyApplicationPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/QueryDaybreakStudyApplicationPort.kt
@@ -42,4 +42,6 @@ interface QueryDaybreakStudyApplicationPort {
     fun getRecentDaybreakStudyApplicationStatusByStudentId(studentId: UUID): DaybreakStudyApplicationStatusVO?
 
     fun findExpiredDaybreakStudyApplications(): List<DaybreakStudyApplication>
+
+    fun getStudentDaybreakStudyApplicationHistoryByStudentId(studentId: UUID): List<DaybreakStudyApplicationVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCase.kt
@@ -1,0 +1,19 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import java.util.UUID
+
+@ReadOnlyUseCase
+class QueryStudentDaybreakStudyApplicationHistoryUseCase(
+    private val daybreakService: DaybreakService
+) {
+
+    fun execute(studentId: UUID): DaybreakStudyApplicationResponse {
+
+        return DaybreakStudyApplicationResponse(
+            daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+        )
+    }
+}

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCase.kt
@@ -1,16 +1,27 @@
 package team.aliens.dms.domain.daybreak.usecase
 
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
 import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.student.service.StudentService
 import java.util.UUID
 
 @ReadOnlyUseCase
 class QueryStudentDaybreakStudyApplicationHistoryUseCase(
-    private val daybreakService: DaybreakService
+    private val daybreakService: DaybreakService,
+    private val studentService: StudentService,
+    private val securityService: SecurityService
 ) {
 
     fun execute(studentId: UUID): DaybreakStudyApplicationResponse {
+
+        val student = studentService.getStudentById(studentId)
+
+        if (student.schoolId != securityService.getCurrentSchoolId()) {
+            throw DaybreakStudentSchoolMismatchException
+        }
 
         return DaybreakStudyApplicationResponse(
             daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCaseTest.kt
@@ -1,0 +1,82 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import team.aliens.dms.common.service.security.SecurityService
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationVO
+import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.service.StudentService
+import java.util.UUID
+
+class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
+
+    val daybreakService = mockk<DaybreakService>()
+    val studentService = mockk<StudentService>()
+    val securityService = mockk<SecurityService>()
+
+    val useCase = QueryStudentDaybreakStudyApplicationHistoryUseCase(
+        daybreakService,
+        studentService,
+        securityService
+    )
+
+    describe("execute") {
+        context("같은 학교 소속 학생의 이력을 조회하면") {
+
+            val studentId = UUID.randomUUID()
+            val schoolId = UUID.randomUUID()
+
+            val mockStudent = mockk<Student> {
+                every { this@mockk.schoolId } returns schoolId
+            }
+            val mockApplications = listOf(mockk<DaybreakStudyApplicationVO>())
+
+            every { studentService.getStudentById(studentId) } returns mockStudent
+            every { securityService.getCurrentSchoolId() } returns schoolId
+            every {
+                daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+            } returns mockApplications
+
+            it("이력 목록을 반환한다") {
+                shouldNotThrowAny {
+                    val response = useCase.execute(studentId)
+
+                    response.applications shouldBe mockApplications
+                }
+
+                verify(exactly = 1) {
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+                }
+            }
+        }
+
+        context("다른 학교 소속 학생의 이력을 조회하면") {
+
+            val studentId = UUID.randomUUID()
+
+            val mockStudent = mockk<Student> {
+                every { this@mockk.schoolId } returns UUID.randomUUID()
+            }
+
+            every { studentService.getStudentById(studentId) } returns mockStudent
+            every { securityService.getCurrentSchoolId() } returns UUID.randomUUID()
+
+            it("DaybreakStudentSchoolMismatchException이 발생한다") {
+                shouldThrow<DaybreakStudentSchoolMismatchException> {
+                    useCase.execute(studentId)
+                }
+
+                verify(exactly = 0) {
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+                }
+            }
+        }
+    }
+})

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCaseTest.kt
@@ -17,34 +17,35 @@ import java.util.UUID
 
 class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
 
-    val daybreakService = mockk<DaybreakService>()
-    val studentService = mockk<StudentService>()
-    val securityService = mockk<SecurityService>()
-
-    val useCase = QueryStudentDaybreakStudyApplicationHistoryUseCase(
-        daybreakService,
-        studentService,
-        securityService
-    )
-
     describe("execute") {
         context("같은 학교 소속 학생의 이력을 조회하면") {
-
-            val studentId = UUID.randomUUID()
-            val schoolId = UUID.randomUUID()
-
-            val mockStudent = mockk<Student> {
-                every { this@mockk.schoolId } returns schoolId
-            }
-            val mockApplications = listOf(mockk<DaybreakStudyApplicationVO>())
-
-            every { studentService.getStudentById(studentId) } returns mockStudent
-            every { securityService.getCurrentSchoolId() } returns schoolId
-            every {
-                daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
-            } returns mockApplications
-
             it("이력 목록을 반환한다") {
+
+                // given
+                val daybreakService = mockk<DaybreakService>()
+                val studentService = mockk<StudentService>()
+                val securityService = mockk<SecurityService>()
+                val useCase = QueryStudentDaybreakStudyApplicationHistoryUseCase(
+                    daybreakService,
+                    studentService,
+                    securityService
+                )
+
+                val studentId = UUID.randomUUID()
+                val schoolId = UUID.randomUUID()
+
+                val mockStudent = mockk<Student> {
+                    every { this@mockk.schoolId } returns schoolId
+                }
+                val mockApplications = listOf(mockk<DaybreakStudyApplicationVO>())
+
+                every { studentService.getStudentById(studentId) } returns mockStudent
+                every { securityService.getCurrentSchoolId() } returns schoolId
+                every {
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+                } returns mockApplications
+
+                // when & then
                 shouldNotThrowAny {
                     val response = useCase.execute(studentId)
 
@@ -58,23 +59,34 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
         }
 
         context("다른 학교 소속 학생의 이력을 조회하면") {
-
-            val studentId = UUID.randomUUID()
-
-            val mockStudent = mockk<Student> {
-                every { this@mockk.schoolId } returns UUID.randomUUID()
-            }
-
-            every { studentService.getStudentById(studentId) } returns mockStudent
-            every { securityService.getCurrentSchoolId() } returns UUID.randomUUID()
-
             it("DaybreakStudentSchoolMismatchException이 발생한다") {
+
+                // given
+                val daybreakService = mockk<DaybreakService>()
+                val studentService = mockk<StudentService>()
+                val securityService = mockk<SecurityService>()
+                val useCase = QueryStudentDaybreakStudyApplicationHistoryUseCase(
+                    daybreakService,
+                    studentService,
+                    securityService
+                )
+
+                val studentId = UUID.randomUUID()
+
+                val mockStudent = mockk<Student> {
+                    every { this@mockk.schoolId } returns UUID.randomUUID()
+                }
+
+                every { studentService.getStudentById(studentId) } returns mockStudent
+                every { securityService.getCurrentSchoolId() } returns UUID.randomUUID()
+
+                // when & then
                 shouldThrow<DaybreakStudentSchoolMismatchException> {
                     useCase.execute(studentId)
                 }
 
                 verify(exactly = 0) {
-                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(any())
                 }
             }
         }

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -242,6 +242,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.POST, "/daybreaks/study-type").hasAuthority(HEAD_TEACHER.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/manager/study-application/export").hasAuthority(MANAGER.name)
+                    .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/history/{student-id}").hasAnyAuthority(HEAD_TEACHER.name, GENERAL_TEACHER.name)
 
                 authorize
                     // /teachers

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -214,6 +214,37 @@ class DaybreakStudyApplicationPersistenceAdapter(
             .mapNotNull { daybreakStudyApplicationMapper.toDomain(it) }
     }
 
+    // status가 EXPIRED, SECOND_APPROVED인 것만 조회
+    override fun getStudentDaybreakStudyApplicationHistoryByStudentId(
+        studentId: UUID
+    ): List<DaybreakStudyApplicationVO> {
+        return queryFactory
+            .select(
+                QQueryDaybreakStudyApplicationVO(
+                    daybreakStudyApplicationJpaEntity.id,
+                    daybreakStudyApplicationJpaEntity.daybreakStudyTypeJpaEntity.name,
+                    daybreakStudyApplicationJpaEntity.createdAt,
+                    daybreakStudyApplicationJpaEntity.startDate,
+                    daybreakStudyApplicationJpaEntity.endDate,
+                    daybreakStudyApplicationJpaEntity.reason,
+                    studentJpaEntity.name,
+                    studentJpaEntity.grade,
+                    studentJpaEntity.classRoom,
+                    studentJpaEntity.number,
+                    daybreakStudyApplicationJpaEntity.teacherJpaEntity.name,
+                    Expressions.nullExpression()
+                )
+            )
+            .from(daybreakStudyApplicationJpaEntity)
+            .join(studentJpaEntity).on(daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentJpaEntity.id))
+            .where(
+                daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId),
+                daybreakStudyApplicationJpaEntity.status.`in`(Status.EXPIRED, Status.SECOND_APPROVED)
+            )
+            .orderBy(daybreakStudyApplicationJpaEntity.createdAt.desc())
+            .fetch()
+    }
+
     override fun deleteOutdatedDaybreakStudyApplications() {
         queryFactory
             .delete(daybreakStudyApplicationJpaEntity)

--- a/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
+++ b/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -34,6 +35,7 @@ import team.aliens.dms.domain.daybreak.usecase.QueryDaybreakStudyTypesUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryGeneralTeacherDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryHeadTeacherDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryManagerDaybreakStudyApplicationUseCase
+import team.aliens.dms.domain.daybreak.usecase.QueryStudentDaybreakStudyApplicationHistoryUseCase
 import java.util.UUID
 
 @Validated
@@ -48,7 +50,8 @@ class DaybreakWebAdapter(
     private val queryDaybreakStudyTypesUseCase: QueryDaybreakStudyTypesUseCase,
     private val changeStatusDaybreakStudyApplicationUseCase: ChangeStatusDaybreakStudyApplicationUseCase,
     private val createDaybreakStudyTypeUseCase: CreateDaybreakStudyTypeUseCase,
-    private val queryDaybreakStudyApplicationStatusUseCase: QueryDaybreakStudyApplicationStatusUseCase
+    private val queryDaybreakStudyApplicationStatusUseCase: QueryDaybreakStudyApplicationStatusUseCase,
+    private val queryStudentDaybreakStudyApplicationHistoryUseCase: QueryStudentDaybreakStudyApplicationHistoryUseCase
 ) {
 
     @ResponseStatus(code = HttpStatus.CREATED)
@@ -137,5 +140,13 @@ class DaybreakWebAdapter(
     @GetMapping("/study-application/my")
     fun getRecentDaybreakStudyApplicationStatus(): DaybreakStudyApplicationStatusResponse {
         return queryDaybreakStudyApplicationStatusUseCase.execute()
+    }
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @GetMapping("/study-application/history/{student-id}")
+    fun getStudentDaybreakStudyApplicationHistory(
+        @PathVariable("student-id") studentId: UUID
+    ): DaybreakStudyApplicationResponse {
+        return queryStudentDaybreakStudyApplicationHistoryUseCase.execute(studentId)
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ]  새벽자습 신청 이력 조회 기능 개발
- [ ] 새벽자습 신청 상태가 `SECOND APPROVED`, `EXPIRED` 인 것만 조회

## 주요 변경 사항
- .gitignore에 `.omc` 추가
- `QueryStudentDaybreakStudyApplicationHistoryUseCase` 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1058 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 학생별 새벽자습 신청 이력을 조회할 수 있습니다.
  - 승인 완료 및 만료된 신청 내역을 최신순으로 확인할 수 있습니다.
  - 교사는 전용 조회 기능을 통해 해당 이력을 확인할 수 있습니다.

- **버그 수정**
  - 이력이 없을 때 적절한 오류가 반환됩니다.
  - 다른 학교 학생의 이력 조회가 제한됩니다.

- **기타**
  - 개발 도구가 생성하는 `.omc` 항목이 버전 관리에서 제외됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->