### PR TITLE
merge: (#1068) 새벽자습 신청 이력 조회 페이지네이션 기능 추가

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakService.kt
@@ -45,5 +45,8 @@ interface GetDaybreakService {
     fun findExpiredDaybreakStudyApplications(): List<DaybreakStudyApplication>
 
     // 학생의 새벽자습 신청 이력(상태가 SECONDE_APPROVED + EXPIRED)을 조회하는 메서드
-    fun getStudentDaybreakStudyApplicationHistoryByStudentId(studentId: UUID): List<DaybreakStudyApplicationVO>
+    fun getStudentDaybreakStudyApplicationHistoryByStudentId(
+        studentId: UUID,
+        pageData: PageData = PageData.DEFAULT
+    ): List<DaybreakStudyApplicationVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
@@ -88,9 +88,12 @@ class GetDaybreakServiceImpl(
     override fun findExpiredDaybreakStudyApplications() =
         queryDaybreakStudyApplicationPort.findExpiredDaybreakStudyApplications()
 
-    override fun getStudentDaybreakStudyApplicationHistoryByStudentId(studentId: UUID): List<DaybreakStudyApplicationVO> {
+    override fun getStudentDaybreakStudyApplicationHistoryByStudentId(
+        studentId: UUID,
+        pageData: PageData
+    ): List<DaybreakStudyApplicationVO> {
         val applications =
-            queryDaybreakStudyApplicationPort.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+            queryDaybreakStudyApplicationPort.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId, pageData)
 
         if (applications.isEmpty()) {
             throw DaybreakStudyApplicationNotFoundException

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/GetDaybreakServiceImpl.kt
@@ -91,14 +91,6 @@ class GetDaybreakServiceImpl(
     override fun getStudentDaybreakStudyApplicationHistoryByStudentId(
         studentId: UUID,
         pageData: PageData
-    ): List<DaybreakStudyApplicationVO> {
-        val applications =
-            queryDaybreakStudyApplicationPort.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId, pageData)
-
-        if (applications.isEmpty()) {
-            throw DaybreakStudyApplicationNotFoundException
-        }
-
-        return applications
-    }
+    ): List<DaybreakStudyApplicationVO> =
+        queryDaybreakStudyApplicationPort.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId, pageData)
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/QueryDaybreakStudyApplicationPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/QueryDaybreakStudyApplicationPort.kt
@@ -43,5 +43,8 @@ interface QueryDaybreakStudyApplicationPort {
 
     fun findExpiredDaybreakStudyApplications(): List<DaybreakStudyApplication>
 
-    fun getStudentDaybreakStudyApplicationHistoryByStudentId(studentId: UUID): List<DaybreakStudyApplicationVO>
+    fun getStudentDaybreakStudyApplicationHistoryByStudentId(
+        studentId: UUID,
+        pageData: PageData = PageData.DEFAULT
+    ): List<DaybreakStudyApplicationVO>
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCase.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.daybreak.usecase
 
 import team.aliens.dms.common.annotation.ReadOnlyUseCase
+import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
 import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
@@ -15,7 +16,7 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCase(
     private val securityService: SecurityService
 ) {
 
-    fun execute(studentId: UUID): DaybreakStudyApplicationResponse {
+    fun execute(studentId: UUID, pageData: PageData): DaybreakStudyApplicationResponse {
 
         val student = studentService.getStudentById(studentId)
 
@@ -24,7 +25,7 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCase(
         }
 
         return DaybreakStudyApplicationResponse(
-            daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+            daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId, pageData)
         )
     }
 }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/QueryStudentDaybreakStudyApplicationHistoryUseCaseTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import team.aliens.dms.common.dto.PageData
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
 import team.aliens.dms.domain.daybreak.service.DaybreakService
@@ -33,6 +34,7 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
 
                 val studentId = UUID.randomUUID()
                 val schoolId = UUID.randomUUID()
+                val pageData = PageData(page = 0, size = 10)
 
                 val mockStudent = mockk<Student> {
                     every { this@mockk.schoolId } returns schoolId
@@ -42,18 +44,18 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
                 every { studentService.getStudentById(studentId) } returns mockStudent
                 every { securityService.getCurrentSchoolId() } returns schoolId
                 every {
-                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId, pageData)
                 } returns mockApplications
 
                 // when & then
                 shouldNotThrowAny {
-                    val response = useCase.execute(studentId)
+                    val response = useCase.execute(studentId, pageData)
 
                     response.applications shouldBe mockApplications
                 }
 
                 verify(exactly = 1) {
-                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId)
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(studentId, pageData)
                 }
             }
         }
@@ -72,6 +74,7 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
                 )
 
                 val studentId = UUID.randomUUID()
+                val pageData = PageData(page = 0, size = 10)
 
                 val mockStudent = mockk<Student> {
                     every { this@mockk.schoolId } returns UUID.randomUUID()
@@ -82,11 +85,11 @@ class QueryStudentDaybreakStudyApplicationHistoryUseCaseTest : DescribeSpec({
 
                 // when & then
                 shouldThrow<DaybreakStudentSchoolMismatchException> {
-                    useCase.execute(studentId)
+                    useCase.execute(studentId, pageData)
                 }
 
                 verify(exactly = 0) {
-                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(any())
+                    daybreakService.getStudentDaybreakStudyApplicationHistoryByStudentId(any(), any())
                 }
             }
         }

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -216,7 +216,8 @@ class DaybreakStudyApplicationPersistenceAdapter(
 
     // status가 EXPIRED, SECOND_APPROVED인 것만 조회
     override fun getStudentDaybreakStudyApplicationHistoryByStudentId(
-        studentId: UUID
+        studentId: UUID,
+        pageData: PageData
     ): List<DaybreakStudyApplicationVO> {
         return queryFactory
             .select(
@@ -241,6 +242,8 @@ class DaybreakStudyApplicationPersistenceAdapter(
                 daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId),
                 daybreakStudyApplicationJpaEntity.status.`in`(Status.EXPIRED, Status.SECOND_APPROVED)
             )
+            .offset(pageData.offset)
+            .limit(pageData.size)
             .orderBy(daybreakStudyApplicationJpaEntity.createdAt.desc())
             .fetch()
     }

--- a/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
+++ b/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
@@ -145,8 +145,9 @@ class DaybreakWebAdapter(
     @ResponseStatus(code = HttpStatus.OK)
     @GetMapping("/study-application/history/{student-id}")
     fun getStudentDaybreakStudyApplicationHistory(
-        @PathVariable("student-id") studentId: UUID
+        @PathVariable("student-id") studentId: UUID,
+        @ModelAttribute pageData: PageData
     ): DaybreakStudyApplicationResponse {
-        return queryStudentDaybreakStudyApplicationHistoryUseCase.execute(studentId)
+        return queryStudentDaybreakStudyApplicationHistoryUseCase.execute(studentId, pageData)
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 새벽자습 신청 이력 조회 시 페이지네이션 기능 추가


## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1068


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 학생의 새벽자습 신청 이력 조회에 페이지네이션을 지원합니다.
  * 페이지 번호와 조회 개수를 지정해 원하는 범위의 이력을 확인할 수 있습니다.
  * 별도 페이지 정보가 없으면 기본 페이지 설정이 적용됩니다.
  * 조회 결과가 없을 때 빈 목록으로 정상 반환됩니다.

* **테스트**
  * 페이지네이션 정보가 이력 조회 과정에 올바르게 전달되는지 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->