### PR TITLE
merge: (#1066) 새벽자습 신청 취소 기능 추가

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/DaybreakException.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/DaybreakException.kt
@@ -34,3 +34,7 @@ object DaybreakInvalidDateRangeException : DmsException(
 object DaybreakStudentSchoolMismatchException : DmsException(
     DaybreakErrorCode.DAYBREAK_STUDENT_SCHOOL_MISMATCH
 )
+
+object DaybreakStudyApplicationCanNotCancelException : DmsException(
+    DaybreakErrorCode.DAYBREAK_CAN_NOT_CANCEL_STUDY_APPLICATION
+)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
@@ -18,6 +18,7 @@ enum class DaybreakErrorCode(
     DAYBREAK_START_DATE_AFTER_END_DATE(ErrorStatus.BAD_REQUEST, "Start Date Cannot Be After End Date", 1),
     DAYBREAK_PAST_DATE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Cannot Be In The Past", 2),
     DAYBREAK_INVALID_DATE_RANGE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Must Be Within Monday To Thursday", 3),
+    DAYBREAK_CAN_NOT_CANCEL_STUDY_APPLICATION(ErrorStatus.BAD_REQUEST, "Daybreak Study Application Can Not Cancel", 4),
 
     DAYBREAK_STUDENT_SCHOOL_MISMATCH(ErrorStatus.FORBIDDEN, "Student Does Not Belong To Current School", 1);
 

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakService.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.domain.daybreak.service
 
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyType
+import java.util.UUID
 
 interface CommandDaybreakService {
 
@@ -12,4 +13,7 @@ interface CommandDaybreakService {
     fun saveAllDaybreakStudyApplications(applications: List<DaybreakStudyApplication>)
 
     fun deleteOutdatedDaybreakStudyApplications()
+
+    // 학생이 자신의 신청을 삭제할 때 사용
+    fun deleteDaybreakStudyApplication(studentId: UUID)
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakService.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakService.kt
@@ -14,6 +14,6 @@ interface CommandDaybreakService {
 
     fun deleteOutdatedDaybreakStudyApplications()
 
-    // 학생이 자신의 신청을 삭제할 때 사용
-    fun deleteDaybreakStudyApplication(studentId: UUID)
+    // 학생이 자신의 신청을 삭제할 때 사용. 삭제 성공 여부를 반환한다
+    fun deleteDaybreakStudyApplication(studentId: UUID): Boolean
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -57,9 +57,8 @@ class CommandDaybreakServiceImpl(
         commandDaybreakStudyApplicationPort.deleteOutdatedDaybreakStudyApplications()
     }
 
-    override fun deleteDaybreakStudyApplication(studentId: UUID) {
+    override fun deleteDaybreakStudyApplication(studentId: UUID) =
         commandDaybreakStudyApplicationPort.deleteDaybreakStudyApplication(studentId)
-    }
 
     private fun isDaybreakStudyFcmSendable(application: DaybreakStudyApplication): Boolean =
         application.status in setOf(

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/service/CommandDaybreakServiceImpl.kt
@@ -10,6 +10,7 @@ import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.spi.CommandDaybreakStudyApplicationPort
 import team.aliens.dms.domain.daybreak.spi.CommandDaybreakStudyTypePort
 import team.aliens.dms.domain.student.spi.QueryStudentPort
+import java.util.UUID
 
 @Service
 class CommandDaybreakServiceImpl(
@@ -54,6 +55,10 @@ class CommandDaybreakServiceImpl(
 
     override fun deleteOutdatedDaybreakStudyApplications() {
         commandDaybreakStudyApplicationPort.deleteOutdatedDaybreakStudyApplications()
+    }
+
+    override fun deleteDaybreakStudyApplication(studentId: UUID) {
+        commandDaybreakStudyApplicationPort.deleteDaybreakStudyApplication(studentId)
     }
 
     private fun isDaybreakStudyFcmSendable(application: DaybreakStudyApplication): Boolean =

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/CommandDaybreakStudyApplicationPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/CommandDaybreakStudyApplicationPort.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms.domain.daybreak.spi
 
 import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
+import java.util.UUID
 
 interface CommandDaybreakStudyApplicationPort {
 
@@ -9,4 +10,6 @@ interface CommandDaybreakStudyApplicationPort {
     fun saveAllDaybreakStudyApplications(applications: List<DaybreakStudyApplication>)
 
     fun deleteOutdatedDaybreakStudyApplications()
+
+    fun deleteDaybreakStudyApplication(studentId: UUID)
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/CommandDaybreakStudyApplicationPort.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/spi/CommandDaybreakStudyApplicationPort.kt
@@ -11,5 +11,6 @@ interface CommandDaybreakStudyApplicationPort {
 
     fun deleteOutdatedDaybreakStudyApplications()
 
-    fun deleteDaybreakStudyApplication(studentId: UUID)
+    // 삭제 성공 여부를 반환한다
+    fun deleteDaybreakStudyApplication(studentId: UUID): Boolean
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCase.kt
@@ -16,10 +16,13 @@ class CancelDaybreakStudyApplicationUseCase(
         val studentId = studentService.getCurrentStudent().id
         val recentApplication = daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId)
 
-        if(recentApplication.status != Status.PENDING) {
+        if (recentApplication.status != Status.PENDING) {
             throw DaybreakStudyApplicationCanNotCancelException
         }
 
-        daybreakService.deleteDaybreakStudyApplication(studentId)
+        // 위 상태 확인과 삭제 사이에 선생님이 상태를 바꾸면 삭제 조건에 걸리지 않아 아무것도 지워지지 않는다
+        if (!daybreakService.deleteDaybreakStudyApplication(studentId)) {
+            throw DaybreakStudyApplicationCanNotCancelException
+        }
     }
 }

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCase.kt
@@ -1,0 +1,25 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotCancelException
+import team.aliens.dms.domain.daybreak.model.Status
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.student.service.StudentService
+
+@UseCase
+class CancelDaybreakStudyApplicationUseCase(
+    private val daybreakService: DaybreakService,
+    private val studentService: StudentService
+) {
+
+    fun execute() {
+        val studentId = studentService.getCurrentStudent().id
+        val recentApplication = daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId)
+
+        if(recentApplication.status != Status.PENDING) {
+            throw DaybreakStudyApplicationCanNotCancelException
+        }
+
+        daybreakService.deleteDaybreakStudyApplication(studentId)
+    }
+}

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/stub/DaybreakStudyApplicationStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/stub/DaybreakStudyApplicationStub.kt
@@ -10,7 +10,7 @@ internal fun createDaybreakStudyApplicationStub(
     studyTypeId: UUID = UUID.randomUUID(),
     startDate: LocalDate = LocalDate.now(),
     endDate: LocalDate = LocalDate.now().plusDays(3),
-    reason: String = "아침 자습 신청합니다.",
+    reason: String = "새벽 자습 신청합니다.",
     status: Status = Status.PENDING,
     teacherId: UUID = UUID.randomUUID(),
     studentId: UUID = UUID.randomUUID(),

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCaseTest.kt
@@ -4,12 +4,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.clearMocks
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
-import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationNotFoundException
 import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotCancelException
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationNotFoundException
 import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.service.DaybreakService
 import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationStatusVO
@@ -48,10 +46,29 @@ class CancelDaybreakStudyApplicationUseCaseTest : DescribeSpec({
             it("신청을 삭제한다") {
                 every { studentService.getCurrentStudent() } returns mockStudent
                 every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } returns applicationStatus
-                every { daybreakService.deleteDaybreakStudyApplication(studentId) } just runs
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } returns true
                 useCase.execute()
 
                 verify(exactly = 1) { daybreakService.deleteDaybreakStudyApplication(studentId) }
+            }
+        }
+
+        context("PENDING 상태를 확인한 뒤 삭제 직전에 상태가 바뀌어 삭제된 신청이 없으면") {
+
+            val applicationStatus = DaybreakStudyApplicationStatusVO(
+                status = Status.PENDING,
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(3)
+            )
+
+            it("예외를 반환한다.") {
+                every { studentService.getCurrentStudent() } returns mockStudent
+                every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } returns applicationStatus
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } returns false
+
+                shouldThrow<DaybreakStudyApplicationCanNotCancelException> {
+                    useCase.execute()
+                }
             }
         }
 
@@ -66,29 +83,29 @@ class CancelDaybreakStudyApplicationUseCaseTest : DescribeSpec({
             it("예외를 반환한다.") {
                 every { studentService.getCurrentStudent() } returns mockStudent
                 every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } returns applicationStatus
-                every { daybreakService.deleteDaybreakStudyApplication(studentId) } just runs
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } returns true
 
                 shouldThrow<DaybreakStudyApplicationCanNotCancelException> {
                     useCase.execute()
                 }
 
                 verify(exactly = 0) { daybreakService.deleteDaybreakStudyApplication(studentId) }
-
             }
         }
 
         context("신청이 없을 때 요청이 들어오면") {
             it("예외를 반환한다.") {
                 every { studentService.getCurrentStudent() } returns mockStudent
-                every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } throws DaybreakStudyApplicationNotFoundException
-                every { daybreakService.deleteDaybreakStudyApplication(studentId) } just runs
+                every {
+                    daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId)
+                } throws DaybreakStudyApplicationNotFoundException
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } returns true
 
                 shouldThrow<DaybreakStudyApplicationNotFoundException> {
                     useCase.execute()
                 }
 
                 verify(exactly = 0) { daybreakService.deleteDaybreakStudyApplication(studentId) }
-
             }
         }
     }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/CancelDaybreakStudyApplicationUseCaseTest.kt
@@ -1,0 +1,95 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationNotFoundException
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotCancelException
+import team.aliens.dms.domain.daybreak.model.Status
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.daybreak.spi.vo.DaybreakStudyApplicationStatusVO
+import team.aliens.dms.domain.student.model.Student
+import team.aliens.dms.domain.student.service.StudentService
+import java.time.LocalDate
+import java.util.UUID
+
+class CancelDaybreakStudyApplicationUseCaseTest : DescribeSpec({
+
+    val daybreakService = mockk<DaybreakService>()
+    val studentService = mockk<StudentService>()
+
+    val useCase = CancelDaybreakStudyApplicationUseCase(daybreakService, studentService)
+
+    beforeTest {
+        clearMocks(daybreakService, studentService)
+    }
+
+    describe("execute") {
+
+        val studentId = UUID.randomUUID()
+
+        val mockStudent = mockk<Student> {
+            every { id } returns studentId
+        }
+
+        context("기존 PENDING 상태인 신청이 있을 때 취소 요청이 들어오면") {
+
+            val applicationStatus = DaybreakStudyApplicationStatusVO(
+                status = Status.PENDING,
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(3),
+            )
+
+            it("신청을 삭제한다") {
+                every { studentService.getCurrentStudent() } returns mockStudent
+                every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } returns applicationStatus
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } just runs
+                useCase.execute()
+
+                verify(exactly = 1) { daybreakService.deleteDaybreakStudyApplication(studentId) }
+            }
+        }
+
+        context("PENDING 상태가 아닌 신청일 때 요청이 들어오면") {
+
+            val applicationStatus = DaybreakStudyApplicationStatusVO(
+                Status.FIRST_APPROVED,
+                startDate = LocalDate.now(),
+                endDate = LocalDate.now().plusDays(3)
+            )
+
+            it("예외를 반환한다.") {
+                every { studentService.getCurrentStudent() } returns mockStudent
+                every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } returns applicationStatus
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } just runs
+
+                shouldThrow<DaybreakStudyApplicationCanNotCancelException> {
+                    useCase.execute()
+                }
+
+                verify(exactly = 0) { daybreakService.deleteDaybreakStudyApplication(studentId) }
+
+            }
+        }
+
+        context("신청이 없을 때 요청이 들어오면") {
+            it("예외를 반환한다.") {
+                every { studentService.getCurrentStudent() } returns mockStudent
+                every { daybreakService.getRecentDaybreakStudyApplicationStatusByStudentId(studentId) } throws DaybreakStudyApplicationNotFoundException
+                every { daybreakService.deleteDaybreakStudyApplication(studentId) } just runs
+
+                shouldThrow<DaybreakStudyApplicationNotFoundException> {
+                    useCase.execute()
+                }
+
+                verify(exactly = 0) { daybreakService.deleteDaybreakStudyApplication(studentId) }
+
+            }
+        }
+    }
+})

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -243,6 +243,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/manager/study-application/export").hasAuthority(MANAGER.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/history/{student-id}").hasAnyAuthority(HEAD_TEACHER.name, GENERAL_TEACHER.name)
+                    .requestMatchers(HttpMethod.DELETE, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)
 
                 authorize
                     // /teachers

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -262,13 +262,15 @@ class DaybreakStudyApplicationPersistenceAdapter(
             .execute()
     }
 
-    override fun deleteDaybreakStudyApplication(studentId: UUID) {
-        queryFactory
+    override fun deleteDaybreakStudyApplication(studentId: UUID): Boolean {
+        val deletedCount = queryFactory
             .delete(daybreakStudyApplicationJpaEntity)
             .where(daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId),
                 daybreakStudyApplicationJpaEntity.status.eq(Status.PENDING)
             )
             .execute()
+
+        return deletedCount > 0
     }
 
     override fun saveDaybreakStudyApplication(application: DaybreakStudyApplication) {

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -259,6 +259,15 @@ class DaybreakStudyApplicationPersistenceAdapter(
             .execute()
     }
 
+    override fun deleteDaybreakStudyApplication(studentId: UUID) {
+        queryFactory
+            .delete(daybreakStudyApplicationJpaEntity)
+            .where(daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId),
+                daybreakStudyApplicationJpaEntity.status.eq(Status.PENDING)
+            )
+            .execute()
+    }
+
     override fun saveDaybreakStudyApplication(application: DaybreakStudyApplication) {
         daybreakStudyApplicationRepository.save(daybreakStudyApplicationMapper.toEntity(application))
     }

--- a/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
+++ b/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
@@ -27,6 +28,7 @@ import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationStat
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyTypesResponse
 import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.usecase.ApplyDaybreakStudyApplicationUseCase
+import team.aliens.dms.domain.daybreak.usecase.CancelDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.ChangeStatusDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.CreateDaybreakStudyTypeUseCase
 import team.aliens.dms.domain.daybreak.usecase.ExportManagerDaybreakStudyApplicationUseCase
@@ -51,7 +53,8 @@ class DaybreakWebAdapter(
     private val changeStatusDaybreakStudyApplicationUseCase: ChangeStatusDaybreakStudyApplicationUseCase,
     private val createDaybreakStudyTypeUseCase: CreateDaybreakStudyTypeUseCase,
     private val queryDaybreakStudyApplicationStatusUseCase: QueryDaybreakStudyApplicationStatusUseCase,
-    private val queryStudentDaybreakStudyApplicationHistoryUseCase: QueryStudentDaybreakStudyApplicationHistoryUseCase
+    private val queryStudentDaybreakStudyApplicationHistoryUseCase: QueryStudentDaybreakStudyApplicationHistoryUseCase,
+    private val cancelDaybreakStudyApplicationUseCase: CancelDaybreakStudyApplicationUseCase
 ) {
 
     @ResponseStatus(code = HttpStatus.CREATED)
@@ -148,5 +151,11 @@ class DaybreakWebAdapter(
         @PathVariable("student-id") studentId: UUID
     ): DaybreakStudyApplicationResponse {
         return queryStudentDaybreakStudyApplicationHistoryUseCase.execute(studentId)
+    }
+
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
+    @DeleteMapping("/study-application/my")
+    fun cancelDaybreakStudyApplication() {
+        cancelDaybreakStudyApplicationUseCase.execute()
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ]  학생이 자신이 신청한(PEDNING 상태인) 새벽자습 신청을 취소(DELETE)하는 기능 추가

## 주요 변경 사항
- CancelDaybreakStudyApplicationUseCase 추가

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1066 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 본인의 새벽 자습 신청을 취소할 수 있습니다.
  * 대기 중인 신청만 취소되며, 취소할 수 없는 상태에서는 오류가 안내됩니다.
  * 신청이 없거나 취소에 실패한 경우 적절한 오류가 반환됩니다.

* **권한**
  * 학생 계정만 신청 취소 기능을 이용할 수 있습니다.

* **테스트**
  * 신청 상태별 취소 처리와 예외 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->