### PR TITLE
merge: (#1071) 에러 코드 sequence 오타 수정

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
@@ -13,7 +13,7 @@ enum class DaybreakErrorCode(
     EXIST_DAYBREAK_STUDY_TYPE(ErrorStatus.CONFLICT, "Exist Daybreak Type of Daybreak", 2),
 
     NOT_FOUND_DAYBREAK_STUDY_APPLICATION(ErrorStatus.NOT_FOUND, "Not Found Daybreak Study Application", 1),
-    NOT_FOUND_DAYBREAK_STUDY_TYPE(ErrorStatus.NOT_FOUND, "Not Found Daybreak Study Type ", 1),
+    NOT_FOUND_DAYBREAK_STUDY_TYPE(ErrorStatus.NOT_FOUND, "Not Found Daybreak Study Type ", 2),
 
     DAYBREAK_START_DATE_AFTER_END_DATE(ErrorStatus.BAD_REQUEST, "Start Date Cannot Be After End Date", 1),
     DAYBREAK_PAST_DATE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Cannot Be In The Past", 2),


### PR DESCRIPTION
## 작업 내용 설명
- [ ] `NOT_FOUND_DAYBREAK_STUDY_APPLICATION`과 `NOT_FOUND_DAYBREAK_STUDY_TYPE`의 sequence가 1로 겹쳐서 `NOT_FOUND_DAYBREAK_STUDY_TYPE`의 sequence를 2로 수정

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1071 