### PR TITLE
merge: (#1074) 조회 정렬 조건을 상태로 변경

### DIFF
--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.persistence.daybreak
 
+import com.querydsl.core.types.dsl.CaseBuilder
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
@@ -69,7 +70,7 @@ class DaybreakStudyApplicationPersistenceAdapter(
             )
             .offset(pageData.offset)
             .limit(pageData.size)
-            .orderBy(*gcnOrder())
+            .orderBy(statusOrder(), *gcnOrder())
             .fetch()
     }
 
@@ -282,6 +283,15 @@ class DaybreakStudyApplicationPersistenceAdapter(
 
         daybreakStudyApplicationRepository.saveAll(applicationEntities)
     }
+
+    // PENDING -> REJECTED -> FIRST_APPROVED -> SECOND_APPROVED 순으로 정렬
+    private fun statusOrder() = CaseBuilder()
+        .`when`(daybreakStudyApplicationJpaEntity.status.eq(Status.PENDING)).then(0)
+        .`when`(daybreakStudyApplicationJpaEntity.status.eq(Status.REJECTED)).then(1)
+        .`when`(daybreakStudyApplicationJpaEntity.status.eq(Status.FIRST_APPROVED)).then(2)
+        .`when`(daybreakStudyApplicationJpaEntity.status.eq(Status.SECOND_APPROVED)).then(3)
+        .otherwise(4)
+        .asc()
 
     private fun gcnOrder() = arrayOf(
         studentJpaEntity.grade.asc(),


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 조회 정렬 조건을 Status로 변경
- [ ] Status 정렬 순서는 PENDING, REJECTED, FIRST_APPROVED, SECOND_APPROVED임

## 주요 변경 사항
-`DaybreakStudyApplicationPersistenceAdapter`에 `statusOrder()` 메서드 작성

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1074 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 교사는 조기 귀가 신청 목록을 상태별 우선순위로 확인할 수 있습니다.
  * 신청 목록이 대기 중, 반려, 1차 승인, 2차 승인 순으로 정렬되며, 이후 학년·반·번호 순으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->