### PR TITLE
merge: (#1059) 부장선생님 새벽자습 신청 상태 되돌리기 기능 개발

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/dto/request/RevertDaybreakStudyApplicationRequest.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/dto/request/RevertDaybreakStudyApplicationRequest.kt
@@ -1,0 +1,7 @@
+package team.aliens.dms.domain.daybreak.dto.request
+
+import java.util.UUID
+
+data class RevertDaybreakStudyApplicationRequest(
+    val applicationIdList: List<UUID>
+)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/DaybreakException.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/DaybreakException.kt
@@ -38,3 +38,7 @@ object DaybreakStudentSchoolMismatchException : DmsException(
 object DaybreakStudyApplicationCanNotCancelException : DmsException(
     DaybreakErrorCode.DAYBREAK_CAN_NOT_CANCEL_STUDY_APPLICATION
 )
+
+object DaybreakStudyApplicationCanNotRevertException : DmsException(
+    DaybreakErrorCode.DAYBREAK_CAN_NOT_REVERT_STUDY_APPLICATION
+)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/exception/error/DaybreakErrorCode.kt
@@ -19,6 +19,7 @@ enum class DaybreakErrorCode(
     DAYBREAK_PAST_DATE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Cannot Be In The Past", 2),
     DAYBREAK_INVALID_DATE_RANGE(ErrorStatus.BAD_REQUEST, "Daybreak Application Date Must Be Within Monday To Thursday", 3),
     DAYBREAK_CAN_NOT_CANCEL_STUDY_APPLICATION(ErrorStatus.BAD_REQUEST, "Daybreak Study Application Can Not Cancel", 4),
+    DAYBREAK_CAN_NOT_REVERT_STUDY_APPLICATION(ErrorStatus.BAD_REQUEST, "Daybreak Study Application Can Not Revert", 5),
 
     DAYBREAK_STUDENT_SCHOOL_MISMATCH(ErrorStatus.FORBIDDEN, "Student Does Not Belong To Current School", 1);
 

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
@@ -27,6 +27,9 @@ data class DaybreakStudyApplication(
 
     var status: Status,
 
+    // 되돌리기를 위해 직전 상태를 보관한다. 상태 변경 이력이 없으면 null
+    var previousStatus: Status? = null,
+
     val teacherId: UUID,
 
     val studentId: UUID,
@@ -79,6 +82,7 @@ data class DaybreakStudyApplication(
             else -> throw InvalidRoleException
         }
 
+        this.previousStatus = this.status
         this.status = newStatus
     }
 
@@ -96,12 +100,14 @@ data class DaybreakStudyApplication(
         if (newStatus != Status.SECOND_APPROVED && newStatus != Status.REJECTED) throw InvalidRoleException
     }
 
-    // 부장선생님이 내린 최종 승인(SECOND_APPROVED)/거절(REJECTED)을 1차 승인 상태로 되돌린다
+    // 최종 승인(SECOND_APPROVED)/거절(REJECTED)을 직전 상태로 되돌린다.
     fun revert() {
-        this.status = when (status) {
-            Status.SECOND_APPROVED, Status.REJECTED -> Status.FIRST_APPROVED
-            else -> throw DaybreakStudyApplicationCanNotRevertException
-        }
+        if (!isTerminalStatus()) throw DaybreakStudyApplicationCanNotRevertException
+
+        val previous = previousStatus ?: throw DaybreakStudyApplicationCanNotRevertException
+
+        this.status = previous
+        this.previousStatus = null
     }
 
     // REJECTED, FIRST_APPROVED, SECOND_APPROVED만 알림을 발송함

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
@@ -6,6 +6,7 @@ import team.aliens.dms.domain.auth.model.Authority
 import team.aliens.dms.domain.daybreak.exception.DaybreakInvalidDateRangeException
 import team.aliens.dms.domain.daybreak.exception.DaybreakPastDateException
 import team.aliens.dms.domain.daybreak.exception.DaybreakStartDateAfterEndDateException
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotRevertException
 import team.aliens.dms.domain.user.exception.InvalidRoleException
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -93,6 +94,14 @@ data class DaybreakStudyApplication(
     private fun validateHeadTeacherTransition(newStatus: Status) {
         if (status != Status.FIRST_APPROVED) throw InvalidRoleException
         if (newStatus != Status.SECOND_APPROVED && newStatus != Status.REJECTED) throw InvalidRoleException
+    }
+
+    // 부장선생님이 내린 최종 승인(SECOND_APPROVED)/거절(REJECTED)을 1차 승인 상태로 되돌린다
+    fun revert() {
+        this.status = when (status) {
+            Status.SECOND_APPROVED, Status.REJECTED -> Status.FIRST_APPROVED
+            else -> throw DaybreakStudyApplicationCanNotRevertException
+        }
     }
 
     // REJECTED, FIRST_APPROVED, SECOND_APPROVED만 알림을 발송함

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCase.kt
@@ -20,7 +20,7 @@ class RevertDaybreakStudyApplicationUseCase(
 
         applications.forEach {
             if (it.schoolId != currentSchoolId) throw DaybreakStudentSchoolMismatchException
--            it.revert()
+            it.revert()
         }
 
         daybreakService.saveAllDaybreakStudyApplications(applications)

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCase.kt
@@ -1,0 +1,28 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import team.aliens.dms.common.annotation.UseCase
+import team.aliens.dms.common.service.security.SecurityService
+import team.aliens.dms.domain.daybreak.dto.request.RevertDaybreakStudyApplicationRequest
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+
+@UseCase
+class RevertDaybreakStudyApplicationUseCase(
+    private val daybreakService: DaybreakService,
+    private val securityService: SecurityService
+) {
+
+    fun execute(request: RevertDaybreakStudyApplicationRequest) {
+
+        val currentSchoolId = securityService.getCurrentSchoolId()
+
+        val applications = daybreakService.getAllByIdIn(request.applicationIdList)
+
+        applications.forEach {
+            if (it.schoolId != currentSchoolId) throw DaybreakStudentSchoolMismatchException
+-            it.revert()
+        }
+
+        daybreakService.saveAllDaybreakStudyApplications(applications)
+    }
+}

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplicationTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplicationTest.kt
@@ -188,6 +188,15 @@ class DaybreakStudyApplicationTest : DescribeSpec({
                 }
             }
 
+            it("상태를 변경하면 직전 상태를 기록한다") {
+                val application = createDaybreakStudyApplicationStub(status = Status.PENDING)
+                application.changeStatus(Authority.GENERAL_TEACHER, Status.FIRST_APPROVED)
+                application.previousStatus shouldBe Status.PENDING
+
+                application.changeStatus(Authority.HEAD_TEACHER, Status.SECOND_APPROVED)
+                application.previousStatus shouldBe Status.FIRST_APPROVED
+            }
+
             it("허용되지 않은 권한(예: STUDENT)으로 변경을 시도하면 예외가 발생한다") {
                 val application = createDaybreakStudyApplicationStub(status = Status.PENDING)
                 shouldThrow<InvalidRoleException> {
@@ -199,16 +208,47 @@ class DaybreakStudyApplicationTest : DescribeSpec({
 
     describe("revert") {
 
-        it("SECOND_APPROVED 상태를 FIRST_APPROVED로 되돌린다") {
-            val application = createDaybreakStudyApplicationStub(status = Status.SECOND_APPROVED)
-            application.revert()
-            application.status shouldBe Status.FIRST_APPROVED
+        it("직전 상태로 되돌린다") {
+            forAll(
+                row(Status.SECOND_APPROVED, Status.FIRST_APPROVED),
+                row(Status.REJECTED, Status.FIRST_APPROVED),
+                row(Status.REJECTED, Status.PENDING),
+            ) { status, previousStatus ->
+                val application = createDaybreakStudyApplicationStub(
+                    status = status,
+                    previousStatus = previousStatus
+                )
+
+                application.revert()
+
+                application.status shouldBe previousStatus
+            }
         }
 
-        it("REJECTED 상태를 FIRST_APPROVED로 되돌린다") {
-            val application = createDaybreakStudyApplicationStub(status = Status.REJECTED)
+        it("되돌린 뒤에는 직전 상태가 비어 다시 되돌릴 수 없다") {
+            val application = createDaybreakStudyApplicationStub(
+                status = Status.SECOND_APPROVED,
+                previousStatus = Status.FIRST_APPROVED
+            )
+
             application.revert()
-            application.status shouldBe Status.FIRST_APPROVED
+
+            application.previousStatus shouldBe null
+            shouldThrow<DaybreakStudyApplicationCanNotRevertException> {
+                application.revert()
+            }
+        }
+
+        it("직전 상태가 없으면 DaybreakStudyApplicationCanNotRevertException을 던진다") {
+            forAll(
+                row(Status.SECOND_APPROVED),
+                row(Status.REJECTED),
+            ) { status ->
+                val application = createDaybreakStudyApplicationStub(status = status, previousStatus = null)
+                shouldThrow<DaybreakStudyApplicationCanNotRevertException> {
+                    application.revert()
+                }
+            }
         }
 
         it("되돌릴 수 없는 상태면 DaybreakStudyApplicationCanNotRevertException을 던진다") {
@@ -217,7 +257,10 @@ class DaybreakStudyApplicationTest : DescribeSpec({
                 row(Status.FIRST_APPROVED),
                 row(Status.EXPIRED),
             ) { status ->
-                val application = createDaybreakStudyApplicationStub(status = status)
+                val application = createDaybreakStudyApplicationStub(
+                    status = status,
+                    previousStatus = Status.FIRST_APPROVED
+                )
                 shouldThrow<DaybreakStudyApplicationCanNotRevertException> {
                     application.revert()
                 }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplicationTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplicationTest.kt
@@ -3,6 +3,8 @@ package team.aliens.dms.domain.daybreak.model
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -11,6 +13,7 @@ import team.aliens.dms.domain.auth.model.Authority
 import team.aliens.dms.domain.daybreak.exception.DaybreakInvalidDateRangeException
 import team.aliens.dms.domain.daybreak.exception.DaybreakPastDateException
 import team.aliens.dms.domain.daybreak.exception.DaybreakStartDateAfterEndDateException
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotRevertException
 import team.aliens.dms.domain.daybreak.stub.createDaybreakStudyApplicationStub
 import team.aliens.dms.domain.user.exception.InvalidRoleException
 import java.time.LocalDate
@@ -189,6 +192,34 @@ class DaybreakStudyApplicationTest : DescribeSpec({
                 val application = createDaybreakStudyApplicationStub(status = Status.PENDING)
                 shouldThrow<InvalidRoleException> {
                     application.changeStatus(Authority.STUDENT, Status.FIRST_APPROVED)
+                }
+            }
+        }
+    }
+
+    describe("revert") {
+
+        it("SECOND_APPROVED 상태를 FIRST_APPROVED로 되돌린다") {
+            val application = createDaybreakStudyApplicationStub(status = Status.SECOND_APPROVED)
+            application.revert()
+            application.status shouldBe Status.FIRST_APPROVED
+        }
+
+        it("REJECTED 상태를 FIRST_APPROVED로 되돌린다") {
+            val application = createDaybreakStudyApplicationStub(status = Status.REJECTED)
+            application.revert()
+            application.status shouldBe Status.FIRST_APPROVED
+        }
+
+        it("되돌릴 수 없는 상태면 DaybreakStudyApplicationCanNotRevertException을 던진다") {
+            forAll(
+                row(Status.PENDING),
+                row(Status.FIRST_APPROVED),
+                row(Status.EXPIRED),
+            ) { status ->
+                val application = createDaybreakStudyApplicationStub(status = status)
+                shouldThrow<DaybreakStudyApplicationCanNotRevertException> {
+                    application.revert()
                 }
             }
         }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/stub/DaybreakStudyApplicationStub.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/stub/DaybreakStudyApplicationStub.kt
@@ -12,6 +12,7 @@ internal fun createDaybreakStudyApplicationStub(
     endDate: LocalDate = LocalDate.now().plusDays(3),
     reason: String = "새벽 자습 신청합니다.",
     status: Status = Status.PENDING,
+    previousStatus: Status? = null,
     teacherId: UUID = UUID.randomUUID(),
     studentId: UUID = UUID.randomUUID(),
     schoolId: UUID = UUID.randomUUID()
@@ -23,6 +24,7 @@ internal fun createDaybreakStudyApplicationStub(
         endDate = endDate,
         reason = reason,
         status = status,
+        previousStatus = previousStatus,
         teacherId = teacherId,
         studentId = studentId,
         schoolId = schoolId

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCaseTest.kt
@@ -1,0 +1,117 @@
+package team.aliens.dms.domain.daybreak.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import team.aliens.dms.common.service.security.SecurityService
+import team.aliens.dms.domain.daybreak.dto.request.RevertDaybreakStudyApplicationRequest
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotRevertException
+import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationNotFoundException
+import team.aliens.dms.domain.daybreak.model.Status
+import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.daybreak.stub.createDaybreakStudyApplicationStub
+import java.util.UUID
+
+class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
+    val daybreakService = mockk<DaybreakService>()
+    val securityService = mockk<SecurityService>()
+
+    val useCase = RevertDaybreakStudyApplicationUseCase(daybreakService, securityService)
+
+    beforeTest {
+        clearMocks(daybreakService, securityService)
+    }
+
+    describe("execute"){
+
+        context("최증 승인(SECOND_APPROVED) 또는 거절(REJECTED)한 새벽자습 신청이라면"){
+
+            it("모두 FIRST_APPROVED로 되돌려 저장한다"){
+                val schoolId = UUID.randomUUID()
+                val applicationIdList = listOf(UUID.randomUUID(), UUID.randomUUID())
+
+                val applications = listOf(
+                    createDaybreakStudyApplicationStub(
+                        id = applicationIdList[0],
+                        status = Status.SECOND_APPROVED,
+                        schoolId = schoolId
+                    ),
+                    createDaybreakStudyApplicationStub(
+                        id = applicationIdList[1],
+                        status = Status.REJECTED,
+                        schoolId = schoolId
+                    ),
+                )
+
+                every { securityService.getCurrentSchoolId() } returns schoolId
+                every { daybreakService.getAllByIdIn(applicationIdList) } returns applications
+                every { daybreakService.saveAllDaybreakStudyApplications(any()) } just runs
+
+                useCase.execute(RevertDaybreakStudyApplicationRequest(applicationIdList))
+
+                applications.forEach { it.status shouldBe Status.FIRST_APPROVED }
+                verify(exactly = 1) {
+                    daybreakService.saveAllDaybreakStudyApplications(
+                        match { list -> list.all { it.status == Status.FIRST_APPROVED } }
+                    )
+                }
+            }
+        }
+
+        context("되돌릴 수 없는 상태(PENDING, FIRST_APPROVED, EXPIRED)의 신청이 포함되면"){
+
+            it("DaybreakStudyApplicationCanNotRevertException을 던지고 저장하지 않는다"){
+                forAll(
+                    row(Status.PENDING),
+                    row(Status.FIRST_APPROVED),
+                    row(Status.EXPIRED),
+                ) { status ->
+                    val schoolId = UUID.randomUUID()
+                    val applicationId = UUID.randomUUID()
+                    val applications = listOf(
+                        createDaybreakStudyApplicationStub(id = applicationId, status = status, schoolId = schoolId)
+                    )
+                    every { securityService.getCurrentSchoolId() } returns schoolId
+                    every { daybreakService.getAllByIdIn(listOf(applicationId)) } returns applications
+
+                    shouldThrow<DaybreakStudyApplicationCanNotRevertException> {
+                        useCase.execute(RevertDaybreakStudyApplicationRequest(listOf(applicationId)))
+                    }
+
+                    verify(exactly = 0) { daybreakService.saveAllDaybreakStudyApplications(any()) }
+
+                    clearAllMocks()
+                }
+            }
+        }
+
+        context("존재하지 않는 신청 id가 포함되면"){
+
+            it("DaybreakStudyApplicationNotFoundException을 그대로 전파하고 저장하지 않는다"){
+                val applicationIdList = listOf(UUID.randomUUID(), UUID.randomUUID())
+
+                every { securityService.getCurrentSchoolId() } returns UUID.randomUUID()
+
+                every {
+                    daybreakService.getAllByIdIn(applicationIdList)
+                } throws DaybreakStudyApplicationNotFoundException
+
+                shouldThrow<DaybreakStudyApplicationNotFoundException> {
+                    useCase.execute(RevertDaybreakStudyApplicationRequest(applicationIdList))
+                }
+                verify(exactly = 0) { daybreakService.saveAllDaybreakStudyApplications(any()) }
+            }
+        }
+
+    }
+})

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCaseTest.kt
@@ -34,21 +34,30 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
 
     describe("execute"){
 
-        context("최증 승인(SECOND_APPROVED) 또는 거절(REJECTED)한 새벽자습 신청이라면"){
+        context("최종 승인(SECOND_APPROVED) 또는 거절(REJECTED)한 새벽자습 신청이라면"){
 
-            it("모두 FIRST_APPROVED로 되돌려 저장한다"){
+            it("각각 직전 상태로 되돌려 저장한다"){
                 val schoolId = UUID.randomUUID()
-                val applicationIdList = listOf(UUID.randomUUID(), UUID.randomUUID())
+                val applicationIdList = listOf(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
 
                 val applications = listOf(
                     createDaybreakStudyApplicationStub(
                         id = applicationIdList[0],
                         status = Status.SECOND_APPROVED,
+                        previousStatus = Status.FIRST_APPROVED,
                         schoolId = schoolId
                     ),
                     createDaybreakStudyApplicationStub(
                         id = applicationIdList[1],
                         status = Status.REJECTED,
+                        previousStatus = Status.FIRST_APPROVED,
+                        schoolId = schoolId
+                    ),
+                    // 담당선생님이 PENDING에서 거절한 신청은 1차 승인을 건너뛰지 않고 PENDING으로 돌아간다
+                    createDaybreakStudyApplicationStub(
+                        id = applicationIdList[2],
+                        status = Status.REJECTED,
+                        previousStatus = Status.PENDING,
                         schoolId = schoolId
                     ),
                 )
@@ -59,12 +68,39 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
 
                 useCase.execute(RevertDaybreakStudyApplicationRequest(applicationIdList))
 
-                applications.forEach { it.status shouldBe Status.FIRST_APPROVED }
+                applications[0].status shouldBe Status.FIRST_APPROVED
+                applications[1].status shouldBe Status.FIRST_APPROVED
+                applications[2].status shouldBe Status.PENDING
                 verify(exactly = 1) {
                     daybreakService.saveAllDaybreakStudyApplications(
-                        match { list -> list.all { it.status == Status.FIRST_APPROVED } }
+                        match { list -> list.all { it.previousStatus == null } }
                     )
                 }
+            }
+        }
+
+        context("직전 상태가 없는 신청이 포함되면"){
+
+            it("DaybreakStudyApplicationCanNotRevertException을 던지고 저장하지 않는다"){
+                val schoolId = UUID.randomUUID()
+                val applicationId = UUID.randomUUID()
+                val applications = listOf(
+                    createDaybreakStudyApplicationStub(
+                        id = applicationId,
+                        status = Status.REJECTED,
+                        previousStatus = null,
+                        schoolId = schoolId
+                    )
+                )
+
+                every { securityService.getCurrentSchoolId() } returns schoolId
+                every { daybreakService.getAllByIdIn(listOf(applicationId)) } returns applications
+
+                shouldThrow<DaybreakStudyApplicationCanNotRevertException> {
+                    useCase.execute(RevertDaybreakStudyApplicationRequest(listOf(applicationId)))
+                }
+
+                verify(exactly = 0) { daybreakService.saveAllDaybreakStudyApplications(any()) }
             }
         }
 
@@ -79,7 +115,12 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
                     val schoolId = UUID.randomUUID()
                     val applicationId = UUID.randomUUID()
                     val applications = listOf(
-                        createDaybreakStudyApplicationStub(id = applicationId, status = status, schoolId = schoolId)
+                        createDaybreakStudyApplicationStub(
+                            id = applicationId,
+                            status = status,
+                            previousStatus = Status.FIRST_APPROVED,
+                            schoolId = schoolId
+                        )
                     )
                     every { securityService.getCurrentSchoolId() } returns schoolId
                     every { daybreakService.getAllByIdIn(listOf(applicationId)) } returns applications

--- a/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
+++ b/dms-main/main-infrastructure/src/main/kotlin/team/aliens/dms/global/security/SecurityConfig.kt
@@ -238,6 +238,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "/daybreaks/head/study-application").hasAuthority(HEAD_TEACHER.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/manager/study-application").hasAuthority(MANAGER.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-type").hasAnyAuthority(HEAD_TEACHER.name,GENERAL_TEACHER.name,STUDENT.name)
+                    .requestMatchers(HttpMethod.PATCH, "/daybreaks/study-application/revert").hasAuthority(HEAD_TEACHER.name)
                     .requestMatchers(HttpMethod.PATCH, "/daybreaks/study-application").hasAnyAuthority(HEAD_TEACHER.name, GENERAL_TEACHER.name)
                     .requestMatchers(HttpMethod.POST, "/daybreaks/study-type").hasAuthority(HEAD_TEACHER.name)
                     .requestMatchers(HttpMethod.GET, "/daybreaks/study-application/my").hasAuthority(STUDENT.name)

--- a/dms-main/main-infrastructure/src/main/resources/db/migration/V28__add_previous_status_in_tbl_daybreak_study_application.sql
+++ b/dms-main/main-infrastructure/src/main/resources/db/migration/V28__add_previous_status_in_tbl_daybreak_study_application.sql
@@ -1,0 +1,3 @@
+-- 새벽 자습 신청 되돌리기(revert)를 위해 직전 상태를 보관하는 컬럼 추가
+alter table tbl_daybreak_study_application
+    add column previous_status varchar(20) null after status;

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/DaybreakStudyApplicationPersistenceAdapter.kt
@@ -266,7 +266,8 @@ class DaybreakStudyApplicationPersistenceAdapter(
     override fun deleteDaybreakStudyApplication(studentId: UUID): Boolean {
         val deletedCount = queryFactory
             .delete(daybreakStudyApplicationJpaEntity)
-            .where(daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId),
+            .where(
+                daybreakStudyApplicationJpaEntity.studentJpaEntity.id.eq(studentId),
                 daybreakStudyApplicationJpaEntity.status.eq(Status.PENDING)
             )
             .execute()

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/entity/DaybreakStudyApplicationJpaEntity.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/entity/DaybreakStudyApplicationJpaEntity.kt
@@ -29,6 +29,10 @@ class DaybreakStudyApplicationJpaEntity(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     var status: Status,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_status", columnDefinition = "VARCHAR(20)")
+    var previousStatus: Status? = null,
+
     @Column(columnDefinition = "DATE", nullable = false)
     val startDate: LocalDate,
 

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/mapper/DaybreakStudyApplicationMapper.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/mapper/DaybreakStudyApplicationMapper.kt
@@ -25,6 +25,7 @@ class DaybreakStudyApplicationMapper(
                 endDate = it.endDate,
                 reason = it.reason,
                 status = it.status,
+                previousStatus = it.previousStatus,
                 teacherId = it.teacherJpaEntity.id,
                 studentId = it.studentJpaEntity.id!!,
                 schoolId = it.schoolJpaEntity.id!!
@@ -39,6 +40,7 @@ class DaybreakStudyApplicationMapper(
             endDate = domain.endDate,
             reason = domain.reason,
             status = domain.status,
+            previousStatus = domain.previousStatus,
             daybreakStudyTypeJpaEntity = entityManager.getReference(DaybreakStudyTypeJpaEntity::class.java, domain.studyTypeId),
             studentJpaEntity = entityManager.getReference(StudentJpaEntity::class.java, domain.studentId),
             teacherJpaEntity = entityManager.getReference(TeacherJpaEntity::class.java, domain.teacherId),

--- a/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
+++ b/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/DaybreakWebAdapter.kt
@@ -23,6 +23,8 @@ import team.aliens.dms.domain.daybreak.dto.request.ChangeDaybreakStudyApplicatio
 import team.aliens.dms.domain.daybreak.dto.request.ChangeDaybreakStudyApplicationStatusWebRequest
 import team.aliens.dms.domain.daybreak.dto.request.CreateDaybreakStudyTypeRequest
 import team.aliens.dms.domain.daybreak.dto.request.CreateDaybreakStudyTypeWebRequest
+import team.aliens.dms.domain.daybreak.dto.request.RevertDaybreakStudyApplicationRequest
+import team.aliens.dms.domain.daybreak.dto.request.RevertDaybreakStudyApplicationWebRequest
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationResponse
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyApplicationStatusResponse
 import team.aliens.dms.domain.daybreak.dto.response.DaybreakStudyTypesResponse
@@ -38,6 +40,7 @@ import team.aliens.dms.domain.daybreak.usecase.QueryGeneralTeacherDaybreakStudyA
 import team.aliens.dms.domain.daybreak.usecase.QueryHeadTeacherDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryManagerDaybreakStudyApplicationUseCase
 import team.aliens.dms.domain.daybreak.usecase.QueryStudentDaybreakStudyApplicationHistoryUseCase
+import team.aliens.dms.domain.daybreak.usecase.RevertDaybreakStudyApplicationUseCase
 import java.util.UUID
 
 @Validated
@@ -54,7 +57,8 @@ class DaybreakWebAdapter(
     private val createDaybreakStudyTypeUseCase: CreateDaybreakStudyTypeUseCase,
     private val queryDaybreakStudyApplicationStatusUseCase: QueryDaybreakStudyApplicationStatusUseCase,
     private val queryStudentDaybreakStudyApplicationHistoryUseCase: QueryStudentDaybreakStudyApplicationHistoryUseCase,
-    private val cancelDaybreakStudyApplicationUseCase: CancelDaybreakStudyApplicationUseCase
+    private val cancelDaybreakStudyApplicationUseCase: CancelDaybreakStudyApplicationUseCase,
+    private val revertDaybreakStudyApplicationUseCase: RevertDaybreakStudyApplicationUseCase
 ) {
 
     @ResponseStatus(code = HttpStatus.CREATED)
@@ -158,5 +162,15 @@ class DaybreakWebAdapter(
     @DeleteMapping("/study-application/my")
     fun cancelDaybreakStudyApplication() {
         cancelDaybreakStudyApplicationUseCase.execute()
+    }
+
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
+    @PatchMapping("/study-application/revert")
+    fun revertDaybreakStudyApplication(
+        @RequestBody @Valid request: RevertDaybreakStudyApplicationWebRequest
+    ) {
+        revertDaybreakStudyApplicationUseCase.execute(
+            RevertDaybreakStudyApplicationRequest(request.applicationIdList)
+        )
     }
 }

--- a/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/dto/request/RevertDaybreakStudyApplicationWebRequest.kt
+++ b/dms-main/main-presentation/src/main/kotlin/team/aliens/dms/domain/daybreak/dto/request/RevertDaybreakStudyApplicationWebRequest.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.domain.daybreak.dto.request
+
+import jakarta.validation.constraints.NotEmpty
+import java.util.UUID
+
+data class RevertDaybreakStudyApplicationWebRequest(
+
+    @field:NotEmpty
+    val applicationIdList: List<UUID>
+)


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 부장선생님이 새벽자습 신청을 바꾸었을 때 상태를 다시 되돌릴 수 있는 기능 개발
- [ ] 최종 승인(`SECOND_APPROVED`) 또는 거절(`REJECTED`) 로 상태를 바꾸었을 때 1차 승인(`FIRST_APPROVED`)로 상태 변이됨

## 주요 변경 사항
- `RevertDaybreakStudyApplicationUseCase` 추가
- `DaybreakStudyApplication revert() `도메인 메서드 추가 

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1059 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 심야 자습 신청을 이전 상태로 되돌리는 기능을 추가했습니다.
  * 여러 신청 ID를 한 번에 처리할 수 있습니다.
  * 해당 기능은 교사장 권한으로 이용할 수 있습니다.

* **오류 처리**
  * 되돌릴 수 없는 상태의 신청에 대한 오류 안내를 추가했습니다.
  * 다른 학교의 신청이나 존재하지 않는 신청은 처리되지 않습니다.

* **테스트**
  * 신청 상태별 되돌리기와 예외 상황을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->