### PR TITLE
merge: (#1080) 값이 변할 수 있지만 내부에서만 값이 변하는 필드를 val로 선언

### DIFF
--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/model/DaybreakStudyApplication.kt
@@ -12,8 +12,10 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.util.UUID
 
+// 상태가 변하는 엔티티라 data class가 아니다(값 기준 equals가 어긋나고, private set을 쓸 수 없다).
+// equals/hashCode는 의도적으로 재정의하지 않고 identity 비교를 쓴다 — 이 리포의 JPA 엔티티도 전부 그렇고,
 @Aggregate
-data class DaybreakStudyApplication(
+class DaybreakStudyApplication(
 
     val id: UUID = UUID(0, 0),
 
@@ -25,10 +27,10 @@ data class DaybreakStudyApplication(
 
     val reason: String,
 
-    var status: Status,
+    status: Status,
 
     // 되돌리기를 위해 직전 상태를 보관한다. 상태 변경 이력이 없으면 null
-    var previousStatus: Status? = null,
+    previousStatus: Status? = null,
 
     val teacherId: UUID,
 
@@ -38,7 +40,24 @@ data class DaybreakStudyApplication(
 
 ) : SchoolIdDomain {
 
+    // 상태 전이는 아래 메서드로만 한다. 외부에서 직접 대입할 수 없도록 setter를 막았다.
+    var status: Status = status
+        private set
+
+    var previousStatus: Status? = previousStatus
+        private set
+
     companion object {
+        /**
+         * 새벽자습은 월~목만 운영하므로, 신청 대상도 한 주의 월~목 구간으로 제한한다.
+         *
+         * 오늘이 월~목이면 이번 주 월~목, 금~일이면 다음 주 월~목이 대상 구간이다
+         * (금요일부터는 이번 주 운영이 끝나 신청할 수 있는 날이 남아있지 않다).
+         *
+         * 검증 순서에 의미가 있다 — 과거 검사가 구간 검사보다 앞이라, 대상 구간 안이지만
+         * 이미 지난 요일을 신청하면 DaybreakInvalidDateRangeException이 아니라
+         * DaybreakPastDateException이 나간다.
+         */
         fun create(
             studyTypeId: UUID,
             startDate: LocalDate,
@@ -50,12 +69,15 @@ data class DaybreakStudyApplication(
             schoolId: UUID
         ): DaybreakStudyApplication {
             val today = LocalDate.now()
+
+            // 금~일이면 이번 주는 이미 끝났으므로 다음 주 월요일을 기준으로 잡는다
             val monday = if (today.dayOfWeek >= DayOfWeek.FRIDAY)
                 today.with(DayOfWeek.MONDAY).plusWeeks(1)
             else
                 today.with(DayOfWeek.MONDAY)
             val thursday = monday.plusDays(3)
 
+            // 1) 시작일이 종료일보다 뒤  2) 과거 날짜(오늘은 허용)  3) 대상 주의 월~목 밖
             if (startDate > endDate) throw DaybreakStartDateAfterEndDateException
             if (startDate < today || endDate < today) throw DaybreakPastDateException
             if (startDate < monday || endDate > thursday) throw DaybreakInvalidDateRangeException
@@ -108,6 +130,12 @@ data class DaybreakStudyApplication(
 
         this.status = previous
         this.previousStatus = null
+    }
+
+    // 스케줄러가 기한이 지난 신청을 만료 처리할 때 사용
+    fun expire() {
+        this.previousStatus = this.status
+        this.status = Status.EXPIRED
     }
 
     // REJECTED, FIRST_APPROVED, SECOND_APPROVED만 알림을 발송함

--- a/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/CloseDaybreakStudyApplicationUseCase.kt
+++ b/dms-main/main-core/src/main/kotlin/team/aliens/dms/domain/daybreak/usecase/CloseDaybreakStudyApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package team.aliens.dms.domain.daybreak.usecase
 
 import team.aliens.dms.common.annotation.SchedulerUseCase
-import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.service.DaybreakService
 
 @SchedulerUseCase
@@ -11,7 +10,7 @@ class CloseDaybreakStudyApplicationUseCase(
 
     fun execute() {
         val applications = daybreakService.findExpiredDaybreakStudyApplications()
-        applications.forEach { it.status = Status.EXPIRED }
+        applications.forEach { it.expire() }
         daybreakService.saveAllDaybreakStudyApplications(applications)
 
         daybreakService.deleteOutdatedDaybreakStudyApplications()

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/ChangeStatusDaybreakStudyApplicationUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/ChangeStatusDaybreakStudyApplicationUseCaseTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.data.forAll
 import io.kotest.data.row
+import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -13,9 +14,9 @@ import io.mockk.verify
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.auth.model.Authority
 import team.aliens.dms.domain.daybreak.dto.request.ChangeDaybreakStudyApplicationStatusRequest
-import team.aliens.dms.domain.daybreak.model.DaybreakStudyApplication
 import team.aliens.dms.domain.daybreak.model.Status
 import team.aliens.dms.domain.daybreak.service.DaybreakService
+import team.aliens.dms.domain.daybreak.stub.createDaybreakStudyApplicationStub
 import team.aliens.dms.domain.user.exception.InvalidRoleException
 import java.util.UUID
 
@@ -28,51 +29,50 @@ class ChangeStatusDaybreakStudyApplicationUseCaseTest : DescribeSpec({
 
     describe("execute") {
         context("권한에 따른 올바른 상태 변경 요청이 왔다면") {
-            it("권한과 요청 상태에 따라 새벽 자습 신청 상태를 바꾼다") {
+            it("권한과 요청 상태에 따라 새벽 자습 신청 상태를 바꾸고 저장한다") {
                 val applicationId = UUID.randomUUID()
-                val mockApplication = mockk<DaybreakStudyApplication>(relaxed = true)
 
                 forAll(
-                    // 담당 선생님
-                    row(Authority.GENERAL_TEACHER, Status.FIRST_APPROVED),
-                    row(Authority.GENERAL_TEACHER, Status.REJECTED),
+                    // 담당 선생님: PENDING → FIRST_APPROVED / REJECTED
+                    row(Authority.GENERAL_TEACHER, Status.PENDING, Status.FIRST_APPROVED),
+                    row(Authority.GENERAL_TEACHER, Status.PENDING, Status.REJECTED),
 
-                    // 부장 선생님
-                    row(Authority.HEAD_TEACHER, Status.SECOND_APPROVED),
-                    row(Authority.HEAD_TEACHER, Status.REJECTED),
-                ) { authority, requestStatus ->
+                    // 부장 선생님: FIRST_APPROVED → SECOND_APPROVED / REJECTED
+                    row(Authority.HEAD_TEACHER, Status.FIRST_APPROVED, Status.SECOND_APPROVED),
+                    row(Authority.HEAD_TEACHER, Status.FIRST_APPROVED, Status.REJECTED),
+                ) { authority, startingStatus, requestStatus ->
 
                     // given
+                    val application = createDaybreakStudyApplicationStub(id = applicationId, status = startingStatus)
                     val request = ChangeDaybreakStudyApplicationStatusRequest(
                         applicationIdList = listOf(applicationId),
                         status = requestStatus
                     )
-
                     every { securityService.getCurrentUserAuthority() } returns authority
-                    every { daybreakService.getAllByIdIn(request.applicationIdList) } returns listOf(mockApplication)
+                    every { daybreakService.getAllByIdIn(request.applicationIdList) } returns listOf(application)
                     every { daybreakService.saveAllDaybreakStudyApplications(any()) } just runs
 
                     // when
                     useCase.execute(request)
 
                     // then
+                    application.status shouldBe requestStatus
+                    application.previousStatus shouldBe startingStatus
+
                     verify(exactly = 1) {
-                        mockApplication.changeStatus(authority, requestStatus)
-                    }
-                    verify(exactly = 1) {
-                        daybreakService.saveAllDaybreakStudyApplications(any())
+                        daybreakService.saveAllDaybreakStudyApplications(listOf(application))
                     }
 
                     clearAllMocks()
                 }
             }
         }
-        context("권한에 따른 옳지 않는 상태 변경 요청이 왔다면") {
-            it("예외를 반환한다") {
+        context("권한에 따른 옳지 않은 상태 변경 요청이 왔다면") {
+            it("도메인 모델의 실제 검증 규칙에 따라 예외를 던지고 저장하지 않는다") {
                 val applicationId = UUID.randomUUID()
-                val mockApplication = mockk<DaybreakStudyApplication>(relaxed = true)
+                // 담당 선생님(GENERAL_TEACHER)은 PENDING에서 SECOND_APPROVED로 못 바꾼다 — 실제 changeStatus()가 던지는 예외
+                val application = createDaybreakStudyApplicationStub(id = applicationId, status = Status.PENDING)
 
-                // given
                 val authority = Authority.GENERAL_TEACHER
                 val illegalStatus = Status.SECOND_APPROVED
                 val request = ChangeDaybreakStudyApplicationStatusRequest(
@@ -81,14 +81,13 @@ class ChangeStatusDaybreakStudyApplicationUseCaseTest : DescribeSpec({
                 )
 
                 every { securityService.getCurrentUserAuthority() } returns authority
-                every { daybreakService.getAllByIdIn(request.applicationIdList) } returns listOf(mockApplication)
+                every { daybreakService.getAllByIdIn(request.applicationIdList) } returns listOf(application)
 
-                every { mockApplication.changeStatus(authority, illegalStatus) } throws InvalidRoleException
-
-                // when & then
                 shouldThrow<InvalidRoleException> {
                     useCase.execute(request)
                 }
+
+                verify(exactly = 0) { daybreakService.saveAllDaybreakStudyApplications(any()) }
             }
         }
     }

--- a/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCaseTest.kt
+++ b/dms-main/main-core/src/test/kotlin/team/aliens/dms/domain/daybreak/usecase/RevertDaybreakStudyApplicationUseCaseTest.kt
@@ -14,7 +14,6 @@ import io.mockk.runs
 import io.mockk.verify
 import team.aliens.dms.common.service.security.SecurityService
 import team.aliens.dms.domain.daybreak.dto.request.RevertDaybreakStudyApplicationRequest
-import team.aliens.dms.domain.daybreak.exception.DaybreakStudentSchoolMismatchException
 import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationCanNotRevertException
 import team.aliens.dms.domain.daybreak.exception.DaybreakStudyApplicationNotFoundException
 import team.aliens.dms.domain.daybreak.model.Status
@@ -32,11 +31,11 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
         clearMocks(daybreakService, securityService)
     }
 
-    describe("execute"){
+    describe("execute") {
 
-        context("최종 승인(SECOND_APPROVED) 또는 거절(REJECTED)한 새벽자습 신청이라면"){
+        context("최종 승인(SECOND_APPROVED) 또는 거절(REJECTED)한 새벽자습 신청이라면") {
 
-            it("각각 직전 상태로 되돌려 저장한다"){
+            it("각각 직전 상태로 되돌려 저장한다") {
                 val schoolId = UUID.randomUUID()
                 val applicationIdList = listOf(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
 
@@ -79,9 +78,9 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
             }
         }
 
-        context("직전 상태가 없는 신청이 포함되면"){
+        context("직전 상태가 없는 신청이 포함되면") {
 
-            it("DaybreakStudyApplicationCanNotRevertException을 던지고 저장하지 않는다"){
+            it("DaybreakStudyApplicationCanNotRevertException을 던지고 저장하지 않는다") {
                 val schoolId = UUID.randomUUID()
                 val applicationId = UUID.randomUUID()
                 val applications = listOf(
@@ -104,9 +103,9 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
             }
         }
 
-        context("되돌릴 수 없는 상태(PENDING, FIRST_APPROVED, EXPIRED)의 신청이 포함되면"){
+        context("되돌릴 수 없는 상태(PENDING, FIRST_APPROVED, EXPIRED)의 신청이 포함되면") {
 
-            it("DaybreakStudyApplicationCanNotRevertException을 던지고 저장하지 않는다"){
+            it("DaybreakStudyApplicationCanNotRevertException을 던지고 저장하지 않는다") {
                 forAll(
                     row(Status.PENDING),
                     row(Status.FIRST_APPROVED),
@@ -136,9 +135,9 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
             }
         }
 
-        context("존재하지 않는 신청 id가 포함되면"){
+        context("존재하지 않는 신청 id가 포함되면") {
 
-            it("DaybreakStudyApplicationNotFoundException을 그대로 전파하고 저장하지 않는다"){
+            it("DaybreakStudyApplicationNotFoundException을 그대로 전파하고 저장하지 않는다") {
                 val applicationIdList = listOf(UUID.randomUUID(), UUID.randomUUID())
 
                 every { securityService.getCurrentSchoolId() } returns UUID.randomUUID()
@@ -153,6 +152,5 @@ class RevertDaybreakStudyApplicationUseCaseTest : DescribeSpec({
                 verify(exactly = 0) { daybreakService.saveAllDaybreakStudyApplications(any()) }
             }
         }
-
     }
 })

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/entity/DaybreakStudyApplicationJpaEntity.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/entity/DaybreakStudyApplicationJpaEntity.kt
@@ -27,11 +27,11 @@ class DaybreakStudyApplicationJpaEntity(
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
-    var status: Status,
+    val status: Status,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "previous_status", columnDefinition = "VARCHAR(20)")
-    var previousStatus: Status? = null,
+    val previousStatus: Status? = null,
 
     @Column(columnDefinition = "DATE", nullable = false)
     val startDate: LocalDate,

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -1,0 +1,97 @@
+# 코드 컨벤션
+
+Kotlin 코드 스타일 규칙입니다. 모듈 구조·네이밍·검증 위치·보안·동시성은 [architecture.md](./architecture.md), 테스트는 [testing.md](./testing.md), 스키마·QueryDSL은 [database.md](./database.md), 브랜치·커밋은 [git-convention.md](./git-convention.md)에 있습니다.
+
+---
+
+## 도메인 모델
+
+기준은 **모델이 자기 상태를 바꾸는 메서드를 갖는가** 하나입니다.
+
+| 상태 전이 | 클래스 | 상태 필드 | 갱신 |
+| --- | --- | --- | --- |
+| 있음 | 일반 `class` | body 프로퍼티 `var` + `private set` | 모델 메서드가 제자리 변경 |
+| 없음 | `data class` | 주생성자 `val` | `copy()`로 새 인스턴스 |
+
+현재 전자는 `DaybreakStudyApplication` 하나입니다. 나머지는 전부 후자이고 그대로 둡니다.
+
+### 상태 전이가 있는 모델
+
+```kotlin
+@Aggregate
+class DaybreakStudyApplication(
+    status: Status,                  // val/var 없는 파라미터로 받고
+    // ...
+) : SchoolIdDomain {
+
+    var status: Status = status      // body에서 프로퍼티로 선언
+        private set
+
+    fun changeStatus(authority: Authority, newStatus: Status) {
+        // 권한·상태 전이 검증 후
+        this.previousStatus = this.status
+        this.status = newStatus
+    }
+}
+```
+
+* 읽기는 공개, 쓰기는 모델 안에서만. **상태를 바꾸는 경로가 필요하면 전이 메서드를 추가하세요** — 필드에 직접 대입하면 검증과 이력 기록이 통째로 우회됩니다(스케줄러 만료도 `expire()` 메서드로 둡니다).
+* **`private set`은 주생성자 파라미터에 못 붙입니다.** 위처럼 body 프로퍼티로 내려야 하고, `data class`는 주생성자가 전부 `val`/`var`여야 해서 이 형태 자체가 불가능합니다.
+* **`copy()`를 반환하는 방식은 쓰지 않습니다.** 호출부가 반환값을 빠뜨리면 경고 없이 no-op이 되는데 컴파일러·detekt·유스케이스 테스트 어느 것도 못 잡습니다.
+* **`equals`/`hashCode`는 재정의하지 않습니다(identity 비교).** JPA 엔티티도 전부 그렇고, 미저장 인스턴스는 `id`가 `UUID(0, 0)`이라 id 기준 `equals`는 오히려 틀립니다.
+
+### 상태 전이가 없는 모델
+
+```kotlin
+data class NotificationOfUser(val isRead: Boolean = false /* ... */) {
+    fun read() = this.copy(isRead = true)
+}
+```
+
+값을 외부에 노출하지 않고 판단만 시키려면 `private val`을 씁니다(`Notification.isSaveRequired` + `runIfSaveRequired`).
+
+---
+
+## 존재/중복 검사
+
+`CheckXxxService` + `CheckXxxServiceImpl`에 두고, 위반이면 throw·반환은 `Unit`. 유스케이스는 호출만 하고 happy path로 진행합니다.
+
+```kotlin
+override fun checkDaybreakStudyTypeExists(schoolId: UUID, name: String) {
+    if (queryDaybreakStudyTypePort.existsDaybreakStudyTypeBySchoolIdAndName(schoolId, name)) {
+        throw DaybreakStudyTypeAlreadyExistsException
+    }
+}
+```
+
+분기가 필요할 때만 `Boolean` 반환 변형을 씁니다. 검사 종류별 위치는 [architecture.md](./architecture.md)를 따르세요.
+
+---
+
+## 예외
+
+* 이름은 조건이 아니라 **막힌 액션**으로 — `XxxCanNotYyyException`. 조건(상태값)을 이름에 넣으면 정책이 바뀔 때 이름이 거짓말이 됩니다.
+* `ErrorCode`의 `sequence`는 수기 관리라 같은 `ErrorStatus` 그룹에서 겹치기 쉽습니다. 추가 전에 그룹 번호를 훑으세요.
+* 리스트 요청 DTO는 `@field:NotNull`이 아니라 **`@field:NotEmpty`** — `[]`가 통과해 조용히 no-op이 됩니다.
+* 페이지네이션을 붙일 땐 기존 `isEmpty() → NotFoundException` 가드를 지우세요. 마지막 페이지 다음이 404가 됩니다.
+
+---
+
+## 알림(FCM)
+
+저장만 `runIfSaveRequired { }`로 감싸고 FCM 발송은 게이트 밖에 둡니다. 덕분에 한쪽만 끄는 게 한 줄입니다.
+
+| `isSaveRequired` | 푸시 | 알림함 |
+| --- | --- | --- |
+| `true` | 발송 | 적재 |
+| `false` | 발송 | 안 남음 |
+
+`Topic` enum 값을 추가할 땐 이름 길이를 `VARCHAR(n)`과 대조하세요 — `ddl-auto: validate`는 길이를 안 봅니다([database.md](./database.md)).
+
+---
+
+## 로컬 빌드
+
+* 시그니처를 바꾼 뒤 이상한 타입 에러가 나면 clean 빌드부터 — 증분 컴파일 캐시가 옛 시그니처를 뭅니다.
+* 파일마다 개행이 섞여 있습니다(CRLF/LF). 스크립트로 치환했으면 `git diff --stat`의 줄 수를 확인하세요.
+* `./gradlew ... | tail`은 종료코드가 가려져 실패가 성공으로 보입니다.


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 문제는 댠순히 `DaybreakStudyApplicaiton` 에서 var로 필드를 사용하고 있어 외부에서 값을 변경할 수 있다는 것이 캡슐화 원칙을 지키지않았기 때문에 val로 수정하려고 함
- [ ] 하지만 코틀린에서 내부에서만 수정할 수 있는 값을 만들려면 private set을 이용해야하지만 data class는 private set를 사용하지 못함, 고로 기존 data class가 아닌 class를 사용하여 문제를 해결함

## 주요 변경 사항
- `DaybreakStudyApplication` data class -> class로 수정, expire() 도메인 메서드 추가
- code-convention 문서 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1080 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 신청 기간이 만료된 신청을 `EXPIRED` 상태로 전환하는 처리를 추가했습니다.
  - 상태 변경 시 이전 상태를 보존하고, 허용된 전용 동작을 통해서만 상태를 변경하도록 개선했습니다.

- **문서**
  - Kotlin 코드 스타일과 도메인 모델, 예외 처리, 알림 및 빌드 관련 규칙을 정리한 개발 가이드를 추가했습니다.

- **테스트**
  - 신청 상태 전이와 권한별 검증 테스트를 실제 도메인 동작에 맞게 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->