### PR TITLE
merge: (#1082) 새벽자습 신청 상태 변경 시 불필요한 쿼리 제거

### DIFF
--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/entity/DaybreakStudyApplicationJpaEntity.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/entity/DaybreakStudyApplicationJpaEntity.kt
@@ -51,7 +51,7 @@ class DaybreakStudyApplicationJpaEntity(
     @JoinColumn(name = "type_id", nullable = false)
     val daybreakStudyTypeJpaEntity: DaybreakStudyTypeJpaEntity,
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teacher_id", nullable = false)
     val teacherJpaEntity: TeacherJpaEntity,
 

--- a/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/mapper/DaybreakStudyApplicationMapper.kt
+++ b/dms-main/main-persistence/src/main/kotlin/team/aliens/dms/persistence/daybreak/mapper/DaybreakStudyApplicationMapper.kt
@@ -13,14 +13,13 @@ import team.aliens.dms.persistence.teacher.entity.TeacherJpaEntity
 @Component
 class DaybreakStudyApplicationMapper(
     private val entityManager: EntityManager,
-    private val daybreakStudyTypeMapper: DaybreakStudyTypeMapper
 ) : GenericMapper<DaybreakStudyApplication, DaybreakStudyApplicationJpaEntity> {
 
     override fun toDomain(entity: DaybreakStudyApplicationJpaEntity?): DaybreakStudyApplication? {
         return entity?.let {
             DaybreakStudyApplication(
                 id = it.id!!,
-                studyTypeId = daybreakStudyTypeMapper.toDomain(it.daybreakStudyTypeJpaEntity)!!.id,
+                studyTypeId = it.daybreakStudyTypeJpaEntity.id!!,
                 startDate = it.startDate,
                 endDate = it.endDate,
                 reason = it.reason,


### PR DESCRIPTION
## 작업 내용 설명
- [ ] `DaybreakStudyApplicationJpaEntity`에 `TeacherJpaEntity`가 `FetchType`이 기본값 `EAGER`로 설정이 되어있어 쿼리가 하나 추가되어 LAZY로 수정
- [ ] `DaybreakStudyApplicationMapper`에서 `DaybreakStudyTypeMapper`를 호출하여 N+1 문제 발생 `DaybreakStudyTypeMapper`를 사용하지 않고 `it.daybreakStudyTypeJpaEntity.id!!`로 수정

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1082 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 학습 신청 정보 조회 시 교사 정보가 필요한 경우에만 불러오도록 변경했습니다.
  * 학습 신청 정보 변환 과정에서 학습 유형 식별자를 보다 효율적으로 처리하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->